### PR TITLE
test: Add integration tests to exercise the Lambda subscriptions

### DIFF
--- a/AWS.Messaging.sln
+++ b/AWS.Messaging.sln
@@ -31,6 +31,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWS.Messaging.Lambda", "src
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LambdaMessaging", "sampleapps\LambdaMessaging\LambdaMessaging.csproj", "{F74A4CF0-D814-426E-8149-46758E86AFE3}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWS.Messaging.Tests.LambdaFunctions", "test\AWS.Messaging.Tests.LambdaFunctions\AWS.Messaging.Tests.LambdaFunctions.csproj", "{F7A1B9DE-86DE-4F70-A2CD-628E56FE5BAD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -69,6 +71,10 @@ Global
 		{F74A4CF0-D814-426E-8149-46758E86AFE3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F74A4CF0-D814-426E-8149-46758E86AFE3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F74A4CF0-D814-426E-8149-46758E86AFE3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F7A1B9DE-86DE-4F70-A2CD-628E56FE5BAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F7A1B9DE-86DE-4F70-A2CD-628E56FE5BAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F7A1B9DE-86DE-4F70-A2CD-628E56FE5BAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F7A1B9DE-86DE-4F70-A2CD-628E56FE5BAD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -82,6 +88,7 @@ Global
 		{A174942B-AF9C-4935-AD7B-AF651BACE63C} = {80DB2C77-6ADD-4A60-B27D-763BDF9659D3}
 		{24FA3671-8C2B-4B64-865C-68FB6237E34D} = {2D0A561B-0B97-4259-8603-3AF5437BB652}
 		{F74A4CF0-D814-426E-8149-46758E86AFE3} = {1AA8985B-897C-4BD5-9735-FD8B33FEBFFB}
+		{F7A1B9DE-86DE-4F70-A2CD-628E56FE5BAD} = {80DB2C77-6ADD-4A60-B27D-763BDF9659D3}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7B2B759D-6455-4089-8173-3F1619567B36}

--- a/test/AWS.Messaging.IntegrationTests/AWS.Messaging.IntegrationTests.csproj
+++ b/test/AWS.Messaging.IntegrationTests/AWS.Messaging.IntegrationTests.csproj
@@ -4,9 +4,17 @@
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
+
+    <!-- Set this to true to package the Lambda functions used in the integration tests.
+    You may want to set it to false when iterating on test code but not the Lambda code. -->
+    <PackageTestLambdas>true</PackageTestLambdas>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.7.104.72" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.100.128" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.7.109.6" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.104.13" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.101.47" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
@@ -29,5 +37,12 @@
     <ProjectReference Include="..\..\src\AWS.Messaging\AWS.Messaging.csproj" />
     <ProjectReference Include="..\AWS.Messaging.Tests.Common\AWS.Messaging.Tests.Common.csproj" />
   </ItemGroup>
+
+  
+  <Target Name="PackageTestFunction" AfterTargets="AfterBuild" Condition="$(PackageTestLambdas)">
+    <Exec Command="dotnet tool install -g Amazon.Lambda.Tools" IgnoreExitCode="true" />
+    <Exec WorkingDirectory="..\AWS.Messaging.Tests.LambdaFunctions" Command="dotnet restore" />
+    <Exec WorkingDirectory="..\AWS.Messaging.Tests.LambdaFunctions" Command="dotnet lambda package -c Release" />
+  </Target>
 
 </Project>

--- a/test/AWS.Messaging.IntegrationTests/AWS.Messaging.IntegrationTests.csproj
+++ b/test/AWS.Messaging.IntegrationTests/AWS.Messaging.IntegrationTests.csproj
@@ -4,10 +4,6 @@
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
-
-    <!-- Set this to true to package the Lambda functions used in the integration tests.
-    You may want to set it to false when iterating on test code but not the Lambda code. -->
-    <PackageTestLambdas>true</PackageTestLambdas>
   </PropertyGroup>
 
   <ItemGroup>
@@ -37,12 +33,5 @@
     <ProjectReference Include="..\..\src\AWS.Messaging\AWS.Messaging.csproj" />
     <ProjectReference Include="..\AWS.Messaging.Tests.Common\AWS.Messaging.Tests.Common.csproj" />
   </ItemGroup>
-
-  
-  <Target Name="PackageTestFunction" AfterTargets="AfterBuild" Condition="$(PackageTestLambdas)">
-    <Exec Command="dotnet tool install -g Amazon.Lambda.Tools" IgnoreExitCode="true" />
-    <Exec WorkingDirectory="..\AWS.Messaging.Tests.LambdaFunctions" Command="dotnet restore" />
-    <Exec WorkingDirectory="..\AWS.Messaging.Tests.LambdaFunctions" Command="dotnet lambda package -c Release" />
-  </Target>
 
 </Project>

--- a/test/AWS.Messaging.IntegrationTests/LambdaTests.cs
+++ b/test/AWS.Messaging.IntegrationTests/LambdaTests.cs
@@ -1,0 +1,299 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.CloudWatchLogs;
+using Amazon.IdentityManagement;
+using Amazon.IdentityManagement.Model;
+using Amazon.Lambda;
+using Amazon.S3;
+using Amazon.SQS;
+using AWS.Messaging.IntegrationTests.Models;
+using AWS.Messaging.Tests.Common;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace AWS.Messaging.IntegrationTests
+{
+    [CollectionDefinition("LambdaIntegrationTests")]
+    public class LambdaIntegrationTestCollection : ICollectionFixture<LambdaIntegrationTestFixture>
+    {
+        // This class has no code, and is never created. It maps the [CollectionDefinition]
+        // to the ICollectionFixture<> interface.
+        // See https://xunit.net/docs/shared-context#collection-fixture
+    }
+
+    /// <summary>
+    /// Creates AWS resources that will be shared across all Lambda integration tests.
+    /// Currently this is the Lambda execution role and the artifact bucket (with the deployment zip uploaded)
+    /// </summary>
+    public class LambdaIntegrationTestFixture : IAsyncLifetime, IDisposable
+    {
+        public string ExecutionRoleArn { get; set; } = string.Empty;
+
+        public string ArtifactBucketName { get; set; } = string.Empty;
+
+        private const string TestBucketRoot = "mpf-lambda-artifacts-";
+        private const string LambdaExecutionRoleName = "ExecutionRoleForMPFTestLambdas";
+        private const string FunctionPackageName = "AWS.Messaging.Tests.LambdaFunctions";
+
+        private readonly IAmazonIdentityManagementService _iamClient;
+        private readonly IAmazonS3 _s3Client;
+
+        public LambdaIntegrationTestFixture()
+        {
+            _iamClient = new AmazonIdentityManagementServiceClient();
+            _s3Client = new AmazonS3Client();
+        }
+
+        public async Task InitializeAsync()
+        {
+            // Create the execution IAM role for the function
+            ExecutionRoleArn = await AWSUtilities.CreateFunctionRoleIfNotExists(_iamClient, LambdaExecutionRoleName);
+
+            // Create the S3 bucket used to deploy the functions
+            ArtifactBucketName = TestBucketRoot + Guid.NewGuid().ToString();
+            await AWSUtilities.CreateBucketWithDeploymentZipAsync(_s3Client, ArtifactBucketName, FunctionPackageName);
+        }
+
+        public async Task DisposeAsync()
+        {
+            // Delete the S3 bucket
+            await AWSUtilities.DeleteDeploymentZipAndBucketAsync(_s3Client, ArtifactBucketName!);
+
+            // Delete the Lambda execution role, which requires detaching the policy first
+            await _iamClient.DetachRolePolicyAsync(new DetachRolePolicyRequest
+            {
+                RoleName = LambdaExecutionRoleName,
+                PolicyArn = AWSUtilities.LambdaManagedPolicyArn
+            });
+
+            await _iamClient.DeleteRoleAsync(new DeleteRoleRequest { RoleName = LambdaExecutionRoleName });
+        }
+
+        public void Dispose()
+        {
+            return;
+        }
+    }
+
+    /// <summary>
+    /// Tests for a Lambda function that uses the ProcessLambdaEventAsync handler
+    /// </summary>
+    [Collection("LambdaIntegrationTests")]
+    public class LambdaEventTests : IAsyncLifetime
+    {
+        private readonly LambdaIntegrationTestFixture _fixture;
+        private readonly IAmazonLambda _lambdaClient;
+        private readonly IAmazonSQS _sqsClient;
+        private readonly IAmazonCloudWatchLogs _cloudWatchLogsClient;
+        private IMessagePublisher? _publisher;
+
+        private string _queueUrl = "";
+        private string _dlqUrl = "";
+        private string _functionName = "";
+
+        public LambdaEventTests(LambdaIntegrationTestFixture fixture)
+        {
+            _fixture = fixture;
+
+            _lambdaClient = new AmazonLambdaClient();
+            _sqsClient = new AmazonSQSClient();
+            _cloudWatchLogsClient = new AmazonCloudWatchLogsClient();
+        }
+
+        public async Task InitializeAsync()
+        {
+            _functionName = "AWS.Messaging.Tests.LambdaFunctions";
+
+            // Create the function 
+            await AWSUtilities.CreateFunctionAsync(_lambdaClient, _fixture.ArtifactBucketName, _functionName, "LambdaEventHandler", _fixture.ExecutionRoleArn, 3);
+
+            // Create the queue and DLQ and map it to the function
+            (_queueUrl, _dlqUrl) = await AWSUtilities.CreateQueueWithDLQAsync(_sqsClient, 3);
+            await AWSUtilities.CreateQueueLambdaMapping(_sqsClient, _lambdaClient, _functionName, _queueUrl);
+
+            // Create the publisher
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddLogging();
+            serviceCollection.AddAWSMessageBus(builder =>
+            {
+                builder.AddSQSPublisher<SimulatedMessage>(_queueUrl, "SimulatedMessage");
+            });
+
+            _publisher = serviceCollection.BuildServiceProvider().GetRequiredService<IMessagePublisher>();
+        }
+
+        public async Task DisposeAsync()
+        {
+            // Delete the function
+            await AWSUtilities.DeleteFunctionIfExistsAsync(_lambdaClient, _functionName);
+
+            // Delete the queues
+            await _sqsClient.DeleteQueueAsync(_queueUrl);
+            await _sqsClient.DeleteQueueAsync(_dlqUrl);
+        }
+
+        /// <summary>
+        /// Happy path test for successful message
+        /// </summary>
+        [Fact]
+        public async Task ProcessLambdaEventAsync_Success()
+        {
+            var message = new SimulatedMessage
+            {
+                Id = $"test-{Guid.NewGuid()}"
+            };
+
+            var publishTimestamp = DateTime.UtcNow;
+            await _publisher!.PublishAsync(message);
+
+            await Task.Delay(TimeSpan.FromSeconds(10));
+
+            // Assert that the message was processed and logged successfully
+            var logs = await AWSUtilities.GetMostRecentLambdaLogs(_cloudWatchLogsClient, _functionName, publishTimestamp);
+            var logsWithHandler = logs.Where(logEvent => logEvent.Message.Contains("Processed message with Id: "));
+            Assert.Single(logsWithHandler);
+            Assert.Contains($"Processed message with Id: {message.Id}", logsWithHandler.First().Message);
+        }
+
+        /// <summary>
+        /// Tests that a message that the Lambda handler fails for is moved to the DLQ appropriately
+        /// </summary>
+        [Fact]
+        public async Task ProcessLambdaEventAsync_Failure()
+        {
+            var message = new SimulatedMessage
+            {
+                Id = $"test-{Guid.NewGuid()}",
+                ReturnFailedStatus = true
+            };
+
+            var publishTimestamp = DateTime.UtcNow;
+            await _publisher!.PublishAsync(message);
+
+            await Task.Delay(TimeSpan.FromSeconds(10));
+
+            // Assert that the message was not processed, since it's expected to fail
+            var logs = await AWSUtilities.GetMostRecentLambdaLogs(_cloudWatchLogsClient, _functionName, publishTimestamp);
+            var logsWithHandler = logs.Where(logEvent => logEvent.Message.Contains("Processed message with Id: "));
+            Assert.Empty(logsWithHandler);
+
+            // Assert that the message was moved to the DLQ
+            var receiveResponse = await _sqsClient.ReceiveMessageAsync(_dlqUrl);
+            Assert.Single(receiveResponse.Messages);
+            Assert.Contains(message.Id, receiveResponse.Messages[0].Body);
+        }
+    }
+
+    /// <summary>
+    /// Tests for a Lambda function that uses our ProcessLambdaEventWithBatchResponseAsync handler
+    /// </summary>
+    [Collection("LambdaIntegrationTests")]
+    public class LambdaBatchTests : IAsyncLifetime
+    {
+        private readonly LambdaIntegrationTestFixture _fixture;
+        private readonly IAmazonLambda _lambdaClient;
+        private readonly IAmazonSQS _sqsClient;
+        private readonly IAmazonCloudWatchLogs _cloudWatchLogsClient;
+        private IMessagePublisher? _publisher;
+
+        private string _queueUrl = "";
+        private string _dlqUrl = "";
+        private string _functionName = "";
+
+        public LambdaBatchTests(LambdaIntegrationTestFixture fixture)
+        {
+            _fixture = fixture;
+
+            _lambdaClient = new AmazonLambdaClient();
+            _sqsClient = new AmazonSQSClient();
+            _cloudWatchLogsClient = new AmazonCloudWatchLogsClient();
+        }
+
+        public async Task InitializeAsync()
+        {
+            _functionName = "AWS.Messaging.Tests.LambdaFunctions";
+
+            // Create the function 
+            await AWSUtilities.CreateFunctionAsync(_lambdaClient, _fixture.ArtifactBucketName, _functionName, "LambdaEventWithBatchResponseHandler", _fixture.ExecutionRoleArn, 3);
+
+            // Create the queue and DLQ and map it to the function
+            (_queueUrl, _dlqUrl) = await AWSUtilities.CreateQueueWithDLQAsync(_sqsClient, 3);
+            await AWSUtilities.CreateQueueLambdaMapping(_sqsClient, _lambdaClient, _functionName, _queueUrl, true);
+
+            // Create the publisher
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddLogging();
+            serviceCollection.AddAWSMessageBus(builder =>
+            {
+                builder.AddSQSPublisher<SimulatedMessage>(_queueUrl, "SimulatedMessage");
+            });
+
+            _publisher = serviceCollection.BuildServiceProvider().GetRequiredService<IMessagePublisher>();
+        }
+
+        public async Task DisposeAsync()
+        {
+            // Delete the function
+            await AWSUtilities.DeleteFunctionIfExistsAsync(_lambdaClient, _functionName);
+
+            // Delete the queue
+            await _sqsClient.DeleteQueueAsync(_queueUrl);
+            await _sqsClient.DeleteQueueAsync(_dlqUrl);
+        }
+
+        /// <summary>
+        /// Happy path test for successful message
+        /// </summary>
+        [Fact]
+        public async Task ProcessLambdaEventAsync_Success()
+        {
+            var message = new SimulatedMessage
+            {
+                Id = $"test-{Guid.NewGuid()}"
+            };
+
+            var publishTimestamp = DateTime.UtcNow;
+            await _publisher!.PublishAsync(message);
+
+            await Task.Delay(TimeSpan.FromSeconds(10));
+
+            // Assert that the message was processed and logged successfully
+            var logs = await AWSUtilities.GetMostRecentLambdaLogs(_cloudWatchLogsClient, _functionName, publishTimestamp);
+            var logsWithHandler = logs.Where(logEvent => logEvent.Message.Contains("Processed message with Id: "));
+            Assert.Single(logsWithHandler);
+            Assert.Contains($"Processed message with Id: {message.Id}", logsWithHandler.First().Message);
+        }
+
+        /// <summary>
+        /// Tests that a message that the Lambda handler fails for is moved to the DLQ appropriately
+        /// </summary>
+        [Fact]
+        public async Task ProcessLambdaEventAsync_Failure()
+        {
+            var message = new SimulatedMessage
+            {
+                Id = $"test-{Guid.NewGuid()}",
+                ReturnFailedStatus = true
+            };
+
+            var publishTimestamp = DateTime.UtcNow;
+            await _publisher!.PublishAsync(message);
+
+            await Task.Delay(TimeSpan.FromSeconds(10));
+
+            // Assert that the message was not processed, since it's expected to fail
+            var logs = await AWSUtilities.GetMostRecentLambdaLogs(_cloudWatchLogsClient, _functionName, publishTimestamp);
+            var logsWithHandler = logs.Where(logEvent => logEvent.Message.Contains("Processed message with Id: "));
+            Assert.Empty(logsWithHandler);
+
+            // Assert that the message was moved to the DLQ
+            var receiveResponse = await _sqsClient.ReceiveMessageAsync(_dlqUrl);
+            Assert.Single(receiveResponse.Messages);
+            Assert.Contains(message.Id, receiveResponse.Messages[0].Body);
+        }
+    }
+}

--- a/test/AWS.Messaging.IntegrationTests/Models/SimulatedMessage.cs
+++ b/test/AWS.Messaging.IntegrationTests/Models/SimulatedMessage.cs
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+
+namespace AWS.Messaging.IntegrationTests.Models
+{
+    public class SimulatedMessage
+    {
+        public string? Id { get; set; }
+
+        public bool ReturnFailedStatus { get; set; } = false;
+
+        public TimeSpan WaitTime { get; set; }
+    }
+}

--- a/test/AWS.Messaging.Tests.Common/AWS.Messaging.Tests.Common.csproj
+++ b/test/AWS.Messaging.Tests.Common/AWS.Messaging.Tests.Common.csproj
@@ -7,6 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.7.104.72" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.100.128" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.7.109.6" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.104.13" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.101.47" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.110" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />

--- a/test/AWS.Messaging.Tests.Common/AWSUtilities.cs
+++ b/test/AWS.Messaging.Tests.Common/AWSUtilities.cs
@@ -1,0 +1,371 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.IdentityManagement;
+using Amazon.IdentityManagement.Model;
+using Amazon.S3.Model;
+using Amazon.S3;
+using Amazon.Lambda.Model;
+using Amazon.Lambda;
+using Amazon.SQS;
+using Amazon.CloudWatchLogs.Model;
+using Amazon.CloudWatchLogs;
+using Amazon.SQS.Model;
+
+namespace AWS.Messaging.Tests.Common;
+
+/// <summary>
+/// Utilities to create AWS resources for integration tests
+/// </summary>
+public static class AWSUtilities
+{
+    public const string LambdaManagedPolicyArn = "arn:aws:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole";
+    private static readonly string LambdaAssumeRolePolicy =
+    @"
+        {
+          ""Version"": ""2012-10-17"",
+          ""Statement"": [
+            {
+              ""Effect"": ""Allow"",
+              ""Principal"": {
+                ""Service"": ""lambda.amazonaws.com""
+              },
+              ""Action"": ""sts:AssumeRole""
+            }
+          ]
+        }
+        ".Trim();
+
+    /// <summary>
+    /// Creates a Lambda execution role if it doesn't already exist, using the AWS-provided AWSLambdaSQSQueueExecutionRole
+    /// </summary>
+    /// <param name="iamClient">IAM Client</param>
+    /// <param name="roleName">Desired name of the role</param>
+    /// <returns>Role ARN</returns>
+    public static async Task<string> CreateFunctionRoleIfNotExists(IAmazonIdentityManagementService iamClient, string roleName)
+    {
+        var getRoleRequest = new GetRoleRequest
+        {
+            RoleName = roleName
+        };
+        try
+        {
+            return (await iamClient.GetRoleAsync(getRoleRequest)).Role.Arn;
+        }
+        catch (NoSuchEntityException)
+        {
+            // create the role
+            var createRoleRequest = new CreateRoleRequest
+            {
+                RoleName = roleName,
+                Description = "Execution role for Lambda functions for testing the .NET message processing framework",
+                AssumeRolePolicyDocument = LambdaAssumeRolePolicy
+            };
+
+            var executionRoleArn = (await iamClient.CreateRoleAsync(createRoleRequest)).Role.Arn;
+
+            // Wait for role to propagate.
+            await Task.Delay(10000);
+
+            await iamClient.AttachRolePolicyAsync(new AttachRolePolicyRequest
+            {
+                RoleName = roleName,
+                PolicyArn = LambdaManagedPolicyArn
+            });
+
+            return executionRoleArn;
+        }
+    }
+
+    /// <summary>
+    /// Creates an S3 bucket to hold the Lambda deployment artifact(s), and uploads the specified deployment zip
+    /// </summary>
+    /// <param name="s3Client">S3 Client</param>
+    /// <param name="bucketName">Desired name of the bucket</param>
+    /// <param name="functionName">Name of the Lambda deployment artifact elsewhere in this test suite</param>
+    public async static Task CreateBucketWithDeploymentZipAsync(IAmazonS3 s3Client, string bucketName, string functionName)
+    {
+        // Create bucket if it doesn't exist
+        var listBucketsResponse = await s3Client.ListBucketsAsync();
+        if (listBucketsResponse.Buckets.Find((bucket) => bucket.BucketName == bucketName) == null)
+        {
+            var putBucketRequest = new PutBucketRequest
+            {
+                BucketName = bucketName
+            };
+            await s3Client.PutBucketAsync(putBucketRequest);
+            await Task.Delay(10000);
+        }
+
+        // Write or overwrite deployment package
+        var putObjectRequest = new PutObjectRequest
+        {
+            BucketName = bucketName,
+            Key = $"{functionName}.zip",
+            FilePath = TestUtilities.GetDeploymentZipPath(functionName)
+        };
+
+        await s3Client.PutObjectAsync(putObjectRequest);
+    }
+
+    /// <summary>
+    /// Deletes an S3 bucket and all objects in it
+    /// </summary>
+    /// <param name="s3Client">S3 Client</param>
+    /// <param name="bucketName">Name of the bucket to delete</param>
+    public static async Task DeleteDeploymentZipAndBucketAsync(IAmazonS3 s3Client, string bucketName)
+    {
+        try
+        {
+            await Amazon.S3.Util.AmazonS3Util.DeleteS3BucketWithObjectsAsync(s3Client, bucketName);
+        }
+        catch (AmazonS3Exception e)
+        {
+            // If it's just telling us the bucket's not there then continue, otherwise throw.
+            if (!e.Message.Contains("The specified bucket does not exist"))
+            {
+                throw;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates a Lambda function
+    /// </summary>
+    /// <param name="lambdaClient">Lambda client</param>
+    /// <param name="bucketName">S3 bucket containing the deployment artifact</param>
+    /// <param name="functionName">Function name, which will be used to name the function as well as match the deployment artifact and handler</param>
+    /// <param name="handlerName">Name of the actual handler function within the deployment artifact</param>
+    /// <param name="executionRoleArn">Lambda execution role to assign</param>
+    /// <param name="functionTimeout">Desired function timeout, in seconds</param>
+    public static async Task CreateFunctionAsync(IAmazonLambda lambdaClient, string bucketName, string functionName, string handlerName, string executionRoleArn, int functionTimeout)
+    {
+        await DeleteFunctionIfExistsAsync(lambdaClient, functionName);
+
+        var createRequest = new CreateFunctionRequest
+        {
+            FunctionName = functionName.Replace(".", ""),
+            Code = new FunctionCode
+            {
+                S3Bucket = bucketName,
+                S3Key = $"{functionName}.zip"
+            },
+            Handler = $"{functionName}::{functionName}.Functions::{handlerName}",
+            MemorySize = 512,
+            Timeout = functionTimeout,
+            Runtime = Runtime.Dotnet6,
+            Role = executionRoleArn,
+        };
+
+        var startTime = DateTime.Now;
+        var created = false;
+        while (DateTime.Now < startTime.AddSeconds(30))
+        {
+            try
+            {
+                await lambdaClient.CreateFunctionAsync(createRequest);
+                created = true;
+                break;
+            }
+            catch (InvalidParameterValueException ipve)
+            {
+                // Wait for the role to be fully propagated through AWS
+                if (ipve.Message == "The role defined for the function cannot be assumed by Lambda.")
+                {
+                    await Task.Delay(2000);
+                }
+                else
+                {
+                    throw;
+                }
+            }
+        }
+        await Task.Delay(5000);
+
+        if (!created)
+        {
+            throw new Exception($"Timed out trying to create Lambda function {functionName}");
+        }
+    }
+
+    /// <summary>
+    /// Deletes a Lambda function if it already exists. Removes any event source mappings first.
+    /// </summary>
+    /// <param name="lambdaClient">Lambda client</param>
+    /// <param name="functionName">Name of the function to delete</param>
+    public static async Task DeleteFunctionIfExistsAsync(IAmazonLambda lambdaClient, string functionName)
+    {
+        // First remove any event source mappings from the function (if it is recreated with the same name these will reappear)
+        var eventSourceMappingsPaginator = lambdaClient.Paginators.ListEventSourceMappings(new ListEventSourceMappingsRequest
+        {
+            FunctionName = functionName.Replace(".", "")
+        });
+
+        await foreach (var mapping in eventSourceMappingsPaginator.EventSourceMappings)
+        {
+            if (mapping.State != "Deleting")
+            {
+                await lambdaClient.DeleteEventSourceMappingAsync(new DeleteEventSourceMappingRequest
+                {
+                    UUID = mapping.UUID
+                });
+            }
+        }
+
+        var request = new DeleteFunctionRequest
+        {
+            FunctionName = functionName.Replace(".", "")
+        };
+
+        try
+        {
+            var response = await lambdaClient.DeleteFunctionAsync(request);
+        }
+        catch (Amazon.Lambda.Model.ResourceNotFoundException)
+        {
+            // no problem
+        }
+    }
+
+    /// <summary>
+    /// Creates an SQS queue
+    /// </summary>
+    /// <param name="sqsClient">SQS Client</param>
+    /// <param name="queueName">Desired name of the queue</param>
+    /// <param name="messageVisiblityTimeout">The queue's default message visibility timeout, in seconds</param>
+    /// <returns>Queue URL</returns>
+    public static async Task<string> CreateQueueAsync(IAmazonSQS sqsClient, string? queueName, int messageVisiblityTimeout = 30)
+    {
+        if (string.IsNullOrEmpty(queueName))
+        {
+            queueName = $"MPFTest-{Guid.NewGuid().ToString().Split('-').Last()}";
+        }
+        var createQueueResponse = await sqsClient.CreateQueueAsync(new CreateQueueRequest {
+            QueueName = queueName,
+            Attributes = new Dictionary<string, string>()
+            {
+                { QueueAttributeName.VisibilityTimeout, messageVisiblityTimeout.ToString() }
+            }
+        });
+
+        return createQueueResponse.QueueUrl;
+    }
+
+    /// <summary>
+    /// Creates an SQS Queue with a dead-letter queue
+    /// </summary>
+    /// <param name="sqsClient">SQS Client</param>
+    /// <param name="messageVisiblityTimeout">The queue's default message visibility timeout, in seconds</param>
+    /// <returns>Tuple consisting of the queue URL followed by the DLQ URL</returns>
+    public static async Task<(string, string)> CreateQueueWithDLQAsync(IAmazonSQS sqsClient, int messageVisiblityTimeout = 30)
+    {
+        // Create both queues
+        var queueName = $"MPFTest-{Guid.NewGuid().ToString().Split('-').Last()}";
+        var sourceQueueUrl = await CreateQueueAsync(sqsClient, queueName, messageVisiblityTimeout);
+        var dlqUrl = await CreateQueueAsync(sqsClient, queueName + "-DLQ", messageVisiblityTimeout);
+
+        // Get the DLQ's arn
+        var dlqAttributes = await sqsClient.GetQueueAttributesAsync(dlqUrl, new List<string> { "QueueArn" });
+
+        // Set the DLQ as the DLQ for the source queue
+        var request = new SetQueueAttributesRequest
+        {
+            QueueUrl = sourceQueueUrl,
+            Attributes = new Dictionary<string, string>
+            {
+                { QueueAttributeName.RedrivePolicy, $"{{ \"maxReceiveCount\": \"1\", \"deadLetterTargetArn\": \"{dlqAttributes.QueueARN}\"}}" }
+            }
+        };
+
+        await sqsClient.SetQueueAttributesAsync(request);
+
+        return (sourceQueueUrl, dlqUrl);
+    }
+
+    /// <summary>
+    /// Returns a list of the most recent log events for a Lambda function
+    /// </summary>
+    /// <param name="cloudWatchLogsClient">CloudWatch Logs client</param>
+    /// <param name="lambdaName">Name of the Lambda function whose logs to request</param>
+    /// <param name="publishTimestamp">Only logs after this timestamp will be returned</param>
+    /// <returns>List of log events</returns>
+    public static async Task<List<OutputLogEvent>> GetMostRecentLambdaLogs(IAmazonCloudWatchLogs cloudWatchLogsClient, string lambdaName, DateTime publishTimestamp)
+    {
+        var logGroupName = $"/aws/lambda/{lambdaName.Replace(".", "")}";
+
+        // Get the most recent log stream
+        var logStreamsResponse = await cloudWatchLogsClient.DescribeLogStreamsAsync(new DescribeLogStreamsRequest
+        {
+            LogGroupName = logGroupName,
+            OrderBy = OrderBy.LastEventTime,
+            Descending = true
+        });
+
+        if (logStreamsResponse.LogStreams.Count == 0)
+        {
+            throw new Exception($"Expected at least one log stream for {logGroupName} to assert against.");
+        }
+
+        var logs = new List<OutputLogEvent>();
+
+        var getLogsRequest = new GetLogEventsRequest()
+        {
+            LogGroupName = logGroupName,
+            LogStreamName = logStreamsResponse.LogStreams[0].LogStreamName,
+            StartTime = publishTimestamp
+        };
+
+        // Do the pagination manually since the generated paginator will keep looping
+        // indefinitely in case more logs become available.
+        do
+        {
+            var getLogsResponse = await cloudWatchLogsClient.GetLogEventsAsync(getLogsRequest);
+
+            logs.AddRange(getLogsResponse.Events);
+
+            // Stop looping once the NextToken repeats, which mean we've read all of the current logs
+            if (getLogsResponse.NextForwardToken == getLogsRequest.NextToken)
+            {
+                break;
+            }
+
+            getLogsRequest.NextToken = getLogsResponse.NextForwardToken;
+
+        } while (true);
+
+        return logs;
+    }
+
+    /// <summary>
+    /// Creates the mapping between an SQS queue and a Lambda function
+    /// </summary>
+    /// <param name="sqsClient">SQS Client</param>
+    /// <param name="lambdaClient">Lambda client</param>
+    /// <param name="functionName">Name of the Lambda function to map</param>
+    /// <param name="queueUrl">Name of the SQS queue to map</param>
+    /// <param name="reportBatchItemFailures">Set to true to activate ReportBatchItemFailures</param>
+    public static async Task CreateQueueLambdaMapping(IAmazonSQS sqsClient, IAmazonLambda lambdaClient, string functionName, string queueUrl, bool reportBatchItemFailures = false)
+    {
+        var queueArn = (await sqsClient.GetQueueAttributesAsync(queueUrl, new List<string> { "All" })).QueueARN;
+
+        var request = new CreateEventSourceMappingRequest()
+        {
+            FunctionName = functionName.Replace(".", ""),
+            EventSourceArn = queueArn,
+        };
+
+        if (reportBatchItemFailures)
+        {
+            request.FunctionResponseTypes = new List<string> { "ReportBatchItemFailures" };
+        }
+
+        var response = await lambdaClient.CreateEventSourceMappingAsync(request);
+
+        await TestUtilities.WaitUntilAsync(async () =>
+        {
+            var state = (await lambdaClient.GetEventSourceMappingAsync(new GetEventSourceMappingRequest { UUID = response.UUID })).State;
+            return state == "Enabled";
+
+        });
+    }
+}

--- a/test/AWS.Messaging.Tests.Common/TestUtilities.cs
+++ b/test/AWS.Messaging.Tests.Common/TestUtilities.cs
@@ -1,0 +1,85 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Tests.Common;
+
+public class TestUtilities
+{
+    /// <summary>
+    /// Recursively searchs upward from the specified path until the target file or directory is found
+    /// </summary>
+    /// <param name="path">Current location</param>
+    /// <param name="fileOrDirectoryName">Name of a file or directory that is a parent of <see cref="path"/> to search for</param>
+    /// <returns>The path of the target destination if it is found and exists, or else an empty string if it wasn't found</returns>
+    public static string FindParentDirectoryWithName(string path, string fileOrDirectoryName)
+    {
+        var fullPath = Path.Combine(path, fileOrDirectoryName);
+        if (File.Exists(fullPath) || Directory.Exists(fullPath))
+        {
+            return fullPath;
+        }
+        else
+        {
+            var parentDirectory = Path.GetDirectoryName(path);
+            if (string.IsNullOrEmpty(parentDirectory))
+            {
+                return string.Empty;
+            }
+            else
+            {
+                return FindParentDirectoryWithName(parentDirectory, fileOrDirectoryName);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Get the path of the deployment package for testing the custom runtime.
+    /// This assumes that the 'dotnet lambda package -c Release' command was run as part of the pre-build of this csproj.
+    /// </summary>
+    /// <returns></returns>
+    public static string GetDeploymentZipPath(string functionName)
+    {
+        var testsProjectDirectory = FindParentDirectoryWithName(Environment.CurrentDirectory, "test");
+        if (string.IsNullOrEmpty(testsProjectDirectory))
+        {
+            throw new Exception("No deployment package zip found");
+        }
+
+        var deploymentZipFile = Path.Combine(testsProjectDirectory, $"{functionName}\\bin\\Release\\net6.0\\{functionName}.zip".Replace('\\', Path.DirectorySeparatorChar));
+
+        if (!File.Exists(deploymentZipFile))
+        {
+            throw new Exception("No deployment package zip found");
+        }
+
+        return deploymentZipFile;
+    }
+
+    /// <summary>
+    /// Waits until a provided function returns true, up to a maximum time limit.
+    /// </summary>
+    /// <param name="matchFunction">Function to wait for returning true</param>
+    /// <param name="sleepSeconds">How many seconds to delay between invocations of matchFunction</param>
+    /// <param name="maxWaitSeconds">Maximum number of seconds to wait for matchFunction to return true</param>
+    /// <param name="failIfNotCompleted">If true, throws an exception if maxWaitSeconds is reached. Otherwise returns.</param>
+    public static async Task WaitUntilAsync(Func<Task<bool>> matchFunction, int sleepSeconds = 5, int maxWaitSeconds = 300, bool failIfNotCompleted = true)
+    {
+        if (sleepSeconds < 0) throw new ArgumentOutOfRangeException("sleepSeconds");
+        if (maxWaitSeconds < 0) throw new ArgumentOutOfRangeException("maxWaitSeconds");
+
+        var sleepTime = TimeSpan.FromSeconds(sleepSeconds);
+        var maxTime = TimeSpan.FromSeconds(maxWaitSeconds);
+        var endTime = DateTime.Now + maxTime;
+
+        while (DateTime.Now < endTime)
+        {
+            if (await matchFunction())
+                return;
+
+            await Task.Delay(sleepTime);
+        }
+
+        if (failIfNotCompleted)
+            throw new TimeoutException(string.Format("Wait condition was not satisfied for {0} seconds", maxWaitSeconds));
+    }
+}

--- a/test/AWS.Messaging.Tests.LambdaFunctions/AWS.Messaging.Tests.LambdaFunctions.csproj
+++ b/test/AWS.Messaging.Tests.LambdaFunctions/AWS.Messaging.Tests.LambdaFunctions.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AWSProjectType>Lambda</AWSProjectType>
+    <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!-- Generate ready to run images during publishing to improve cold start time. -->
+    <PublishReadyToRun>true</PublishReadyToRun>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.1" />
+    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AWS.Messaging.Lambda\AWS.Messaging.Lambda.csproj" />
+    <ProjectReference Include="..\..\src\AWS.Messaging\AWS.Messaging.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/AWS.Messaging.Tests.LambdaFunctions/Functions.cs
+++ b/test/AWS.Messaging.Tests.LambdaFunctions/Functions.cs
@@ -1,0 +1,98 @@
+using Amazon.Lambda.Core;
+using Amazon.Lambda.SQSEvents;
+using AWS.Messaging.Lambda;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace AWS.Messaging.Tests.LambdaFunctions;
+
+public class Functions
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    /// <summary>
+    /// Default constructor. This constructor is used by Lambda to construct the instance. When invoked in a Lambda environment
+    /// the AWS credentials will come from the IAM role associated with the function and the AWS region will be set to the
+    /// region the Lambda function is executed in.
+    /// </summary>
+    public Functions()
+    {
+        var serviceCollection = new ServiceCollection();
+
+        serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddMessageHandler<SimulatedMessageHandler, SimulatedMessage>("SimulatedMessage");
+
+            builder.AddLambdaMessageProcessor();
+        });
+
+        serviceCollection.AddLogging(builder =>
+        {
+            builder.AddConsole();
+            builder.SetMinimumLevel(Microsoft.Extensions.Logging.LogLevel.Trace);
+         });
+
+        _serviceProvider = serviceCollection.BuildServiceProvider();
+    }
+
+
+    /// <summary>
+    /// This method is called for every Lambda invocation. This method takes in an SQS event object and can be used 
+    /// to respond to SQS messages.
+    /// </summary>
+    /// <param name="evnt"></param>
+    /// <param name="context"></param>
+    /// <returns></returns>
+    public async Task LambdaEventHandler(SQSEvent evnt, ILambdaContext context)
+    {
+        var messaging = _serviceProvider.GetRequiredService<ILambdaMessaging>();
+
+        await messaging.ProcessLambdaEventAsync(evnt, context);
+    }
+
+    /// <summary>
+    /// This method is called for every Lambda invocation. This method takes in an SQS event object and can be used 
+    /// to respond to SQS messages.
+    /// </summary>
+    /// <param name="evnt"></param>
+    /// <param name="context"></param>
+    /// <returns></returns>
+    public async Task<SQSBatchResponse> LambdaEventWithBatchResponseHandler(SQSEvent evnt, ILambdaContext context)
+    {
+        var messaging = _serviceProvider.GetRequiredService<ILambdaMessaging>();
+
+        return await messaging.ProcessLambdaEventWithBatchResponseAsync(evnt, context);
+    }
+}
+
+public class SimulatedMessage
+{
+    public string? Id { get; set; }
+
+    public bool ReturnFailedStatus { get; set; } = false;
+
+    public TimeSpan WaitTime { get; set; } = TimeSpan.Zero;
+}
+
+public class SimulatedMessageHandler : IMessageHandler<SimulatedMessage>
+{
+    public async Task<MessageProcessStatus> HandleAsync(MessageEnvelope<SimulatedMessage> messageEnvelope, CancellationToken token = default)
+    {
+        // Wait for the delay specified in the message
+        await Task.Delay(messageEnvelope.Message.WaitTime, token);
+
+        if (messageEnvelope.Message.ReturnFailedStatus)
+        {
+            return MessageProcessStatus.Failed();
+        }
+
+        // Log the received message's ID to the Lambda's logs, the test will assert via CloudWatchLogs
+        LambdaLogger.Log($"Processed message with Id: {messageEnvelope.Message.Id}");
+
+        return MessageProcessStatus.Success();
+    }
+}

--- a/test/AWS.Messaging.Tests.LambdaFunctions/Properties/launchSettings.json
+++ b/test/AWS.Messaging.Tests.LambdaFunctions/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "Mock Lambda Test Tool": {
+      "commandName": "Executable",
+      "commandLineArgs": "--port 5050",
+      "workingDirectory": ".\\bin\\$(Configuration)\\net6.0",
+      "executablePath": "%USERPROFILE%\\.dotnet\\tools\\dotnet-lambda-test-tool-6.0.exe"
+    }
+  }
+}


### PR DESCRIPTION
*Issue #, if available:* DOTNET-6922

*Description of changes:* Adds integration tests that create actual SQS queues mapped to Lambda functions.

The technique here was lifted from https://github.com/aws/aws-lambda-dotnet/tree/master/Libraries/test/Amazon.Lambda.RuntimeSupport.Tests/Amazon.Lambda.RuntimeSupport.IntegrationTests, where we're packaging the Lambda code via an msbuild target, and then deploying it during the test setup.

The majority of this is the scaffolding, right now the tests are just testing etiher a single successful or single failing message against `ProcessLambdaEventAsync` and  `ProcessLambdaEventWithBatchResponseAsync`. But it's easier to iterate on tests now that the setup is in place, so open to feedback!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
