### PR TITLE
chore: Use same message identifiers across sample applications

### DIFF
--- a/sampleapps/LambdaMessaging/Startup.cs
+++ b/sampleapps/LambdaMessaging/Startup.cs
@@ -16,7 +16,7 @@ public class Startup
         });
         services.AddAWSMessageBus(builder =>
         {
-            builder.AddMessageHandler<ChatMessageHandler, ChatMessage>();
+            builder.AddMessageHandler<ChatMessageHandler, ChatMessage>("chatMessage");
 
             builder.AddLambdaMessageProcessor(options =>
             {

--- a/sampleapps/PublisherAPI/Program.cs
+++ b/sampleapps/PublisherAPI/Program.cs
@@ -14,9 +14,9 @@ builder.Services.AddAWSMessageBus(bus =>
     // To load the configuration from appsettings.json instead of the code below, uncomment this and remove the following lines.
     // bus.LoadConfigurationFromSettings(builder.Configuration);
 
-    bus.AddSQSPublisher<ChatMessage>("https://sqs.us-west-2.amazonaws.com/012345678910/MPF");
-    bus.AddSNSPublisher<OrderInfo>("arn:aws:sns:us-west-2:012345678910:MPF");
-    bus.AddEventBridgePublisher<FoodItem>("arn:aws:events:us-west-2:012345678910:event-bus/default");
+    bus.AddSQSPublisher<ChatMessage>("https://sqs.us-west-2.amazonaws.com/012345678910/MPF", "chatMessage");
+    bus.AddSNSPublisher<OrderInfo>("arn:aws:sns:us-west-2:012345678910:MPF", "orderInfo");
+    bus.AddEventBridgePublisher<FoodItem>("arn:aws:events:us-west-2:012345678910:event-bus/default", "foodItem");
     bus.ConfigureSerializationOptions(options =>
     {
         options.SystemTextJsonOptions = new JsonSerializerOptions

--- a/sampleapps/PublisherAPI/appsettings.json
+++ b/sampleapps/PublisherAPI/appsettings.json
@@ -11,21 +11,21 @@
             {
                 "MessageType": "PublisherAPI.Models.ChatMessage",
                 "QueueUrl": "https://sqs.us-west-2.amazonaws.com/012345678910/MPF",
-                "MessageTypeIdentifier": "chatmessage"
+                "MessageTypeIdentifier": "chatMessage"
             }
         ],
         "SNSPublishers": [
             {
                 "MessageType": "PublisherAPI.Models.OrderInfo",
                 "TopicUrl": "arn:aws:sns:us-west-2:012345678910:MPF",
-                "MessageTypeIdentifier": "orderinfo"
+                "MessageTypeIdentifier": "orderInfo"
             }
         ],
         "EventBridgePublishers": [
             {
                 "MessageType": "PublisherAPI.Models.FoodItem",
                 "EventBusName": "arn:aws:events:us-west-2:012345678910:event-bus/default",
-                "MessageTypeIdentifier": "orderinfo",
+                "MessageTypeIdentifier": "foodItem",
                 "Options": {
                     "EndpointID": "default"
                 }

--- a/sampleapps/SubscriberService/Program.cs
+++ b/sampleapps/SubscriberService/Program.cs
@@ -1,10 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Text.Json;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using SubscriberService.MessageHandlers;
 using SubscriberService.Models;
 
@@ -26,7 +28,15 @@ await Host.CreateDefaultBuilder(args)
             // builder.LoadConfigurationFromSettings(context.Configuration);
 
             builder.AddSQSPoller("https://sqs.us-west-2.amazonaws.com/012345678910/MPF");
-            builder.AddMessageHandler<ChatMessageHandler, ChatMessage>();
+            builder.AddMessageHandler<ChatMessageHandler, ChatMessage>("chatMessage");
+
+            builder.ConfigureSerializationOptions(options =>
+            {
+                options.SystemTextJsonOptions = new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                };
+            });
         });
     })
     .Build()

--- a/sampleapps/SubscriberService/appsettings.json
+++ b/sampleapps/SubscriberService/appsettings.json
@@ -10,7 +10,8 @@
         "MessageHandlers": [
             {
                 "HandlerType": "SubscriberService.MessageHandlers.ChatMessageHandler",
-                "MessageType": "SubscriberService.Models.ChatMessage"
+                "MessageType": "SubscriberService.Models.ChatMessage",
+                "MessageTypeIdentifier": "chatMessage"
             }
         ],
         "SQSPollers": [


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Currently the sample applications all define their own message POCOs, and do not use message identifiers so the framework is using the namespace and class names. These do not match across the sample applications, so the subscribers fail to deserialize the messages from the publishers.

This adds message identifiers so the sample applications work out of the box once you plug in your own queue URLs.

Alternatively we can move the message POCOs to a "SharedModels" assembly, let me know if you'd rather see that.

I also added the same JSON options to the subscriber that we're using on the publisher.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
