### PR TITLE
chore: Throw an exception when a message group ID is not specified while publishing to FIFO queues/topics

### DIFF
--- a/sampleapps/PublisherAPI/Models/BidInfo.cs
+++ b/sampleapps/PublisherAPI/Models/BidInfo.cs
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace PublisherAPI.Models;
+
+public class BidInfo
+{
+    public string BidId { get; set; } = string.Empty;
+}

--- a/sampleapps/PublisherAPI/Models/TransactionInfo.cs
+++ b/sampleapps/PublisherAPI/Models/TransactionInfo.cs
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace PublisherAPI.Models;
+
+public class TransactionInfo
+{
+    public string TransactionId { get; set; } = string.Empty;
+}

--- a/sampleapps/PublisherAPI/Program.cs
+++ b/sampleapps/PublisherAPI/Program.cs
@@ -17,6 +17,11 @@ builder.Services.AddAWSMessageBus(bus =>
     bus.AddSQSPublisher<ChatMessage>("https://sqs.us-west-2.amazonaws.com/012345678910/MPF", "chatMessage");
     bus.AddSNSPublisher<OrderInfo>("arn:aws:sns:us-west-2:012345678910:MPF", "orderInfo");
     bus.AddEventBridgePublisher<FoodItem>("arn:aws:events:us-west-2:012345678910:event-bus/default", "foodItem");
+
+    // FIFO endpoints
+    bus.AddSQSPublisher<TransactionInfo>("https://sqs.us-west-2.amazonaws.com/012345678910/MPF.fifo", "transactionInfo");
+    bus.AddSNSPublisher<BidInfo>("arn:aws:sns:us-west-2:012345678910:MPF.fifo", "bidInfo");
+
     bus.ConfigureSerializationOptions(options =>
     {
         options.SystemTextJsonOptions = new JsonSerializerOptions

--- a/sampleapps/PublisherAPI/appsettings.json
+++ b/sampleapps/PublisherAPI/appsettings.json
@@ -12,6 +12,11 @@
                 "MessageType": "PublisherAPI.Models.ChatMessage",
                 "QueueUrl": "https://sqs.us-west-2.amazonaws.com/012345678910/MPF",
                 "MessageTypeIdentifier": "chatMessage"
+            },
+            {
+                "MessageType": "PublisherAPI.Models.TransactionInfo",
+                "QueueUrl": "https://sqs.us-west-2.amazonaws.com/012345678910/MPF.fifo",
+                "MessageTypeIdentifier": "transactionInfo"
             }
         ],
         "SNSPublishers": [
@@ -19,6 +24,11 @@
                 "MessageType": "PublisherAPI.Models.OrderInfo",
                 "TopicUrl": "arn:aws:sns:us-west-2:012345678910:MPF",
                 "MessageTypeIdentifier": "orderInfo"
+            },
+            {
+                "MessageType": "PublisherAPI.Models.BidInfo",
+                "TopicUrl": "arn:aws:sns:us-west-2:012345678910:MPF.fifo",
+                "MessageTypeIdentifier": "bidInfo"
             }
         ],
         "EventBridgePublishers": [

--- a/src/AWS.Messaging/Exceptions.cs
+++ b/src/AWS.Messaging/Exceptions.cs
@@ -238,3 +238,14 @@ public class InvalidSQSQueueArnException : AWSMessagingException
     /// </summary>
     public InvalidSQSQueueArnException(string message, Exception? innerException = null) : base(message, innerException) { }
 }
+
+/// <summary>
+/// Thrown when the publish request to a FIFO endpoint is invalid.
+/// </summary>
+public class InvalidFifoPublishingRequestException : AWSMessagingException
+{
+    /// <summary>
+    /// Creates an instance of <see cref="InvalidFifoPublishingRequestException"/>.
+    /// </summary>
+    public InvalidFifoPublishingRequestException(string message, Exception? innerException = null) : base(message, innerException) { }
+}


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7234

*Description of changes:*
This PR throws an exception when a message group ID is not specified while publishing to FIFO queues/topics.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
