### PR TITLE
feat: add ability to configure message source or compute it as a fallback

### DIFF
--- a/docs/design/message-source-computation-design.md
+++ b/docs/design/message-source-computation-design.md
@@ -1,0 +1,61 @@
+# Message Source Computation
+
+## Background
+
+The AWS Message Processing framework adheres to the [CloudEvents specification](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md). It wraps each application message sent by a customer with a message envelope that contains all the required attributes specified by the CloudEvents spec. One of the required attributes is the **Source** attribute. The Source attribute provides context of where the message originated and primarily needs to be configurable at a message bus level by the user. If a source is not configured by the user, a value will be computed for it based on the environment in which the process is running.
+
+## How to set the message source?
+
+The **Source** attribute is stored at the `MessageConfiguration` level and will be passed to the `MessageEnvelope` irrespective of the type of message being published. When configuring the message bus, you can use the `AddMessageSource` method to set the message source.
+
+```csharp
+builder.Services.AddAWSMessageBus(builder =>
+{
+    // This is where the message source is set
+    builder.AddMessageSource(new Uri("/fancy/backend-service", UriKind.Relative))
+
+    // continue message bus configuration below ...
+    builder.AddSQSPublisher<ChatMessage>("https://sqs.us-west-2.amazonaws.com/012345678910/TestQueue");
+});
+```
+
+In case access to the `Source` attribute is needed, the attribute is accessible through the dependency injection framework by injecting `IMessageConfiguration`. The `Source` attribute is defined as follows:
+
+```csharp
+public class MessageConfiguration : IMessageConfiguration
+{
+    /// <summary>
+    /// The relative or absolute Uri to be used as a message source.
+    /// This source is added globally to any message sent through the framework.
+    /// </summary>
+    public Uri? Source { get; set; }
+}
+```
+
+## What if I don't set the message source?
+
+When a user does not specify any source attribute, the message processing framework will resolve a source depending on the compute environment that the process is executing in. The following compute environments are considered when computing the source.
+
+### AWS Lambda
+
+Lambda runtimes set several environment variables during initialization. We will look for the `AWS_LAMBDA_FUNCTION_NAME` environment variable to check if the process is running inside a Lambda function. More information on environment variables defined by AWS Lambda can be found at https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime
+
+**Resolved Source** - `/AWSLambda/{FUNCTION-NAME}`
+
+### Amazon ECS
+
+The Amazon ECS container agent injects an environment variable called `ECS_CONTAINER_METADATA_URI` into each container in an ECS task. To retrieve the metadata related to an ECS task we can issue a GET request to `${ECS_CONTAINER_METADATA_URI}/task`. The GET request will return a JSON response representing a dictionary. The keys in this dictionary that we are interested in are the ECS `Cluster` and `TaskARN`. More information on the task metadata endpoint in Amazon ECS can be found at https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v3.html.
+
+**Resolved Source** - `/AmazonECS/{CLUSTER}/{TASK-ARN}`
+
+### Amazon EC2
+
+The AWS SDK for .NET exposes a utility class that represents the instance metadata in EC2 which is called `EC2InstanceMetadata`. This class contains static properties that provide access to metadata from a running EC2 instance. If this class is used on a non-EC2 instance, the properties in this class will be null. We can retrieve the EC2 instance ID using the `EC2InstanceMetadata.InstanceId` property.
+
+**Resolved Source** - `/AmazonEC2/{INSTANCE-ID}`
+
+### Fallback Source Attribute
+
+If we cannot resolve the source attribute from the above compute environments then we will retrieve the DNS host name which is made available in .NET through `Dns.GetHostName()`.
+
+**Resolved Source** - `/DNSHostName/{Dns.GetHostName()}`

--- a/src/AWS.Messaging/AWS.Messaging.csproj
+++ b/src/AWS.Messaging/AWS.Messaging.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="AWSSDK.SQS" Version="3.7.100.69" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
   </ItemGroup>
   

--- a/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
@@ -60,4 +60,18 @@ public interface IMessageBusBuilder
     /// </summary>
     /// <param name="serializationCallback">An instance of <see cref="ISerializationCallback"/>that lets users inject their own metadata to incoming and outgoing messages.</param>
     IMessageBusBuilder AddSerializationCallback(ISerializationCallback serializationCallback);
+
+    /// <summary>
+    /// Adds a global message source to the message bus.
+    /// This source will be added to the message envelope of all the messages sent through the framework.
+    /// </summary>
+    /// <param name="messageSource">The relative or absolute Uri to be used as a message source.</param>
+    IMessageBusBuilder AddMessageSource(string messageSource);
+
+    /// <summary>
+    /// Appends a suffix to the message source that is either set using <see cref="AddMessageSource(string)"/>
+    /// or computed by the framework in the absence of a user-defined source.
+    /// </summary>
+    /// <param name="suffix">The suffix to append to the message source.</param>
+    IMessageBusBuilder AddMessageSourceSuffix(string suffix);
 }

--- a/src/AWS.Messaging/Configuration/IMessageConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/IMessageConfiguration.cs
@@ -55,4 +55,16 @@ public interface IMessageConfiguration
     /// Holds instances of <see cref="ISerializationCallback"/> that lets users inject their own metadata to incoming and outgoing messages.
     /// </summary>
     IList<ISerializationCallback> SerializationCallbacks { get; }
+
+    /// <summary>
+    /// The relative or absolute Uri to be used as a message source.
+    /// This source is added globally to any message sent through the framework.
+    /// </summary>
+    string? Source { get; set; }
+
+    /// <summary>
+    /// A suffix to append to the user-defined <see cref="Source"/> or
+    /// computed by the framework in the absence of a user-defined one.
+    /// </summary>
+    string? SourceSuffix { get; set; }
 }

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -108,6 +108,20 @@ public class MessageBusBuilder : IMessageBusBuilder
         return this;
     }
 
+    /// <inheritdoc/>
+    public IMessageBusBuilder AddMessageSource(string messageSource)
+    {
+        _messageConfiguration.Source = messageSource;
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public IMessageBusBuilder AddMessageSourceSuffix(string suffix)
+    {
+        _messageConfiguration.SourceSuffix = suffix;
+        return this;
+    }
+
     internal void Build(IServiceCollection services)
     {
         services.AddSingleton<IMessageConfiguration>(_messageConfiguration);
@@ -116,6 +130,12 @@ public class MessageBusBuilder : IMessageBusBuilder
         services.TryAddSingleton<IDateTimeHandler, DateTimeHandler>();
         services.TryAddSingleton<IMessageIdGenerator, MessageIdGenerator>();
         services.TryAddSingleton<IAWSClientProvider, AWSClientProvider>();
+        services.TryAddSingleton<IMessageSourceHandler, MessageSourceHandler>();
+        services.TryAddSingleton<IEnvironmentManager, EnvironmentManager>();
+        services.TryAddSingleton<IDnsManager, DnsManager>();
+        services.TryAddSingleton<IEC2InstanceMetadataManager, EC2InstanceMetadataManager>();
+        services.TryAddSingleton<IECSContainerMetadataManager, ECSContainerMetadataManager>();
+        services.AddHttpClient("ECSMetadataClient");
 
         if (_messageConfiguration.PublisherMappings.Any())
         {

--- a/src/AWS.Messaging/Configuration/MessageConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/MessageConfiguration.cs
@@ -45,4 +45,10 @@ public class MessageConfiguration : IMessageConfiguration
 
     /// <inheritdoc/>
     public IList<ISerializationCallback> SerializationCallbacks { get; } = new List<ISerializationCallback>();
+
+    /// <inheritdoc/>
+    public string? Source { get; set; }
+
+    /// <inheritdoc/>
+    public string? SourceSuffix { get; set; }
 } 

--- a/src/AWS.Messaging/Properties/AssemblyInfo.cs
+++ b/src/AWS.Messaging/Properties/AssemblyInfo.cs
@@ -5,3 +5,4 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("AWS.Messaging.UnitTests")]
 [assembly: InternalsVisibleTo("AWS.Messaging.IntegrationTests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/src/AWS.Messaging/Services/DnsManager.cs
+++ b/src/AWS.Messaging/Services/DnsManager.cs
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Net;
+
+namespace AWS.Messaging.Services;
+
+/// <summary>
+/// A wrapper around <see cref="Dns"/>.
+/// </summary>
+internal class DnsManager : IDnsManager
+{
+    /// <inheritdoc/>
+    public string GetHostName() => Dns.GetHostName();
+}

--- a/src/AWS.Messaging/Services/EC2InstanceMetadataManager.cs
+++ b/src/AWS.Messaging/Services/EC2InstanceMetadataManager.cs
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Util;
+
+namespace AWS.Messaging.Services;
+
+/// <summary>
+/// A wrapper around <see cref="EC2InstanceMetadata"/>.
+/// </summary>
+internal class EC2InstanceMetadataManager : IEC2InstanceMetadataManager
+{
+    /// <inheritdoc/>
+    public string InstanceId
+    {
+        get
+        {
+            return EC2InstanceMetadata.InstanceId;
+        }
+    }
+}

--- a/src/AWS.Messaging/Services/ECSContainerMetadataManager.cs
+++ b/src/AWS.Messaging/Services/ECSContainerMetadataManager.cs
@@ -1,0 +1,55 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace AWS.Messaging.Services;
+
+/// <summary>
+/// A wrapper around ECS container metadata.
+/// </summary>
+internal class ECSContainerMetadataManager : IECSContainerMetadataManager
+{
+    private readonly IEnvironmentManager _environmentManager;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<MessageSourceHandler> _logger;
+
+    public ECSContainerMetadataManager(
+        IEnvironmentManager environmentManager,
+        IHttpClientFactory httpClientFactory,
+        ILogger<MessageSourceHandler> logger)
+    {
+        _environmentManager = environmentManager;
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<Dictionary<string, object>> GetContainerTaskMetadata()
+    {
+        var metadata = new Dictionary<string, object>();
+
+        var ecsMetadataURI = _environmentManager.GetEnvironmentVariable("ECS_CONTAINER_METADATA_URI");
+        if (string.IsNullOrEmpty(ecsMetadataURI))
+            return metadata;
+
+        try
+        {
+            var client = _httpClientFactory.CreateClient("ECSMetadataClient");
+
+            var response = await client.GetAsync(new Uri($"{ecsMetadataURI}/task"));
+            if (!response.IsSuccessStatusCode)
+                return metadata;
+
+            var taskMetadataJson = await response.Content.ReadAsStringAsync();
+            return JsonSerializer.Deserialize<Dictionary<string, object>>(taskMetadataJson) ??
+                metadata;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unable to retrieve Task Arn from ECS container metadata.");
+            return metadata;
+        }
+    }
+}

--- a/src/AWS.Messaging/Services/EnvironmentManager.cs
+++ b/src/AWS.Messaging/Services/EnvironmentManager.cs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Services;
+
+/// <summary>
+/// A wrapper around <see cref="Environment"/>.
+/// </summary>
+internal class EnvironmentManager : IEnvironmentManager
+{
+    /// <inheritdoc/>
+    public string? GetEnvironmentVariable(string variable) => Environment.GetEnvironmentVariable(variable);
+}

--- a/src/AWS.Messaging/Services/IDnsManager.cs
+++ b/src/AWS.Messaging/Services/IDnsManager.cs
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Net;
+
+namespace AWS.Messaging.Services;
+
+/// <summary>
+/// A wrapper around <see cref="Dns"/>.
+/// </summary>
+internal interface IDnsManager
+{
+    /// <summary>
+    /// Gets the host name of the local computer.
+    /// </summary>
+    /// <returns>A string that contains the host name of the local computer.</returns>
+    string GetHostName();
+}

--- a/src/AWS.Messaging/Services/IEC2InstanceMetadataManager.cs
+++ b/src/AWS.Messaging/Services/IEC2InstanceMetadataManager.cs
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Util;
+
+namespace AWS.Messaging.Services;
+
+/// <summary>
+/// A wrapper around <see cref="EC2InstanceMetadata"/>.
+/// </summary>
+internal interface IEC2InstanceMetadataManager
+{
+    /// <summary>
+    /// The ID of the EC2 instance.
+    /// </summary>
+    string InstanceId { get; }
+}

--- a/src/AWS.Messaging/Services/IECSContainerMetadataManager.cs
+++ b/src/AWS.Messaging/Services/IECSContainerMetadataManager.cs
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Services;
+
+/// <summary>
+/// A wrapper around ECS container metadata.
+/// </summary>
+internal interface IECSContainerMetadataManager
+{
+    /// <summary>
+    /// The Amazon ECS container agent injects an environment variable called ECS_CONTAINER_METADATA_URI into each container in a task.
+    /// To retrieve the TaskArn related to an ECS task we can issue a GET request to ${ECS_CONTAINER_METADATA_URI}/task.
+    /// </summary>
+    /// <returns>Task metadata as a dictionary</returns>
+    Task<Dictionary<string, object>> GetContainerTaskMetadata();
+}

--- a/src/AWS.Messaging/Services/IEnvironmentManager.cs
+++ b/src/AWS.Messaging/Services/IEnvironmentManager.cs
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Services;
+
+/// <summary>
+/// A wrapper around <see cref="Environment"/>.
+/// </summary>
+internal interface IEnvironmentManager
+{
+    /// <summary>
+    /// Retrieve a specified system environment variable.
+    /// </summary>
+    /// <param name="variable">Environment variable name</param>
+    /// <returns>Environment variable value</returns>
+    string? GetEnvironmentVariable(string variable);
+}

--- a/src/AWS.Messaging/Services/IMessageSourceHandler.cs
+++ b/src/AWS.Messaging/Services/IMessageSourceHandler.cs
@@ -1,0 +1,17 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Services;
+
+/// <summary>
+/// This interface provides the functionality to compute the message source
+/// based on the hosting environment.
+/// </summary>
+internal interface IMessageSourceHandler
+{
+    /// <summary>
+    /// Resolves a message source depending on the compute environment that it's executing in.
+    /// </summary>
+    /// <returns>The computed message source.</returns>
+    Task<Uri> ComputeMessageSource();
+}

--- a/src/AWS.Messaging/Services/MessageSourceHandler.cs
+++ b/src/AWS.Messaging/Services/MessageSourceHandler.cs
@@ -1,0 +1,194 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Net;
+using Amazon.Util;
+using AWS.Messaging.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace AWS.Messaging.Services;
+
+/// <summary>
+/// Provides the functionality to compute the message source
+/// based on the hosting environment.
+/// </summary>
+internal class MessageSourceHandler : IMessageSourceHandler
+{
+    private readonly IEnvironmentManager _environmentManager;
+    private readonly IDnsManager _dnsManager;
+    private readonly IECSContainerMetadataManager _ecsContainerMetadataManager;
+    private readonly IEC2InstanceMetadataManager _ec2InstanceMetadataHandler;
+    private readonly IMessageConfiguration _messageConfiguration;
+    private readonly ILogger<MessageSourceHandler> _logger;
+
+    public MessageSourceHandler(
+        IEnvironmentManager environmentManager,
+        IDnsManager dnsManager,
+        IECSContainerMetadataManager ecsContainerMetadataManager,
+        IEC2InstanceMetadataManager ec2InstanceMetadataHandler,
+        IMessageConfiguration messageConfiguration,
+        ILogger<MessageSourceHandler> logger)
+    {
+        _environmentManager = environmentManager;
+        _dnsManager = dnsManager;
+        _ecsContainerMetadataManager = ecsContainerMetadataManager;
+        _ec2InstanceMetadataHandler = ec2InstanceMetadataHandler;
+        _messageConfiguration = messageConfiguration;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Resolves a message source depending on the compute environment that it's executing in.
+    /// The following compute environments are considered, in the specified order below:
+    /// <list type="number">
+    /// <item>
+    ///     <term>AWS Lambda</term>
+    ///     <description>The AWS_LAMBDA_FUNCTION_NAME environment variable is checked.</description>
+    /// </item>
+    /// <item>
+    ///     <term>Amazon ECS</term>
+    ///     <description>The ECS_CONTAINER_METADATA_URI environment variable is checked.</description>
+    /// </item>
+    /// <item>
+    ///     <term>Amazon EC2</term>
+    ///     <description>The AWS SDK for .NET is used to retrieve the <see cref="EC2InstanceMetadata.InstanceId"/>
+    ///     property using <see cref="EC2InstanceMetadata"/></description>
+    /// </item>
+    /// <item>
+    ///     <description>If the source cannot be resolved from the compute environment,
+    ///     we fallback to using <see cref="Dns.GetHostName"/></description>
+    /// </item>
+    /// </list>
+    /// After a source is computed, the message source suffix is appended if one is set.
+    /// </summary>
+    /// <returns>The computed message source.</returns>
+    public async Task<Uri> ComputeMessageSource()
+    {
+        if (_messageConfiguration.Source != null)
+            return GetFullSourceUri(_messageConfiguration.Source, _messageConfiguration.SourceSuffix);
+
+        _logger.LogTrace("Attempting to compute message source based on the current environment...");
+        string? messageSource = GetSourceFromLambda();
+        if (string.IsNullOrEmpty(messageSource))
+        {
+            messageSource = await GetSourceFromECS();
+        }
+        if (string.IsNullOrEmpty(messageSource))
+        {
+            messageSource = GetSourceFromEC2();
+        }
+        if (string.IsNullOrEmpty(messageSource))
+        {
+            messageSource = GetSourceFromDnsHostName();
+        }
+        if (string.IsNullOrEmpty(messageSource))
+        {
+            messageSource = "/aws/messaging";
+        }
+
+        _logger.LogTrace("Computed message source is '{MessageSource}'", messageSource);
+
+        return GetFullSourceUri(messageSource, _messageConfiguration.SourceSuffix);
+    }
+
+    /// <summary>
+    /// Combines the message source and the source suffix
+    /// and ensures the proper separation is included between the two.
+    /// </summary>
+    /// <param name="source">The message source</param>
+    /// <param name="suffix">The message source suffix</param>
+    /// <returns>A Uri that represents the message source and source suffix</returns>
+    private Uri GetFullSourceUri(string source, string? suffix)
+    {
+        source = source.Trim();
+        suffix = suffix?.Trim();
+        var sourceEndsInSlash = source.EndsWith("/");
+        var suffixStartsWithSlash = suffix?.StartsWith("/") ?? true;
+
+        if (sourceEndsInSlash && suffixStartsWithSlash)
+        {
+            source = source[..^1];
+        }
+        else if (!sourceEndsInSlash && !suffixStartsWithSlash)
+        {
+            suffix = $"/{suffix}";
+        }
+
+        return new Uri($"{source}{suffix}", UriKind.Relative);
+    }
+
+    /// <summary>
+    /// Lambda runtime sets several environment variables during initialization.
+    /// This checks the AWS_LAMBDA_FUNCTION_NAME environment variable to tell if the process is running inside a Lambda function.
+    /// </summary>
+    /// <returns>Message source from AWS Lambda</returns>
+    private string? GetSourceFromLambda()
+    {
+        _logger.LogTrace("Checking if process if running in AWS Lambda...");
+
+        var lambdaFunctionName = _environmentManager.GetEnvironmentVariable("AWS_LAMBDA_FUNCTION_NAME");
+
+        return
+            !string.IsNullOrEmpty(lambdaFunctionName) ?
+            $"/AWSLambda/{lambdaFunctionName}" :
+            null;
+    }
+
+    /// <summary>
+    /// The Amazon ECS container agent injects an environment variable called ECS_CONTAINER_METADATA_URI into each container in a task.
+    /// To retrieve the metadata related to an ECS task we can issue a GET request to ${ECS_CONTAINER_METADATA_URI}/task
+    /// If a value is found for the Cluster and TaskARN, this would indicate that the process is running in Amazon ECS.
+    /// </summary>
+    /// <returns>Message source from Amazon ECS</returns>
+    private async Task<string?> GetSourceFromECS()
+    {
+        _logger.LogTrace("Checking if process if running in Amazon ECS...");
+
+        var taskMetadata = await _ecsContainerMetadataManager.GetContainerTaskMetadata();
+
+        if (!taskMetadata.TryGetValue("Cluster", out var clusterName) ||
+            string.IsNullOrEmpty(clusterName?.ToString()))
+            return null;
+        if (!taskMetadata.TryGetValue("TaskARN", out var taskArn) ||
+            string.IsNullOrEmpty(taskArn?.ToString()))
+            return null;
+
+        return $"/AmazonECS/{clusterName}/{taskArn}";
+    }
+
+    /// <summary>
+    /// The AWS SDK for .NET is used to check the EC2 Instance Metadata.
+    /// If the SDK returns valid values, this would indicate that the process is running in Amazon EC2.
+    /// </summary>
+    /// <returns>Message source from Amazon EC2</returns>
+    private string? GetSourceFromEC2()
+    {
+        _logger.LogTrace("Checking if process if running in Amazon EC2...");
+
+        var instanceID = _ec2InstanceMetadataHandler.InstanceId;
+
+        return
+            !string.IsNullOrEmpty(instanceID) ?
+            $"/AmazonEC2/{instanceID}" :
+            null;
+    }
+
+    /// <summary>
+    /// Retrieve the DNS host name using <see cref="Dns.GetHostName"/>.
+    /// </summary>
+    /// <returns>Message source from DNS host name</returns>
+    private string? GetSourceFromDnsHostName()
+    {
+        _logger.LogTrace("Retrieving the DNS host name...");
+
+        try
+        {
+            return $"/DNSHostName/{_dnsManager.GetHostName()}";
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unable to retrieve the DNS host name.");
+            return null;
+        }
+    }
+}

--- a/test/AWS.Messaging.IntegrationTests/EventBridgePublisherTests.cs
+++ b/test/AWS.Messaging.IntegrationTests/EventBridgePublisherTests.cs
@@ -104,6 +104,7 @@ public class EventBridgePublisherTests : IAsyncLifetime
         serviceCollection.AddAWSMessageBus(builder =>
         {
             builder.AddEventBridgePublisher<ChatMessage>(_eventBusArn);
+            builder.AddMessageSource("/aws/messaging");
         });
         _serviceProvider = serviceCollection.BuildServiceProvider();
     }

--- a/test/AWS.Messaging.IntegrationTests/SNSPublisherTests.cs
+++ b/test/AWS.Messaging.IntegrationTests/SNSPublisherTests.cs
@@ -44,6 +44,7 @@ public class SNSPublisherTests : IAsyncLifetime
         serviceCollection.AddAWSMessageBus(builder =>
         {
             builder.AddSNSPublisher<ChatMessage>(_snsTopicArn);
+            builder.AddMessageSource("/aws/messaging");
         });
         _serviceProvider = serviceCollection.BuildServiceProvider();
     }

--- a/test/AWS.Messaging.IntegrationTests/SQSPublisherTests.cs
+++ b/test/AWS.Messaging.IntegrationTests/SQSPublisherTests.cs
@@ -32,6 +32,7 @@ public class SQSPublisherTests : IAsyncLifetime
         serviceCollection.AddAWSMessageBus(builder =>
         {
             builder.AddSQSPublisher<ChatMessage>(_sqsQueueUrl);
+            builder.AddMessageSource("/aws/messaging");
         });
         _serviceProvider = serviceCollection.BuildServiceProvider();
     }

--- a/test/AWS.Messaging.IntegrationTests/SubscriberTests.cs
+++ b/test/AWS.Messaging.IntegrationTests/SubscriberTests.cs
@@ -50,6 +50,7 @@ public class SubscriberTests : IAsyncLifetime
                 options.VisibilityTimeoutExtensionThreshold = 3;
             });
             builder.AddMessageHandler<ChatMessageHandler, ChatMessage>();
+            builder.AddMessageSource("/aws/messaging");
         });
         var serviceProvider = _serviceCollection.BuildServiceProvider();
 
@@ -101,6 +102,7 @@ public class SubscriberTests : IAsyncLifetime
                 options.MaxNumberOfConcurrentMessages = maxConcurrentMessages;
             });
             builder.AddMessageHandler<ChatMessageHandler_10sDelay, ChatMessage>();
+            builder.AddMessageSource("/aws/messaging");
         });
         var serviceProvider = _serviceCollection.BuildServiceProvider();
 
@@ -160,6 +162,7 @@ public class SubscriberTests : IAsyncLifetime
             builder.AddMessageHandler<ChatMessageHandler, ChatMessage>();
             builder.AddMessageHandler<FoodItemHandler, FoodItem>();
             builder.AddMessageHandler<OrderInfoHandler, OrderInfo>();
+            builder.AddMessageSource("/aws/messaging");
         });
         var serviceProvider = _serviceCollection.BuildServiceProvider();
 
@@ -235,6 +238,7 @@ public class SubscriberTests : IAsyncLifetime
             builder.AddSQSPublisher<ChatMessage>(_sqsQueueUrl);
             builder.AddSQSPoller(_sqsQueueUrl);
             builder.AddMessageHandler<ChatMessageHandler, ChatMessage>();
+            builder.AddMessageSource("/aws/messaging");
         });
         var serviceProvider = _serviceCollection.BuildServiceProvider();
 

--- a/test/AWS.Messaging.UnitTests/MessageSourceHandlerTests.cs
+++ b/test/AWS.Messaging.UnitTests/MessageSourceHandlerTests.cs
@@ -1,0 +1,255 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AWS.Messaging.Configuration;
+using AWS.Messaging.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace AWS.Messaging.UnitTests;
+
+public class MessageSourceHandlerTests
+{
+    private readonly Mock<IEnvironmentManager> _environmentManager;
+    private readonly Mock<IDnsManager> _dnsManager;
+    private readonly Mock<IEC2InstanceMetadataManager> _ec2InstanceMetadataManager;
+    private readonly Mock<IECSContainerMetadataManager> _ecsContainerMetadataManager;
+    private readonly IMessageConfiguration _messageConfiguration;
+    private readonly Mock<ILogger<MessageSourceHandler>> _logger;
+
+    public MessageSourceHandlerTests()
+    {
+        _environmentManager = new Mock<IEnvironmentManager>();
+        _dnsManager = new Mock<IDnsManager>();
+        _ec2InstanceMetadataManager = new Mock<IEC2InstanceMetadataManager>();
+        _ecsContainerMetadataManager = new Mock<IECSContainerMetadataManager>();
+        _messageConfiguration = new MessageConfiguration();
+        _logger = new Mock<ILogger<MessageSourceHandler>>();
+    }
+
+    [Fact]
+    public async Task MessageSourceIsSet()
+    {
+        _messageConfiguration.Source = "/aws/messaging";
+
+        var messageSourceHandler = new MessageSourceHandler(
+            _environmentManager.Object,
+            _dnsManager.Object,
+            _ecsContainerMetadataManager.Object,
+            _ec2InstanceMetadataManager.Object,
+            _messageConfiguration,
+            _logger.Object
+            );
+
+        var messageSource = await messageSourceHandler.ComputeMessageSource();
+
+        Assert.Equal("/aws/messaging", messageSource.OriginalString);
+    }
+
+    [Fact]
+    public async Task MessageSourceAndSuffixIsSet()
+    {
+        _messageConfiguration.Source = "/aws/messaging";
+        _messageConfiguration.SourceSuffix = "/suffix";
+
+        var messageSourceHandler = new MessageSourceHandler(
+            _environmentManager.Object,
+            _dnsManager.Object,
+            _ecsContainerMetadataManager.Object,
+            _ec2InstanceMetadataManager.Object,
+            _messageConfiguration,
+            _logger.Object
+            );
+
+        var messageSource = await messageSourceHandler.ComputeMessageSource();
+
+        Assert.Equal("/aws/messaging/suffix", messageSource.OriginalString);
+    }
+
+    [Fact]
+    public async Task MessageSourceAndSuffixIsSet_SourceDoesntEndInSlash_SuffixDoesntStartWithSlash()
+    {
+        _messageConfiguration.Source = "/aws/messaging";
+        _messageConfiguration.SourceSuffix = "suffix";
+
+        var messageSourceHandler = new MessageSourceHandler(
+            _environmentManager.Object,
+            _dnsManager.Object,
+            _ecsContainerMetadataManager.Object,
+            _ec2InstanceMetadataManager.Object,
+            _messageConfiguration,
+            _logger.Object
+            );
+
+        var messageSource = await messageSourceHandler.ComputeMessageSource();
+
+        Assert.Equal("/aws/messaging/suffix", messageSource.OriginalString);
+    }
+
+    [Fact]
+    public async Task MessageSourceAndSuffixIsSet_SourceEndsInSlash_SuffixStartsWithSlash()
+    {
+        _messageConfiguration.Source = "/aws/messaging/";
+        _messageConfiguration.SourceSuffix = "/suffix";
+
+        var messageSourceHandler = new MessageSourceHandler(
+            _environmentManager.Object,
+            _dnsManager.Object,
+            _ecsContainerMetadataManager.Object,
+            _ec2InstanceMetadataManager.Object,
+            _messageConfiguration,
+            _logger.Object
+            );
+
+        var messageSource = await messageSourceHandler.ComputeMessageSource();
+
+        Assert.Equal("/aws/messaging/suffix", messageSource.OriginalString);
+    }
+
+    [Fact]
+    public async Task MessageSourceAndSuffixIsSet_SourceAndSuffixHaveWhitespace()
+    {
+        _messageConfiguration.Source = " /aws/messaging/ ";
+        _messageConfiguration.SourceSuffix = " /suffix ";
+
+        var messageSourceHandler = new MessageSourceHandler(
+            _environmentManager.Object,
+            _dnsManager.Object,
+            _ecsContainerMetadataManager.Object,
+            _ec2InstanceMetadataManager.Object,
+            _messageConfiguration,
+            _logger.Object
+            );
+
+        var messageSource = await messageSourceHandler.ComputeMessageSource();
+
+        Assert.Equal("/aws/messaging/suffix", messageSource.OriginalString);
+    }
+
+    [Fact]
+    public async Task MessageSourceNotSet_RunningLocally()
+    {
+        _ecsContainerMetadataManager.Setup(x => x.GetContainerTaskMetadata()).ReturnsAsync(new Dictionary<string, object>());
+        _dnsManager.Setup(x => x.GetHostName()).Returns("local");
+
+        var messageSourceHandler = new MessageSourceHandler(
+            _environmentManager.Object,
+            _dnsManager.Object,
+            _ecsContainerMetadataManager.Object,
+            _ec2InstanceMetadataManager.Object,
+            _messageConfiguration,
+            _logger.Object
+            );
+
+        var messageSource = await messageSourceHandler.ComputeMessageSource();
+
+        Assert.Equal("/DNSHostName/local", messageSource.ToString());
+    }
+
+    [Fact]
+    public async Task MessageSourceNotSet_SuffixSet_RunningLocally()
+    {
+        _messageConfiguration.SourceSuffix = "/suffix";
+        _ecsContainerMetadataManager.Setup(x => x.GetContainerTaskMetadata()).ReturnsAsync(new Dictionary<string, object>());
+        _dnsManager.Setup(x => x.GetHostName()).Returns("local");
+
+        var messageSourceHandler = new MessageSourceHandler(
+            _environmentManager.Object,
+            _dnsManager.Object,
+            _ecsContainerMetadataManager.Object,
+            _ec2InstanceMetadataManager.Object,
+            _messageConfiguration,
+            _logger.Object
+            );
+
+        var messageSource = await messageSourceHandler.ComputeMessageSource();
+
+        Assert.Equal("/DNSHostName/local/suffix", messageSource.ToString());
+    }
+
+    [Fact]
+    public async Task MessageSourceNotSet_RunningInLambda()
+    {
+        _environmentManager.Setup(x => x.GetEnvironmentVariable("AWS_LAMBDA_FUNCTION_NAME")).Returns("lambda");
+
+        var messageSourceHandler = new MessageSourceHandler(
+            _environmentManager.Object,
+            _dnsManager.Object,
+            _ecsContainerMetadataManager.Object,
+            _ec2InstanceMetadataManager.Object,
+            _messageConfiguration,
+            _logger.Object
+            );
+
+        var messageSource = await messageSourceHandler.ComputeMessageSource();
+
+        Assert.Equal("/AWSLambda/lambda", messageSource.ToString());
+    }
+
+    [Fact]
+    public async Task MessageSourceNotSet_RunningInECS()
+    {
+        _ecsContainerMetadataManager.Setup(x => x.GetContainerTaskMetadata()).ReturnsAsync(new Dictionary<string, object>
+        {
+            { "Cluster", "cluster" },
+            { "TaskARN", "taskArn" }
+        });
+
+        var messageSourceHandler = new MessageSourceHandler(
+            _environmentManager.Object,
+            _dnsManager.Object,
+            _ecsContainerMetadataManager.Object,
+            _ec2InstanceMetadataManager.Object,
+            _messageConfiguration,
+            _logger.Object
+            );
+
+        var messageSource = await messageSourceHandler.ComputeMessageSource();
+
+        Assert.Equal("/AmazonECS/cluster/taskArn", messageSource.ToString());
+    }
+
+    [Fact]
+    public async Task MessageSourceNotSet_RunningInEC2()
+    {
+        _ecsContainerMetadataManager.Setup(x => x.GetContainerTaskMetadata()).ReturnsAsync(new Dictionary<string, object>());
+        _ec2InstanceMetadataManager.Setup(x => x.InstanceId).Returns("instanceId");
+
+        var messageSourceHandler = new MessageSourceHandler(
+            _environmentManager.Object,
+            _dnsManager.Object,
+            _ecsContainerMetadataManager.Object,
+            _ec2InstanceMetadataManager.Object,
+            _messageConfiguration,
+            _logger.Object
+            );
+
+        var messageSource = await messageSourceHandler.ComputeMessageSource();
+
+        Assert.Equal("/AmazonEC2/instanceId", messageSource.ToString());
+    }
+
+    [Fact]
+    public async Task MessageSourceNotSet_DnsThrowsException()
+    {
+        _ecsContainerMetadataManager.Setup(x => x.GetContainerTaskMetadata()).ReturnsAsync(new Dictionary<string, object>());
+        _dnsManager.Setup(x => x.GetHostName()).Throws<Exception>();
+
+        var messageSourceHandler = new MessageSourceHandler(
+            _environmentManager.Object,
+            _dnsManager.Object,
+            _ecsContainerMetadataManager.Object,
+            _ec2InstanceMetadataManager.Object,
+            _messageConfiguration,
+            _logger.Object
+            );
+
+        var messageSource = await messageSourceHandler.ComputeMessageSource();
+
+        Assert.Equal("/aws/messaging", messageSource.ToString());
+    }
+}

--- a/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
@@ -31,6 +31,7 @@ public class EnvelopeSerializerTests
         {
             builder.AddSQSPublisher<AddressInfo>("sqsQueueUrl", "addressInfo");
             builder.AddMessageHandler<AddressInfoHandler, AddressInfo>("addressInfo");
+            builder.AddMessageSource("/aws/messaging");
         });
 
         var mockDateTimeHandler = new Mock<IDateTimeHandler>();


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6903

*Description of changes:*
* Added the ability for users to configure the message source in the message bus
* If a value is not configured, the source will be computed based on the compute environment the process is running in.
* Added a design doc that explains the behavior implemented in this PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
