### PR TITLE
docs: Add design for how the SQS poller will handle message visibility timeout for in flight messages

### DIFF
--- a/docs/design/message-visibility-timeout-handling.md
+++ b/docs/design/message-visibility-timeout-handling.md
@@ -1,0 +1,43 @@
+# SQS Message Visibility Timeout Handling
+
+When a consumer receives a message, Amazon SQS sets a [visibility timeout](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html). This is the period of time during which _additional_ consumers are prevented from receiving a duplicate message. The default visibility timeout is 30 seconds. The minimum is 0 seconds. The maximum is 12 hours. 
+
+When a message handler returns `MessageProcessStatus.Success`, the framework will delete the message from the queue. When a handler returns `MessageProcessStatus.Failed`, the visibility timeout will be allowed to expire and the message will become visible to consumers again (pending interactions with other SQS settings, such as the message retention period or dead-letter queue maximum receives count).
+
+The message processing framework tracks _in flight_ messages, which are those that have been received from the SQS queue but have not yet finished processing. The framework will periodically extend the visibility timeout of these messages to prevent another consumer from receiving them.
+
+This visibility timeout extension behavior can be controlled by the following settings:
+```
+builder.AddSQSPoller("<queueURL>", options => 
+{ 
+    options.VisibilityTimeout = 30; 
+    options.VisibilityTimeoutExtensionThreshold = 5;
+    options.VisibilityTimeoutExtensionHeartbeatInterval = TimeSpan.FromSeconds(1);
+});
+```
+1. `VisibilityTimeout` - This is is the length of time in seconds that the message will not be visible to other consumers once it is received, as well as the length of time that the framework will extend the visibility timeout for messages that are still processing. The default value is 30 seconds.
+    * Note that the SQS poller will always set this when it receives messages with either the configured value or _framework default_ of 30 seconds, it will not respect the value configured on the queue.
+2. `VisibilityTimeoutExtensionThreshold` - When an in flight message is within this many seconds of becoming visible again, the framework will extend its visibility timeout automatically. The new visibility timeout will be set to `VisibilityTimeout` relative to now. The default value is 5 seconds.
+3. `VisibilityTimeoutExtensionHeartbeatInterval` - This is how frequently the framework will check in flight messages and extend the the visibility timeout of messages that are within the `VisibilityTimeoutExtensionThreshold`. The default value is 1 second.
+    * Note that this is a `TimeSpan` instead of integer seconds since it controls client behavior, and is not passed to SQS.
+
+Refer to [processing messages in a timely manner](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/working-with-messages.html#processing-messages-timely-manner) for possible strategies for these options.
+
+As an example for a message handler that takes 45 seconds to complete and the options above:
+* T+0: The message is received from SQS
+* T+1 through T+24: The heartbeat task will check the message every second, but since it is not within 5 seconds of becoming visible again it will do nothing.
+* T+25: The heartbeat will see that the message is within the 5 second threshold of becoming visible again, so it will change the visibility timeout to 30 seconds from now (T+55).
+* T+25 through T+44: The heartbeat task will check the message every second, but since it is not within 5 seconds of becoming visible again it will do nothing.
+* T+45: The message handler completes, so the framework will delete the message from the queue.
+
+The heartbeat task will check _all_ in flight messages (the number of which are controlled by `options.MaxNumberOfConcurrentMessages`) at each heartbeat interval and batch the extensions together for messages within the threshold via [ChangeMessageVisibilityBatch](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ChangeMessageVisibilityBatch.html).
+
+The message visibility timeout extension feature is only available to the SQS poller configured via `AddSQSPoller`, and **not** to the forthcoming Lambda message pump. When [using Lambda with Amazon SQS](https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html), Lambda will use the queue's configured visibility timeout, and [recommends setting that to at least six times the configured function timeout](https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#events-sqs-queueconfig). 
+
+Open Questions:
+1. When a handler returns `MessageProcessStatus.Failed`, should the framework let the remaining visibility timeout run out before the message becomes visible again? Or should the framework call `ChangeMessageVisibility` with 0 seconds so the message becomes available again immediately? 
+    * Perhaps this should be configurable as a boolean? `options.MakeFailedMessagesVisibleImmediately`?
+    * Or the result of different `MessageProcessStatus` values that a message handler could return? 
+2. Should the `SQSPoller` give users the ability to opt-out of the automatic visibility timeout extensions?
+    * Perhaps by setting `VisibilityTimeoutExtensionHeartbeatInterval` to less than or equal to `0`? 
+    * Or we can add an explicit `options.DisableVisibilityTimeoutExtensionHeartbeat` boolean?

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -85,7 +85,8 @@ public class MessageBusBuilder : IMessageBusBuilder
         {
             MaxNumberOfConcurrentMessages = sqsMessagePollerOptions.MaxNumberOfConcurrentMessages,
             VisibilityTimeout = sqsMessagePollerOptions.VisibilityTimeout,
-            VisibilityTimeoutExtensionInterval = sqsMessagePollerOptions.VisibilityTimeoutExtensionInterval,
+            VisibilityTimeoutExtensionThreshold = sqsMessagePollerOptions.VisibilityTimeoutExtensionThreshold,
+            VisibilityTimeoutExtensionHeartbeatInterval = sqsMessagePollerOptions.VisibilityTimeoutExtensionHeartbeatInterval,
             WaitTimeSeconds = sqsMessagePollerOptions.WaitTimeSeconds
         };
 

--- a/src/AWS.Messaging/Configuration/MessageManagerConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/MessageManagerConfiguration.cs
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Messaging.Services;
+
+namespace AWS.Messaging.Configuration;
+
+/// <summary>
+/// Internal configuration for a <see cref="DefaultMessageManager"/>
+/// </summary>
+/// <remarks>
+/// Currently this closely mirrors <see cref="SQSMessagePollerConfiguration"/>, but could be expanded
+/// if we allow message managers to be configured independently of their poller(s)
+/// </remarks>
+/// TODO: revisit not marking this public since it's not user-configurable. Currently it's required due to DefaultMessageManagerFactory's implementation
+public class MessageManagerConfiguration
+{
+    /// <inheritdoc cref="SQSMessagePollerConfiguration.VisibilityTimeout"/>
+    internal int VisibilityTimeout { get; set; } = SQSMessagePollerConfiguration.DEFAULT_VISIBILITY_TIMEOUT_SECONDS;
+
+    /// <inheritdoc cref="SQSMessagePollerConfiguration.VisibilityTimeoutExtensionThreshold"/>
+    internal int VisibilityTimeoutExtensionThreshold { get; set; } = SQSMessagePollerConfiguration.DEFAULT_VISIBILITY_TIMEOUT_EXTENSION_THRESHOLD_SECONDS;
+
+    /// <inheritdoc cref="SQSMessagePollerConfiguration.VisibilityTimeoutExtensionHeartbeatInterval"/>
+    internal TimeSpan VisibilityTimeoutExtensionHeartbeatInterval { get; set; } = SQSMessagePollerConfiguration.DEFAULT_VISIBILITY_TIMEOUT_EXTENSION_HEARTBEAT_INTERVAL;
+}

--- a/src/AWS.Messaging/Configuration/SQSMessagePollerConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/SQSMessagePollerConfiguration.cs
@@ -19,14 +19,20 @@ internal class SQSMessagePollerConfiguration : IMessagePollerConfiguration
     /// <summary>
     /// Default value for <see cref="VisibilityTimeout"/>
     /// </summary>
-    /// <remarks>The default value is 20 seconds.</remarks>
-    public const int DEFAULT_VISIBILITY_TIMEOUT_SECONDS = 20;
+    /// <remarks>The default value is 30 seconds.</remarks>
+    public const int DEFAULT_VISIBILITY_TIMEOUT_SECONDS = 30;
 
     /// <summary>
-    /// Default value for <see cref="VisibilityTimeoutExtensionInterval"/>
+    /// Default value for <see cref="VisibilityTimeoutExtensionThreshold"/>
     /// </summary>
-    /// <remarks>The default value is 18 seconds.</remarks>
-    public const int DEFAULT_VISIBILITY_TIMEOUT_EXTENSION_INTERVAL_SECONDS = 18;
+    /// <remarks>The default value is 5 seconds.</remarks>
+    public const int DEFAULT_VISIBILITY_TIMEOUT_EXTENSION_THRESHOLD_SECONDS = 5;
+
+    /// <summary>
+    /// Default value for <see cref="VisibilityTimeoutExtensionHeartbeatInterval"/>
+    /// </summary>
+    /// <remarks>The default value is 1 second.</remarks>
+    public static TimeSpan DEFAULT_VISIBILITY_TIMEOUT_EXTENSION_HEARTBEAT_INTERVAL = TimeSpan.FromSeconds(1);
 
     /// <summary>
     /// Default value for <see cref="WaitTimeSeconds"/>
@@ -55,13 +61,22 @@ internal class SQSMessagePollerConfiguration : IMessagePollerConfiguration
     public int VisibilityTimeout { get; init; } = DEFAULT_VISIBILITY_TIMEOUT_SECONDS;
 
     /// <summary>
-    /// How often in seconds to extend the visibility timeout of messages that have been
-    /// received from SQS but are still being processed
+    /// When an in flight message is within this many seconds of becoming visible again, the framework will extend its visibility timeout automatically.
+    /// The new visibility timeout will be set to <see cref="VisibilityTimeout"/> seconds relative to now.
     /// </summary>
     /// <remarks>
-    /// <inheritdoc cref="DEFAULT_VISIBILITY_TIMEOUT_EXTENSION_INTERVAL_SECONDS" path="//remarks"/>
+    /// <inheritdoc cref="DEFAULT_VISIBILITY_TIMEOUT_EXTENSION_THRESHOLD_SECONDS" path="//remarks"/>
     /// </remarks>
-    public int VisibilityTimeoutExtensionInterval { get; init; } = DEFAULT_VISIBILITY_TIMEOUT_EXTENSION_INTERVAL_SECONDS;
+    public int VisibilityTimeoutExtensionThreshold { get; init; } = DEFAULT_VISIBILITY_TIMEOUT_EXTENSION_THRESHOLD_SECONDS;
+
+    /// <summary>
+    /// How frequently the framework will check in flight messages and extend the visibility
+    /// timeout of messages that will expire within the <see cref="VisibilityTimeoutExtensionThreshold"/>.
+    /// </summary>
+    /// /// <remarks>
+    /// <inheritdoc cref="DEFAULT_VISIBILITY_TIMEOUT_EXTENSION_HEARTBEAT_INTERVAL" path="//remarks"/>
+    /// </remarks>
+    public TimeSpan VisibilityTimeoutExtensionHeartbeatInterval { get; init; } = DEFAULT_VISIBILITY_TIMEOUT_EXTENSION_HEARTBEAT_INTERVAL;
 
     /// <summary>
     /// <inheritdoc cref="ReceiveMessageRequest.WaitTimeSeconds"/>
@@ -82,5 +97,19 @@ internal class SQSMessagePollerConfiguration : IMessagePollerConfiguration
             throw new InvalidSubscriberEndpointException("The SQS Queue URL cannot be empty.");
 
         SubscriberEndpoint = queueUrl;
+    }
+
+    /// <summary>
+    /// Converts this instance to a <see cref="MessageManagerConfiguration"/>
+    /// </summary>
+    /// <returns></returns>
+    internal MessageManagerConfiguration ToMessageManagerConfiguration()
+    {
+        return new MessageManagerConfiguration
+        {
+            VisibilityTimeout = VisibilityTimeout,
+            VisibilityTimeoutExtensionThreshold = VisibilityTimeoutExtensionThreshold,
+            VisibilityTimeoutExtensionHeartbeatInterval = VisibilityTimeoutExtensionHeartbeatInterval
+        };
     }
 }

--- a/src/AWS.Messaging/Configuration/SQSMessagePollerOptions.cs
+++ b/src/AWS.Messaging/Configuration/SQSMessagePollerOptions.cs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Text;
-
 namespace AWS.Messaging.Configuration;
 
 /// <summary>
@@ -19,8 +17,11 @@ public class SQSMessagePollerOptions
     /// <inheritdoc cref="SQSMessagePollerConfiguration.WaitTimeSeconds"/>
     public int WaitTimeSeconds { get; set; } = SQSMessagePollerConfiguration.DEFAULT_WAIT_TIME_SECONDS;
 
-    /// <inheritdoc cref="SQSMessagePollerConfiguration.VisibilityTimeoutExtensionInterval"/>
-    public int VisibilityTimeoutExtensionInterval { get; set; } = SQSMessagePollerConfiguration.DEFAULT_VISIBILITY_TIMEOUT_EXTENSION_INTERVAL_SECONDS;
+    /// <inheritdoc cref="SQSMessagePollerConfiguration.VisibilityTimeoutExtensionThreshold"/>
+    public int VisibilityTimeoutExtensionThreshold { get; set; } = SQSMessagePollerConfiguration.DEFAULT_VISIBILITY_TIMEOUT_EXTENSION_THRESHOLD_SECONDS;
+
+    /// <inheritdoc cref="SQSMessagePollerConfiguration.VisibilityTimeoutExtensionHeartbeatInterval"/>
+    public TimeSpan VisibilityTimeoutExtensionHeartbeatInterval { get; set; } = SQSMessagePollerConfiguration.DEFAULT_VISIBILITY_TIMEOUT_EXTENSION_HEARTBEAT_INTERVAL;
 
     /// <summary>
     /// Validates that the options are valid against the message framework's and/or SQS limits
@@ -47,16 +48,29 @@ public class SQSMessagePollerOptions
             errorMessages.Add($"{nameof(WaitTimeSeconds)} must be between 0 seconds and 20 seconds. Current value: {WaitTimeSeconds}.");
         }
 
-        if (VisibilityTimeoutExtensionInterval <= 0)
+        if (VisibilityTimeoutExtensionThreshold <= 0)
         {
-            errorMessages.Add($"{nameof(VisibilityTimeoutExtensionInterval)} must be greater than 0. Current value: {VisibilityTimeoutExtensionInterval}.");
+            errorMessages.Add($"{nameof(VisibilityTimeoutExtensionThreshold)} must be greater than 0. Current value: {VisibilityTimeoutExtensionThreshold}.");
         }
 
-        if (VisibilityTimeoutExtensionInterval >= VisibilityTimeout)
+        if (VisibilityTimeoutExtensionThreshold >= VisibilityTimeout)
         {
-            errorMessages.Add($"{nameof(VisibilityTimeoutExtensionInterval)} ({VisibilityTimeoutExtensionInterval} seconds) " +
+            errorMessages.Add($"{nameof(VisibilityTimeoutExtensionThreshold)} ({VisibilityTimeoutExtensionThreshold} seconds) " +
                 $"must be less than {nameof(VisibilityTimeout)} ({VisibilityTimeout} seconds), " +
                 $"or else other consumers may receive the message while it is still being processed.");
+        }
+
+        if (VisibilityTimeoutExtensionHeartbeatInterval <= TimeSpan.Zero)
+        {
+            errorMessages.Add($"{nameof(VisibilityTimeoutExtensionHeartbeatInterval)} must be greater than 0 seconds. " +
+                $"Current value: {VisibilityTimeoutExtensionHeartbeatInterval}.");
+        }
+
+        if (VisibilityTimeoutExtensionHeartbeatInterval >= TimeSpan.FromSeconds(VisibilityTimeoutExtensionThreshold))
+        {
+            errorMessages.Add($"{nameof(VisibilityTimeoutExtensionHeartbeatInterval)} ({VisibilityTimeoutExtensionHeartbeatInterval}) " +
+                            $"must be less than {nameof(VisibilityTimeoutExtensionThreshold)} ({TimeSpan.FromSeconds(VisibilityTimeoutExtensionThreshold)}), " +
+                            $"or else other consumers may receive the message while it is still being processed.");
         }
 
         if (errorMessages.Any())

--- a/src/AWS.Messaging/MessageEnvelope.cs
+++ b/src/AWS.Messaging/MessageEnvelope.cs
@@ -92,4 +92,7 @@ public class MessageEnvelope<T> : MessageEnvelope
     {
         Message = (T)message;
     }
+
+    /// <inheritdoc/>
+    public override string ToString() => Id;
 }

--- a/src/AWS.Messaging/Services/IMessageManagerFactory.cs
+++ b/src/AWS.Messaging/Services/IMessageManagerFactory.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using AWS.Messaging.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace AWS.Messaging.Services;
@@ -16,8 +17,9 @@ public interface IMessageManagerFactory
     /// Create an instance of <see cref="AWS.Messaging.Services.IMessageManager" />
     /// </summary>
     /// <param name="poller">The <see cref="AWS.Messaging.Services.IMessagePoller" /> that the <see cref="AWS.Messaging.Services.IMessageManager" /> to make lifecycle changes to the message.</param>
-    /// <returns></returns>
-    IMessageManager CreateMessageManager(IMessagePoller poller);
+    /// <param name="configuration">The configuration for the message manager.</param>
+    /// <returns>New instance of an <see cref="IMessageManager"/></returns>
+    internal IMessageManager CreateMessageManager(IMessagePoller poller, MessageManagerConfiguration configuration);
 }
 
 /// <summary>
@@ -35,8 +37,8 @@ internal class DefaultMessageManagerFactory : IMessageManagerFactory
     }
 
     /// <inheritdoc/>
-    public IMessageManager CreateMessageManager(IMessagePoller poller)
+    public IMessageManager CreateMessageManager(IMessagePoller poller, MessageManagerConfiguration configuration)
     {
-        return ActivatorUtilities.CreateInstance<DefaultMessageManager>(_serviceProvider, poller);
+        return ActivatorUtilities.CreateInstance<DefaultMessageManager>(_serviceProvider, poller, configuration);
     }
 }

--- a/src/AWS.Messaging/Services/IMessagePoller.cs
+++ b/src/AWS.Messaging/Services/IMessagePoller.cs
@@ -14,12 +14,6 @@ namespace AWS.Messaging.Services;
 public interface IMessagePoller
 {
     /// <summary>
-    /// How frequently message visibility should be extended in seconds
-    /// via <see cref="ExtendMessageVisibilityTimeoutAsync"/> while the message is still being processed
-    /// </summary>
-    int VisibilityTimeoutExtensionInterval { get; }
-
-    /// <summary>
     /// Start polling the underlying service. Polling will run indefinitely till the CancellationToken is cancelled.
     /// </summary>
     /// <param name="token">Optional cancellation token to shutdown the poller.</param>

--- a/src/AWS.Messaging/Services/InFlightMetadata.cs
+++ b/src/AWS.Messaging/Services/InFlightMetadata.cs
@@ -1,0 +1,55 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Services;
+
+/// <summary>
+/// Metadata for a received message that is being handled by the framework
+/// </summary>
+internal class InFlightMetadata
+{
+    internal InFlightMetadata(Task<MessageProcessStatus> handlerTask, DateTimeOffset expectedVisibilityTimeoutExpiration)
+    {
+        HandlerTask = handlerTask;
+        ExpectedVisibilityTimeoutExpiration = expectedVisibilityTimeoutExpiration;
+    }
+
+    /// <summary>
+    /// Task for handling the message, created via <see cref="HandlerInvoker.InvokeAsync"/>
+    /// </summary>
+    internal Task<MessageProcessStatus> HandlerTask { get; set; }
+
+    /// <summary>
+    /// The timestamp that the message's visibility timeout is expected to expire
+    /// </summary>
+    internal DateTimeOffset ExpectedVisibilityTimeoutExpiration { get; set; }
+
+    /// <summary>
+    /// Updates the <see cref="ExpectedVisibilityTimeoutExpiration"/> to given number of seconds from now
+    /// </summary>
+    /// <param name="newVisibilityTimeoutWindowSeconds">How many seconds from now the message is now expected to become visible again</param>
+    internal void UpdateExpectedVisibilityTimeoutExpiration(int newVisibilityTimeoutWindowSeconds)
+    {
+        ExpectedVisibilityTimeoutExpiration = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(newVisibilityTimeoutWindowSeconds);
+    }
+
+    /// <summary>
+    /// Determines if a given message's visibility timeout expiration timestamp is within the
+    /// threshold where the framework should extend it
+    /// </summary>
+    /// <param name="expirationThresholdSeconds">
+    /// How many seconds before which a message will become visibile again its visibility timeout should be extended
+    /// </param>
+    /// <returns>True if the message's visibility timeout should be extended per the specified threshold, false otherwise</returns>
+    internal bool IsMessageVisibilityTimeoutExpiring(int expirationThresholdSeconds)
+    {
+        var timeUntilExpiration = ExpectedVisibilityTimeoutExpiration - DateTimeOffset.UtcNow;
+
+        if (timeUntilExpiration.TotalSeconds <= expirationThresholdSeconds)
+        {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/test/AWS.Messaging.IntegrationTests/Models/ChatMessage.cs
+++ b/test/AWS.Messaging.IntegrationTests/Models/ChatMessage.cs
@@ -6,4 +6,6 @@ namespace AWS.Messaging.IntegrationTests.Models;
 public class ChatMessage
 {
     public string MessageDescription { get; set; } = string.Empty;
+
+    public override string ToString() => MessageDescription;
 }

--- a/test/AWS.Messaging.UnitTests/DefaultMessageManagerTests.cs
+++ b/test/AWS.Messaging.UnitTests/DefaultMessageManagerTests.cs
@@ -24,37 +24,31 @@ namespace AWS.Messaging.UnitTests
         [Fact]
         public async Task DefaultMessageManager_ManagesMessageSuccess()
         {
-            var mockPoller = CreateMockPoller(messageVisibilityRefreshInterval: 10);
+            var mockPoller = CreateMockPoller();
             var mockHandlerInvoker = CreateMockHandlerInvoker(MessageProcessStatus.Success());
 
-            var manager = new DefaultMessageManager(mockPoller.Object, mockHandlerInvoker.Object, new NullLogger<DefaultMessageManager>());
+            var manager = new DefaultMessageManager(mockPoller.Object, mockHandlerInvoker.Object, new NullLogger<DefaultMessageManager>(), new MessageManagerConfiguration());
 
-            var messsageEnvelope = new MessageEnvelope<ChatMessage>();
+            var messsageEnvelope = new MessageEnvelope<ChatMessage> { Id = "1" };
             var subscriberMapping = new SubscriberMapping(typeof(ChatMessageHandler), typeof(ChatMessage));
 
             await manager.ProcessMessageAsync(messsageEnvelope, subscriberMapping);
 
             // Verify that the handler was invoked once with the expected message and mapping
-            mockHandlerInvoker.Verify(x => x.InvokeAsync(
-                    It.Is<MessageEnvelope>(actualEnvelope => actualEnvelope == messsageEnvelope),
-                    It.Is<SubscriberMapping>(actualMapping => actualMapping == subscriberMapping),
-                    It.IsAny<CancellationToken>()),
-                Times.Once());
+            mockHandlerInvoker.VerifyInvokeAsyncWasCalledWith(messsageEnvelope, subscriberMapping, Times.Once());
 
             // Since the mock handler invoker returns success, verify that delete was called
-            mockPoller.Verify(poller => poller.DeleteMessagesAsync(
-                    It.Is<IEnumerable<MessageEnvelope>>(x => x.Count() == 1 && x.First() == messsageEnvelope),
-                    It.IsAny<CancellationToken>()),
-                Times.Once());
+            mockPoller.VerifyDeleteMessagesAsyncWasCalledWith(messsageEnvelope, Times.Once());
 
             // Since the handler succeeds right away, verify the visiblity was never extended
-            mockPoller.Verify(poller => poller.ExtendMessageVisibilityTimeoutAsync(
-                    It.IsAny<IEnumerable<MessageEnvelope>>(),
-                    It.IsAny<CancellationToken>()),
-                Times.Never());
+            mockPoller.VerifyExtendMessageVisibilityTimeoutAsync(new[] { messsageEnvelope }, Times.Never());
 
             // Verify that the active message count was deprecated back to 0
             Assert.Equal(0, manager.ActiveMessageCount);
+
+            // Verify that there were no expected poller/handler calls
+            mockPoller.VerifyNoOtherCalls();
+            mockHandlerInvoker.VerifyNoOtherCalls();
         }
 
         /// <summary>
@@ -63,80 +57,137 @@ namespace AWS.Messaging.UnitTests
         [Fact]
         public async Task DefaultMessageManager_ManagesMessageFailed()
         {
-            var mockPoller = CreateMockPoller(messageVisibilityRefreshInterval: 10);
+            var mockPoller = CreateMockPoller();
             var mockHandlerInvoker = CreateMockHandlerInvoker(MessageProcessStatus.Failed());
 
-            var manager = new DefaultMessageManager(mockPoller.Object, mockHandlerInvoker.Object, new NullLogger<DefaultMessageManager>());
+            var manager = new DefaultMessageManager(mockPoller.Object, mockHandlerInvoker.Object, new NullLogger<DefaultMessageManager>(), new MessageManagerConfiguration());
 
-            var messsageEnvelope = new MessageEnvelope<ChatMessage>();
+            var messsageEnvelope = new MessageEnvelope<ChatMessage> { Id = "1" };
             var subscriberMapping = new SubscriberMapping(typeof(ChatMessageHandler), typeof(ChatMessage));
 
             await manager.ProcessMessageAsync(messsageEnvelope, subscriberMapping);
 
             // Verify that the handler was invoked once with the expected message and mapping
-            mockHandlerInvoker.Verify(x => x.InvokeAsync(
-                    It.Is<MessageEnvelope>(actualEnvelope => actualEnvelope == messsageEnvelope),
-                    It.Is<SubscriberMapping>(actualMapping => actualMapping == subscriberMapping),
-                    It.IsAny<CancellationToken>()),
-                Times.Once());
+            mockHandlerInvoker.VerifyInvokeAsyncWasCalledWith(messsageEnvelope, subscriberMapping, Times.Once());
 
             // Since the message handling failed, verify that delete was never called
-            mockPoller.Verify(poller => poller.DeleteMessagesAsync(
-                    It.IsAny<IEnumerable<MessageEnvelope>>(),
-                    It.IsAny<CancellationToken>()),
-                Times.Never());
+            mockPoller.VerifyDeleteMessagesAsyncWasCalledWith(messsageEnvelope, Times.Never());
 
             // Since the handler fails right away, verify the visiblity was never extended
-            mockPoller.Verify(poller => poller.ExtendMessageVisibilityTimeoutAsync(
-                    It.IsAny<IEnumerable<MessageEnvelope>>(),
-                    It.IsAny<CancellationToken>()),
-                Times.Never());
+            mockPoller.VerifyExtendMessageVisibilityTimeoutAsync(new[] { messsageEnvelope }, Times.Never());
+
+            // Verify that the active message count was deprecated back to 0
+            Assert.Equal(0, manager.ActiveMessageCount);
+
+            // Verify that there were no expected poller/handler calls
+            mockPoller.VerifyNoOtherCalls();
+            mockHandlerInvoker.VerifyNoOtherCalls();
+        }
+
+        /// <summary>
+        /// Tests that the manager extends the visibility timeout when appropriate for a batch of in flight messages
+        /// </summary>
+        [Fact]
+        public async Task DefaultMessageManager_ExtendsVisibilityTimeout_Batch()
+        {
+            var mockPoller = CreateMockPoller();
+            var mockHandlerInvoker = CreateMockHandlerInvoker(MessageProcessStatus.Success(), messageHandlingDelay: TimeSpan.FromSeconds(3));
+
+            var manager = new DefaultMessageManager(mockPoller.Object, mockHandlerInvoker.Object, new NullLogger<DefaultMessageManager>(), new MessageManagerConfiguration
+            {
+                VisibilityTimeout = 2,
+                VisibilityTimeoutExtensionThreshold = 1,
+                VisibilityTimeoutExtensionHeartbeatInterval = TimeSpan.FromSeconds(1)
+            });
+
+            var subscriberMapping = new SubscriberMapping(typeof(ChatMessageHandler), typeof(ChatMessage));
+
+            // Start handling two messages at roughly the same time
+            var message1 = new MessageEnvelope<ChatMessage>() { Id = "1" };
+            var message2 = new MessageEnvelope<ChatMessage>() { Id = "2" };
+
+            var message1Task = manager.ProcessMessageAsync(message1, subscriberMapping);
+            var message2Task = manager.ProcessMessageAsync(message2, subscriberMapping);
+
+            // Don't await the tasks yet,so we can assert that ActiveMessageCount was incremented while the handlers are still processing
+            Assert.Equal(2, manager.ActiveMessageCount);
+
+            // Now finish awaiting the handlers
+            await Task.WhenAll(message1Task, message2Task);
+
+            // Verify that the handler was invoked with the expected messages and mapping
+            mockHandlerInvoker.VerifyInvokeAsyncWasCalledWith(message1, subscriberMapping, Times.Once());
+            mockHandlerInvoker.VerifyInvokeAsyncWasCalledWith(message2, subscriberMapping, Times.Once());
+
+            // Since the mock handler invoker returns success, verify that delete was called
+            mockPoller.VerifyDeleteMessagesAsyncWasCalledWith(message1, Times.Once());
+            mockPoller.VerifyDeleteMessagesAsyncWasCalledWith(message2, Times.Once());
+
+            // Since the message handler takes 3 seconds, verify that the visibility was extended
+            // The 1 to 3 allows for some instability around the second boundaries
+            mockPoller.VerifyExtendMessageVisibilityTimeoutAsync(new[] { message2, message1 }, Times.Between(1, 3, Moq.Range.Inclusive));
+
+            // Verify that there were no other calls, which is guarding against
+            // ExtendMessageVisibilityTimeoutAsync being called with only a single message since
+            // we expect these to have the same lifecycle
+            mockHandlerInvoker.VerifyNoOtherCalls();
 
             // Verify that the active message count was deprecated back to 0
             Assert.Equal(0, manager.ActiveMessageCount);
         }
 
         /// <summary>
-        /// Tests that the manager extends the visibility timeout when the message handler
-        /// takes longer than the refresh interval
+        /// Tests that the manager extends the visibility timeout when appropriate for in flight messages
+        /// that were received at different timestamps
         /// </summary>
         [Fact]
-        public async Task DefaultMessageManager_RefreshesLongHandler()
+        public async Task DefaultMessageManager_ExtendsVisibilityTimeout_OnlyWhenNecessary()
         {
-            var mockPoller = CreateMockPoller(messageVisibilityRefreshInterval: 1);
-            var mockHandlerInvoker = CreateMockHandlerInvoker(MessageProcessStatus.Success(), messageHandlingDelay: TimeSpan.FromSeconds(3));
+            var mockPoller = CreateMockPoller();
+            var mockHandlerInvoker = CreateMockHandlerInvoker(MessageProcessStatus.Success(), messageHandlingDelay: TimeSpan.FromSeconds(4));
 
-            var manager = new DefaultMessageManager(mockPoller.Object, mockHandlerInvoker.Object, new NullLogger<DefaultMessageManager>());
+            var manager = new DefaultMessageManager(mockPoller.Object, mockHandlerInvoker.Object, new NullLogger<DefaultMessageManager>(), new MessageManagerConfiguration
+            {
+                VisibilityTimeout = 2,
+                VisibilityTimeoutExtensionThreshold = 1,
+                VisibilityTimeoutExtensionHeartbeatInterval = TimeSpan.FromSeconds(1)
+            });
 
-            var messsageEnvelope = new MessageEnvelope<ChatMessage>();
             var subscriberMapping = new SubscriberMapping(typeof(ChatMessageHandler), typeof(ChatMessage));
 
-            // Don't await the task, but start it so we can assert ActiveMessageCount was incremented while the handler is still processing
-            var task = manager.ProcessMessageAsync(messsageEnvelope, subscriberMapping);
-            Assert.Equal(1, manager.ActiveMessageCount);
+            // Start handling a single message
+            var earlyMessage = new MessageEnvelope<ChatMessage>() { Id = "1" };
+            var earlyTask = manager.ProcessMessageAsync(earlyMessage, subscriberMapping);
 
-            // Now finish awaiting the handler
-            await task;
+            // Delay, then start handling another message
+            await Task.Delay(TimeSpan.FromSeconds(3));
 
-            // Verify that the handler was invoked once with the expected message and mapping
-            mockHandlerInvoker.Verify(x => x.InvokeAsync(
-                        It.Is<MessageEnvelope>(actualEnvelope => actualEnvelope == messsageEnvelope),
-                        It.Is<SubscriberMapping>(actualMapping => actualMapping == subscriberMapping),
-                        It.IsAny<CancellationToken>()),
-                Times.Once());
+            var laterMessage = new MessageEnvelope<ChatMessage>() { Id = "2" };
+            var laterTask = manager.ProcessMessageAsync(laterMessage, subscriberMapping);
+
+            // Now finish awaiting the handlers
+            await Task.WhenAll(earlyTask, laterTask);
+
+            // Verify that the handler was invoked with the expected messages and mapping
+            mockHandlerInvoker.VerifyInvokeAsyncWasCalledWith(earlyMessage, subscriberMapping, Times.Once());
+            mockHandlerInvoker.VerifyInvokeAsyncWasCalledWith(laterMessage, subscriberMapping, Times.Once());
 
             // Since the mock handler invoker returns success, verify that delete was called
-            mockPoller.Verify(poller => poller.DeleteMessagesAsync(
-                    It.Is<IEnumerable<MessageEnvelope>>(x => x.Count() == 1 && x.First() == messsageEnvelope),
-                    It.IsAny<CancellationToken>()),
-                Times.Once());
+            mockPoller.VerifyDeleteMessagesAsyncWasCalledWith(earlyMessage, Times.Once());
+            mockPoller.VerifyDeleteMessagesAsyncWasCalledWith(laterMessage, Times.Once());
 
             // Since the message handler takes 3 seconds, verify the the visibility was extended
-            // TODO: the 2 to 3 allows for some instability
-            mockPoller.Verify(poller => poller.ExtendMessageVisibilityTimeoutAsync(
-                    It.Is<IEnumerable<MessageEnvelope>>(x => x.Count() == 1 && x.First() == messsageEnvelope),
-                    It.IsAny<CancellationToken>()),
-                Times.Between(2, 3, Moq.Range.Inclusive));
+            // The 1 to 3 allows for some instability around the second boundaries
+            mockPoller.VerifyExtendMessageVisibilityTimeoutAsync(new[] { earlyMessage }, Times.Between(1, 3, Moq.Range.Inclusive));
+            mockPoller.VerifyExtendMessageVisibilityTimeoutAsync(new[] { laterMessage }, Times.Between(1, 3, Moq.Range.Inclusive));
+
+            // Verify that there were no other calls, which is guarding against ExtendMessageVisibilityTimeoutAsync
+            // being called with both messages since we never expect them to be batched together
+            // T  | T+0   | T+1    | T+2    | T+3    | T+4    | T+5    | T + 6  | T + 7  |
+            // M1 | Start |        | Extend | Extend | Finish |        |        |        |
+            // M2 |       |                 | Start  |        | Extend | Extend | Finish |
+            mockPoller.VerifyNoOtherCalls();
+            mockHandlerInvoker.VerifyNoOtherCalls();
 
             // Verify that the active message count was deprecated back to 0
             Assert.Equal(0, manager.ActiveMessageCount);
@@ -149,10 +200,10 @@ namespace AWS.Messaging.UnitTests
         [Fact]
         public async Task DefaultMessageManager_CountsActiveMessagesCorrectly()
         {
-            var mockPoller = CreateMockPoller(messageVisibilityRefreshInterval: 1);
+            var mockPoller = CreateMockPoller();
             var mockHandlerInvoker = CreateMockHandlerInvoker(MessageProcessStatus.Success(), TimeSpan.FromSeconds(1));
 
-            var manager = new DefaultMessageManager(mockPoller.Object, mockHandlerInvoker.Object, new NullLogger<DefaultMessageManager>());
+            var manager = new DefaultMessageManager(mockPoller.Object, mockHandlerInvoker.Object, new NullLogger<DefaultMessageManager>(), new MessageManagerConfiguration());
             var subscriberMapping = new SubscriberMapping(typeof(ChatMessageHandler), typeof(ChatMessage));
            
             var tasks = new List<Task>();
@@ -175,9 +226,8 @@ namespace AWS.Messaging.UnitTests
         /// <summary>
         /// Mocks a message poller with the given visibility refresh interval
         /// </summary>
-        /// <param name="messageVisibilityRefreshInterval">How frequently the manager should extend message visibility in seconds</param>
         /// <returns>Mock poller</returns>
-        private Mock<IMessagePoller> CreateMockPoller(int messageVisibilityRefreshInterval)
+        private Mock<IMessagePoller> CreateMockPoller()
         {
             var mockPoller = new Mock<IMessagePoller>();
 
@@ -185,8 +235,6 @@ namespace AWS.Messaging.UnitTests
                     It.IsAny<IEnumerable<MessageEnvelope>>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
-
-            mockPoller.Setup(x => x.VisibilityTimeoutExtensionInterval).Returns(messageVisibilityRefreshInterval);
 
             return mockPoller;
         }
@@ -220,6 +268,46 @@ namespace AWS.Messaging.UnitTests
             }
 
             return mockHandlerInvoker;
+        }
+    }
+
+    /// <summary>
+    /// Extension methods for mocked <see cref="IMessagePoller"/> and <see cref="IHandlerInvoker"/> objects to be able to verify more concisely above
+    /// </summary>
+    public static class MockSQSMessagePollerExtensions
+    {
+        /// <summary>
+        /// Verifies that <see cref="IMessagePoller.DeleteMessagesAsync"/> was called with a specified message a specified number of times
+        /// </summary>
+        public static void VerifyDeleteMessagesAsyncWasCalledWith(this Mock<IMessagePoller> mockPoller, MessageEnvelope expectedMessage, Times times)
+        {
+            mockPoller.Verify(poller => poller.DeleteMessagesAsync(
+                    It.Is<IEnumerable<MessageEnvelope>>(x => x.Count() == 1 && x.First() == expectedMessage),
+                    It.IsAny<CancellationToken>()),
+                times);
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="IHandlerInvoker.InvokeAsync"/> was called with a specified message and mapping a specified number of times
+        /// </summary>
+        public static void VerifyInvokeAsyncWasCalledWith(this Mock<IHandlerInvoker> mockHandlerInvoker, MessageEnvelope expectedMessage, SubscriberMapping expectedSubscriberMapping, Times times)
+        {
+            mockHandlerInvoker.Verify(x => x.InvokeAsync(
+                    It.Is<MessageEnvelope>(actualEnvelope => actualEnvelope == expectedMessage),
+                    It.Is<SubscriberMapping>(actualMapping => actualMapping == expectedSubscriberMapping),
+                    It.IsAny<CancellationToken>()),
+                times);
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="IMessagePoller.ExtendMessageVisibilityTimeoutAsync"/> was called with specified message(s) a specified number of times
+        /// </summary>
+        public static void VerifyExtendMessageVisibilityTimeoutAsync(this Mock<IMessagePoller> mockPoller, IEnumerable<MessageEnvelope> messages, Times times)
+        {
+            mockPoller.Verify(poller => poller.ExtendMessageVisibilityTimeoutAsync(
+                    It.Is<IEnumerable<MessageEnvelope>>(x => x.ToHashSet().SetEquals(messages.ToHashSet())), // use HashSets becuase the order may differ
+                    It.IsAny<CancellationToken>()),
+                times);
         }
     }
 }

--- a/test/AWS.Messaging.UnitTests/MessageBusBuilderTests.cs
+++ b/test/AWS.Messaging.UnitTests/MessageBusBuilderTests.cs
@@ -304,7 +304,8 @@ public class MessageBusBuilderTests
             builder.AddSQSPoller("queueUrl", options => {
                 options.MaxNumberOfConcurrentMessages = 20;
                 options.VisibilityTimeout = 5;
-                options.VisibilityTimeoutExtensionInterval = 2;
+                options.VisibilityTimeoutExtensionThreshold = 2;
+                options.VisibilityTimeoutExtensionHeartbeatInterval = TimeSpan.FromMilliseconds(500);
                 options.WaitTimeSeconds = 10;
             });
         });
@@ -323,7 +324,8 @@ public class MessageBusBuilderTests
             Assert.Equal("queueUrl", sqsConfiguration.SubscriberEndpoint);
             Assert.Equal(20, sqsConfiguration.MaxNumberOfConcurrentMessages);
             Assert.Equal(5, sqsConfiguration.VisibilityTimeout);
-            Assert.Equal(2, sqsConfiguration.VisibilityTimeoutExtensionInterval);
+            Assert.Equal(2, sqsConfiguration.VisibilityTimeoutExtensionThreshold);
+            Assert.Equal(TimeSpan.FromMilliseconds(500), sqsConfiguration.VisibilityTimeoutExtensionHeartbeatInterval);
             Assert.Equal(10, sqsConfiguration.WaitTimeSeconds);
         }
         else
@@ -385,21 +387,38 @@ public class MessageBusBuilderTests
         yield return new object[] { new Action<SQSMessagePollerOptions>((options) => options.WaitTimeSeconds = -1) };
         yield return new object[] { new Action<SQSMessagePollerOptions>((options) => options.WaitTimeSeconds = 21) };
 
-        // VisibilityTimeoutExtensionInterval must be postive 
-        yield return new object[] { new Action<SQSMessagePollerOptions>((options) => options.VisibilityTimeoutExtensionInterval = -1) };
-        yield return new object[] { new Action<SQSMessagePollerOptions>((options) => options.VisibilityTimeoutExtensionInterval = 0) };
+        // VisibilityTimeoutExtensionThreshold must be postive 
+        yield return new object[] { new Action<SQSMessagePollerOptions>((options) => options.VisibilityTimeoutExtensionThreshold = -1) };
+        yield return new object[] { new Action<SQSMessagePollerOptions>((options) => options.VisibilityTimeoutExtensionThreshold = 0) };
 
-        // VisibilityTimeoutExtensionInterval must be strictly less than than VisibilityTimeout
+        // VisibilityTimeoutExtensionThreshold must be strictly less than than VisibilityTimeout
         yield return new object[] { new Action<SQSMessagePollerOptions>((options) =>
         {
             options.VisibilityTimeout = 5;
-            options.VisibilityTimeoutExtensionInterval = 5;
+            options.VisibilityTimeoutExtensionThreshold = 5;
         })};
         yield return new object[] { new Action<SQSMessagePollerOptions>((options) =>
         {
             options.VisibilityTimeout = 4;
-            options.VisibilityTimeoutExtensionInterval = 5;
+            options.VisibilityTimeoutExtensionThreshold = 5;
         })};
+
+        // VisibilityTimeoutExtensionHeartbeatInterval must be postive
+        yield return new object[] { new Action<SQSMessagePollerOptions>((options) => options.VisibilityTimeoutExtensionHeartbeatInterval = TimeSpan.FromSeconds(-1)) };
+        yield return new object[] { new Action<SQSMessagePollerOptions>((options) => options.VisibilityTimeoutExtensionHeartbeatInterval = TimeSpan.Zero) };
+
+        // VisibilityTimeoutExtensionHeartbeatInterval must be strictly less than than VisibilityTimeoutExtensionThreshold
+        yield return new object[] { new Action<SQSMessagePollerOptions>((options) =>
+        {
+            options.VisibilityTimeoutExtensionHeartbeatInterval = TimeSpan.FromSeconds(5);
+            options.VisibilityTimeoutExtensionThreshold = 5;
+        })};
+        yield return new object[] { new Action<SQSMessagePollerOptions>((options) =>
+        {
+            options.VisibilityTimeoutExtensionHeartbeatInterval  = TimeSpan.FromSeconds(6);
+            options.VisibilityTimeoutExtensionThreshold = 5;
+        })};
+
     }
 
     /// <summary>

--- a/test/AWS.Messaging.UnitTests/SQSMessagePollerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SQSMessagePollerTests.cs
@@ -42,7 +42,7 @@ public class SQSMessagePollerTests
 
     /// <summary>
     /// Tests that configuring a poller with <see cref="SQSMessagePollerConfiguration.MaxNumberOfConcurrentMessages"/>
-    /// set to a value greater than SQS's current limit of 10 will only recieve 10 messages at a time.
+    /// set to a value greater than SQS's current limit of 10 will only receive 10 messages at a time.
     /// </summary>
     [Fact]
     public async Task SQSMessagePoller_ManyConcurrentMessages_DoesNotExceedSQSMax()
@@ -118,8 +118,8 @@ public class SQSMessagePollerTests
             It.Is<ChangeMessageVisibilityBatchRequest>(request =>
                 request.QueueUrl == TEST_QUEUE_URL &&
                 request.Entries.Count == 2 &&
-                request.Entries.Any(entry => entry.Id == "1" && entry.ReceiptHandle == "rh1") &&
-                request.Entries.Any(entry => entry.Id == "2" && entry.ReceiptHandle == "rh2")),
+                request.Entries.Any(entry => entry.Id == "batchNum_0_messageId_1" && entry.ReceiptHandle == "rh1") &&
+                request.Entries.Any(entry => entry.Id == "batchNum_1_messageId_2" && entry.ReceiptHandle == "rh2")),
             It.IsAny<CancellationToken>()));
     }
 


### PR DESCRIPTION
*Issue #, if available:* DOTNET-6901

*Description of changes:* Adds a design doc for the SQS poller will manage the visibility timeout for messages that are still being handled.
* This is discussed briefly in the overall design, but here's more detail. I imagine pieces of this can be reused for the documentation later.
* A rudimentary version of this is currently implemented in `main`/`dev` (all in flight messages are extended). A code change will follow this PR with updates to the configuration options and batching behavior.

See the two open questions at the end, thanks.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
