### PR TITLE
chore: Register message handlers as scoped dependencies in the service collection

### DIFF
--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -308,7 +308,7 @@ public class MessageBusBuilder : IMessageBusBuilder
 
             foreach (var subscriberMapping in _messageConfiguration.SubscriberMappings)
             {
-                services.AddSingleton(subscriberMapping.HandlerType);
+                services.AddScoped(subscriberMapping.HandlerType);
             }
         }
 

--- a/src/AWS.Messaging/Services/HandlerInvoker.cs
+++ b/src/AWS.Messaging/Services/HandlerInvoker.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.Reflection;
 using AWS.Messaging.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace AWS.Messaging.Services;
@@ -34,59 +35,62 @@ public class HandlerInvoker : IHandlerInvoker
     /// <inheritdoc/>
     public async Task<MessageProcessStatus> InvokeAsync(MessageEnvelope messageEnvelope, SubscriberMapping subscriberMapping, CancellationToken token = default)
     {
-        var handler = _serviceProvider.GetService(subscriberMapping.HandlerType);
-
-        if (handler == null)
+        using (var scope = _serviceProvider.CreateScope())
         {
-            _logger.LogError("Unable to resolve a handler for {HandlerType} while handling message ID {MessageEnvelopeId}.", subscriberMapping.HandlerType, messageEnvelope.Id);
-            throw new InvalidMessageHandlerSignatureException($"Unable to resolve a handler for {subscriberMapping.HandlerType} " +
-                                                              $"while handling message ID {messageEnvelope.Id}.");
-        }
+            var handler = scope.ServiceProvider.GetService(subscriberMapping.HandlerType);
 
-        var method = _handlerMethods.GetOrAdd(subscriberMapping.MessageType, x =>
-        {
-            return subscriberMapping.HandlerType.GetMethod(    // Look up the method on the handler type with:
-                nameof(IMessageHandler<MessageProcessStatus>.HandleAsync),              // name "HandleAsync"
-                new Type[] { messageEnvelope.GetType(), typeof(CancellationToken) });   // parameters (MessageEnvelope<MessageType>, CancellationToken)
-        });
-
-        if (method == null)
-        {
-            _logger.LogError("Unable to resolve a compatible HandleAsync method for {HandlerType} while handling message ID {MessageEnvelopeId}.", subscriberMapping.HandlerType, messageEnvelope.Id);
-            throw new InvalidMessageHandlerSignatureException($"Unable to resolve a compatible HandleAsync method for {subscriberMapping.HandlerType} while handling message ID {messageEnvelope.Id}.");
-        }
-
-        try
-        {
-            var task = method.Invoke(handler, new object[] { messageEnvelope, token }) as Task<MessageProcessStatus>;
-
-            if (task == null)
+            if (handler == null)
             {
-                _logger.LogError("Unexpected return type for the HandleAsync method on {HandlerType} while handling message ID {MessageEnvelopeId}. Expected {ExpectedType}", subscriberMapping.HandlerType, messageEnvelope.Id, nameof(Task<MessageProcessStatus>));
-                throw new InvalidMessageHandlerSignatureException($"Unexpected return type for the HandleAsync method on {subscriberMapping.HandlerType} while handling message ID {messageEnvelope.Id}. Expected {nameof(Task<MessageProcessStatus>)}");
+                _logger.LogError("Unable to resolve a handler for {HandlerType} while handling message ID {MessageEnvelopeId}.", subscriberMapping.HandlerType, messageEnvelope.Id);
+                throw new InvalidMessageHandlerSignatureException($"Unable to resolve a handler for {subscriberMapping.HandlerType} " +
+                                                                  $"while handling message ID {messageEnvelope.Id}.");
             }
 
-            return await task;
-        }
-        // Since we are invoking HandleAsync via reflection, we need to unwrap the TargetInvocationException
-        // containing application exceptions that happened inside the IMessageHandler
-        catch (TargetInvocationException ex)
-        {
-            if (ex.InnerException != null)
+            var method = _handlerMethods.GetOrAdd(subscriberMapping.MessageType, x =>
             {
-                _logger.LogError(ex.InnerException, "A handler exception occurred while handling message ID {MessageId}.", messageEnvelope.Id);
-                return MessageProcessStatus.Failed();
+                return subscriberMapping.HandlerType.GetMethod(    // Look up the method on the handler type with:
+                    nameof(IMessageHandler<MessageProcessStatus>.HandleAsync),              // name "HandleAsync"
+                    new Type[] { messageEnvelope.GetType(), typeof(CancellationToken) });   // parameters (MessageEnvelope<MessageType>, CancellationToken)
+            });
+
+            if (method == null)
+            {
+                _logger.LogError("Unable to resolve a compatible HandleAsync method for {HandlerType} while handling message ID {MessageEnvelopeId}.", subscriberMapping.HandlerType, messageEnvelope.Id);
+                throw new InvalidMessageHandlerSignatureException($"Unable to resolve a compatible HandleAsync method for {subscriberMapping.HandlerType} while handling message ID {messageEnvelope.Id}.");
             }
-            else
+
+            try
+            {
+                var task = method.Invoke(handler, new object[] { messageEnvelope, token }) as Task<MessageProcessStatus>;
+
+                if (task == null)
+                {
+                    _logger.LogError("Unexpected return type for the HandleAsync method on {HandlerType} while handling message ID {MessageEnvelopeId}. Expected {ExpectedType}", subscriberMapping.HandlerType, messageEnvelope.Id, nameof(Task<MessageProcessStatus>));
+                    throw new InvalidMessageHandlerSignatureException($"Unexpected return type for the HandleAsync method on {subscriberMapping.HandlerType} while handling message ID {messageEnvelope.Id}. Expected {nameof(Task<MessageProcessStatus>)}");
+                }
+
+                return await task;
+            }
+            // Since we are invoking HandleAsync via reflection, we need to unwrap the TargetInvocationException
+            // containing application exceptions that happened inside the IMessageHandler
+            catch (TargetInvocationException ex)
+            {
+                if (ex.InnerException != null)
+                {
+                    _logger.LogError(ex.InnerException, "A handler exception occurred while handling message ID {MessageId}.", messageEnvelope.Id);
+                    return MessageProcessStatus.Failed();
+                }
+                else
+                {
+                    _logger.LogError(ex, "An unexpected exception occurred while handling message ID {MessageId}.", messageEnvelope.Id);
+                    return MessageProcessStatus.Failed();
+                }
+            }
+            catch (Exception ex)
             {
                 _logger.LogError(ex, "An unexpected exception occurred while handling message ID {MessageId}.", messageEnvelope.Id);
                 return MessageProcessStatus.Failed();
             }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "An unexpected exception occurred while handling message ID {MessageId}.", messageEnvelope.Id);
-            return MessageProcessStatus.Failed();
         }
     }
 }

--- a/test/AWS.Messaging.UnitTests/Models/Models.cs
+++ b/test/AWS.Messaging.UnitTests/Models/Models.cs
@@ -1,7 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Text.Json.Serialization;
+using System;
+using System.Collections.Concurrent;
 
 namespace AWS.Messaging.UnitTests.Models;
 
@@ -30,4 +31,29 @@ public enum Gender
 {
     Male,
     Female
+}
+
+public interface IGreeter
+{
+    string Greet();
+}
+
+public class Greeter : IGreeter
+{
+    public readonly string _message;
+
+    public Greeter()
+    {
+        _message = Guid.NewGuid().ToString();
+    }
+
+    public string Greet()
+    {
+        return _message;
+    }
+}
+
+public class TempStorage<T>
+{
+    public ConcurrentBag<MessageEnvelope<T>> Messages { get; set; } = new ConcurrentBag<MessageEnvelope<T>>();
 }


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-6957, https://github.com/awslabs/aws-dotnet-messaging/issues/46

*Description of changes:*
This PR registers message handlers as scoped dependencies in the service collection.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
