### PR TITLE
feat: Add OpenTelemetry Instrumentation Provider

### DIFF
--- a/AWS.Messaging.sln
+++ b/AWS.Messaging.sln
@@ -31,6 +31,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWS.Messaging.Lambda", "src
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LambdaMessaging", "sampleapps\LambdaMessaging\LambdaMessaging.csproj", "{F74A4CF0-D814-426E-8149-46758E86AFE3}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWS.Messaging.Telemetry.OpenTelemetry", "src\AWS.Messaging.Telemetry.OpenTelemetry\AWS.Messaging.Telemetry.OpenTelemetry.csproj", "{C529DC6E-72DA-49ED-908A-21DBC40F26C0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -69,6 +71,10 @@ Global
 		{F74A4CF0-D814-426E-8149-46758E86AFE3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F74A4CF0-D814-426E-8149-46758E86AFE3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F74A4CF0-D814-426E-8149-46758E86AFE3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C529DC6E-72DA-49ED-908A-21DBC40F26C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C529DC6E-72DA-49ED-908A-21DBC40F26C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C529DC6E-72DA-49ED-908A-21DBC40F26C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C529DC6E-72DA-49ED-908A-21DBC40F26C0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -82,6 +88,7 @@ Global
 		{A174942B-AF9C-4935-AD7B-AF651BACE63C} = {80DB2C77-6ADD-4A60-B27D-763BDF9659D3}
 		{24FA3671-8C2B-4B64-865C-68FB6237E34D} = {2D0A561B-0B97-4259-8603-3AF5437BB652}
 		{F74A4CF0-D814-426E-8149-46758E86AFE3} = {1AA8985B-897C-4BD5-9735-FD8B33FEBFFB}
+		{C529DC6E-72DA-49ED-908A-21DBC40F26C0} = {2D0A561B-0B97-4259-8603-3AF5437BB652}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7B2B759D-6455-4089-8173-3F1619567B36}

--- a/sampleapps/PublisherAPI/Program.cs
+++ b/sampleapps/PublisherAPI/Program.cs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Text.Json;
+using AWS.Messaging.Telemetry.OpenTelemetry;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
 using PublisherAPI.Models;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -33,6 +36,11 @@ builder.Services.AddAWSMessageBus(bus =>
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(resource => resource.AddService("PublisherAPI"))
+    .WithTracing(tracing => tracing
+        .AddAWSMessagingInstrumentation()
+        .AddConsoleExporter());
 
 var app = builder.Build();
 

--- a/sampleapps/PublisherAPI/PublisherAPI.csproj
+++ b/sampleapps/PublisherAPI/PublisherAPI.csproj
@@ -7,10 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\AWS.Messaging.Telemetry.OpenTelemetry\AWS.Messaging.Telemetry.OpenTelemetry.csproj" />
     <ProjectReference Include="..\..\src\AWS.Messaging\AWS.Messaging.csproj" />
   </ItemGroup>
 

--- a/sampleapps/SubscriberService/Program.cs
+++ b/sampleapps/SubscriberService/Program.cs
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Text.Json;
+using AWS.Messaging.Telemetry.OpenTelemetry;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
 using SubscriberService.MessageHandlers;
 using SubscriberService.Models;
 
@@ -37,7 +39,12 @@ await Host.CreateDefaultBuilder(args)
                     PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
                 };
             });
-        });
+        })
+        .AddOpenTelemetry()
+            .ConfigureResource(resource => resource.AddService("SubscriberService"))
+            .WithTracing(tracing => tracing
+                .AddAWSMessagingInstrumentation()
+                .AddConsoleExporter());
     })
     .Build()
     .RunAsync();

--- a/sampleapps/SubscriberService/SubscriberService.csproj
+++ b/sampleapps/SubscriberService/SubscriberService.csproj
@@ -20,9 +20,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\AWS.Messaging.Telemetry.OpenTelemetry\AWS.Messaging.Telemetry.OpenTelemetry.csproj" />
     <ProjectReference Include="..\..\src\AWS.Messaging\AWS.Messaging.csproj" />
   </ItemGroup>
 

--- a/src/AWS.Messaging.Telemetry.OpenTelemetry/AWS.Messaging.Telemetry.OpenTelemetry.csproj
+++ b/src/AWS.Messaging.Telemetry.OpenTelemetry/AWS.Messaging.Telemetry.OpenTelemetry.csproj
@@ -10,6 +10,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RollForward>Major</RollForward>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <WarningsAsErrors>CA1727</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AWS.Messaging.Telemetry.OpenTelemetry/AWS.Messaging.Telemetry.OpenTelemetry.csproj
+++ b/src/AWS.Messaging.Telemetry.OpenTelemetry/AWS.Messaging.Telemetry.OpenTelemetry.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>true</IsPackable>
+    <Product>AWS Message Processing Framework Instrumention for OpenTelemetry</Product>
+    <PackageProjectUrl>https://github.com/awslabs/aws-dotnet-messaging</PackageProjectUrl>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <RollForward>Major</RollForward>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AWS.Messaging\AWS.Messaging.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\LICENSE" Pack="true" PackagePath="" />
+    <None Include="..\..\NOTICE" Pack="true" PackagePath="" />
+    <None Include="..\..\THIRD_PARTY_LICENSES" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include=".\README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+</Project>

--- a/src/AWS.Messaging.Telemetry.OpenTelemetry/Constants.cs
+++ b/src/AWS.Messaging.Telemetry.OpenTelemetry/Constants.cs
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Telemetry.OpenTelemetry;
+
+/// <summary>
+/// Constants related to the OpenTelemetry instrumentation for AWS.Messaging
+/// </summary>
+public class Constants
+{
+    /// <summary>
+    /// OpenTelemetry activity source name
+    /// </summary>
+    public const string SourceName = "AWS.Messaging";
+}

--- a/src/AWS.Messaging.Telemetry.OpenTelemetry/OpenTelemetryProvider.cs
+++ b/src/AWS.Messaging.Telemetry.OpenTelemetry/OpenTelemetryProvider.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
-using System.Text.Json;
 using OpenTelemetry;
 using OpenTelemetry.Context.Propagation;
 
@@ -13,7 +12,7 @@ namespace AWS.Messaging.Telemetry.OpenTelemetry
     /// </summary>
     public class OpenTelemetryProvider : ITelemetryProvider
     {
-        private static readonly ActivitySource _activitySource = new ActivitySource(TelemetryKeys.Source, TelemetryKeys.AWSMessagingAssemblyVersion);
+        private static readonly ActivitySource _activitySource = new ActivitySource(Constants.SourceName, TelemetryKeys.AWSMessagingAssemblyVersion);
 
         /// <inheritdoc/>
         public ITelemetryTrace Trace(string traceName)
@@ -74,16 +73,9 @@ namespace AWS.Messaging.Telemetry.OpenTelemetry
         /// <returns>Context value</returns>
         private IEnumerable<string> ExtractTraceContextFromEnvelope(MessageEnvelope envelope, string key)
         {
-            if (envelope.Metadata.TryGetValue(key, out var value))
-            {               
-                if (value is JsonElement jsonValue)
-                {
-                    return new string[] { jsonValue.ToString() };
-                }
-                else if (value is string stringValue)
-                {
-                    return new string[] { stringValue };
-                }
+            if (envelope.Metadata.TryGetValue(key, out var jsonElement))
+            {
+                return new string[] { jsonElement.ToString() };
             }
 
             return Enumerable.Empty<string>();

--- a/src/AWS.Messaging.Telemetry.OpenTelemetry/OpenTelemetryProvider.cs
+++ b/src/AWS.Messaging.Telemetry.OpenTelemetry/OpenTelemetryProvider.cs
@@ -5,80 +5,79 @@ using System.Diagnostics;
 using OpenTelemetry;
 using OpenTelemetry.Context.Propagation;
 
-namespace AWS.Messaging.Telemetry.OpenTelemetry
+namespace AWS.Messaging.Telemetry.OpenTelemetry;
+
+/// <summary>
+/// Creates OpenTelemetry traces
+/// </summary>
+public class OpenTelemetryProvider : ITelemetryProvider
 {
-    /// <summary>
-    /// Creates OpenTelemetry traces
-    /// </summary>
-    public class OpenTelemetryProvider : ITelemetryProvider
+    private static readonly ActivitySource _activitySource = new ActivitySource(Constants.SourceName, TelemetryKeys.AWSMessagingAssemblyVersion);
+
+    /// <inheritdoc/>
+    public ITelemetryTrace Trace(string traceName)
     {
-        private static readonly ActivitySource _activitySource = new ActivitySource(Constants.SourceName, TelemetryKeys.AWSMessagingAssemblyVersion);
-
-        /// <inheritdoc/>
-        public ITelemetryTrace Trace(string traceName)
+        var activity = _activitySource.StartActivity(traceName, ActivityKind.Producer);
+        if (activity != null)
         {
-            var activity = _activitySource.StartActivity(traceName, ActivityKind.Producer);
-            if (activity != null)
-            {
-                return new OpenTelemetryTrace(activity);
-            }
-
-            // If we initially failed to create an activity, attempt to force creation with 
-            // a link to the current activity, see https://opentelemetry.io/docs/instrumentation/net/manual/#creating-new-root-activities
-            var parentActivity = Activity.Current;
-            Activity.Current = null;
-            ActivityLink[]? links = null;
-            if (parentActivity != null)
-            {
-                links = new[] { new ActivityLink(parentActivity.Context) };
-            }
-
-            activity = _activitySource.StartActivity(traceName, ActivityKind.Producer, parentContext: default, links: links);
-            
-            return new OpenTelemetryTrace(activity, parentActivity);
+            return new OpenTelemetryTrace(activity);
         }
 
-        /// <inheritdoc/>
-        public ITelemetryTrace Trace(string traceName, MessageEnvelope envelope)
+        // If we initially failed to create an activity, attempt to force creation with 
+        // a link to the current activity, see https://opentelemetry.io/docs/instrumentation/net/manual/#creating-new-root-activities
+        var parentActivity = Activity.Current;
+        Activity.Current = null;
+        ActivityLink[]? links = null;
+        if (parentActivity != null)
         {
-            var propogatedContext = Propagators.DefaultTextMapPropagator.Extract(default, envelope, ExtractTraceContextFromEnvelope);
-            Baggage.Current = propogatedContext.Baggage;
-
-            var activity = _activitySource.StartActivity(traceName, ActivityKind.Consumer, parentContext: propogatedContext.ActivityContext);
-            if (activity != null)
-            {
-                return new OpenTelemetryTrace(activity);
-            }
-
-            // If we initially failed to create an activity, attempt to force creation with 
-            // a link to the current activity, see https://opentelemetry.io/docs/instrumentation/net/manual/#creating-new-root-activities
-            var parentActivity = Activity.Current;
-            Activity.Current = null;
-            ActivityLink[]? links = null;
-            if (parentActivity != null)
-            {
-                links = new[] { new ActivityLink(parentActivity.Context) };
-            }
-
-            activity = _activitySource.StartActivity(traceName, ActivityKind.Consumer, parentContext: propogatedContext.ActivityContext, links: links);
-
-            return new OpenTelemetryTrace(activity, parentActivity);
+            links = new[] { new ActivityLink(parentActivity.Context) };
         }
 
-        /// <summary>
-        /// Extracts propogation context from a <see cref="MessageEnvelope"/>, meant to be used with <see cref="TextMapPropagator"/>
-        /// </summary>
-        /// <param name="envelope">Inbound message envelope</param>
-        /// <param name="key">Context key</param>
-        /// <returns>Context value</returns>
-        private IEnumerable<string> ExtractTraceContextFromEnvelope(MessageEnvelope envelope, string key)
-        {
-            if (envelope.Metadata.TryGetValue(key, out var jsonElement))
-            {
-                return new string[] { jsonElement.ToString() };
-            }
+        activity = _activitySource.StartActivity(traceName, ActivityKind.Producer, parentContext: default, links: links);
+        
+        return new OpenTelemetryTrace(activity, parentActivity);
+    }
 
-            return Enumerable.Empty<string>();
+    /// <inheritdoc/>
+    public ITelemetryTrace Trace(string traceName, MessageEnvelope envelope)
+    {
+        var propogatedContext = Propagators.DefaultTextMapPropagator.Extract(default, envelope, ExtractTraceContextFromEnvelope);
+        Baggage.Current = propogatedContext.Baggage;
+
+        var activity = _activitySource.StartActivity(traceName, ActivityKind.Consumer, parentContext: propogatedContext.ActivityContext);
+        if (activity != null)
+        {
+            return new OpenTelemetryTrace(activity);
         }
+
+        // If we initially failed to create an activity, attempt to force creation with 
+        // a link to the current activity, see https://opentelemetry.io/docs/instrumentation/net/manual/#creating-new-root-activities
+        var parentActivity = Activity.Current;
+        Activity.Current = null;
+        ActivityLink[]? links = null;
+        if (parentActivity != null)
+        {
+            links = new[] { new ActivityLink(parentActivity.Context) };
+        }
+
+        activity = _activitySource.StartActivity(traceName, ActivityKind.Consumer, parentContext: propogatedContext.ActivityContext, links: links);
+
+        return new OpenTelemetryTrace(activity, parentActivity);
+    }
+
+    /// <summary>
+    /// Extracts propogation context from a <see cref="MessageEnvelope"/>, meant to be used with <see cref="TextMapPropagator"/>
+    /// </summary>
+    /// <param name="envelope">Inbound message envelope</param>
+    /// <param name="key">Context key</param>
+    /// <returns>Context value</returns>
+    private IEnumerable<string> ExtractTraceContextFromEnvelope(MessageEnvelope envelope, string key)
+    {
+        if (envelope.Metadata.TryGetValue(key, out var jsonElement))
+        {
+            return new string[] { jsonElement.ToString() };
+        }
+
+        return Enumerable.Empty<string>();
     }
 }

--- a/src/AWS.Messaging.Telemetry.OpenTelemetry/OpenTelemetryProvider.cs
+++ b/src/AWS.Messaging.Telemetry.OpenTelemetry/OpenTelemetryProvider.cs
@@ -66,7 +66,7 @@ public class OpenTelemetryProvider : ITelemetryProvider
     }
 
     /// <summary>
-    /// Extracts propogation context from a <see cref="MessageEnvelope"/>, meant to be used with <see cref="TextMapPropagator"/>
+    /// Extracts propagation context from a <see cref="MessageEnvelope"/>, meant to be used with <see cref="TextMapPropagator"/>
     /// </summary>
     /// <param name="envelope">Inbound message envelope</param>
     /// <param name="key">Context key</param>

--- a/src/AWS.Messaging.Telemetry.OpenTelemetry/OpenTelemetryProvider.cs
+++ b/src/AWS.Messaging.Telemetry.OpenTelemetry/OpenTelemetryProvider.cs
@@ -1,0 +1,92 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using System.Text.Json;
+using OpenTelemetry;
+using OpenTelemetry.Context.Propagation;
+
+namespace AWS.Messaging.Telemetry.OpenTelemetry
+{
+    /// <summary>
+    /// Creates OpenTelemetry traces
+    /// </summary>
+    public class OpenTelemetryProvider : ITelemetryProvider
+    {
+        private static readonly ActivitySource _activitySource = new ActivitySource(TelemetryKeys.Source, TelemetryKeys.AWSMessagingAssemblyVersion);
+
+        /// <inheritdoc/>
+        public ITelemetryTrace Trace(string traceName)
+        {
+            var activity = _activitySource.StartActivity(traceName, ActivityKind.Producer);
+            if (activity != null)
+            {
+                return new OpenTelemetryTrace(activity);
+            }
+
+            // If we initially failed to create an activity, attempt to force creation with 
+            // a link to the current activity, see https://opentelemetry.io/docs/instrumentation/net/manual/#creating-new-root-activities
+            var parentActivity = Activity.Current;
+            Activity.Current = null;
+            ActivityLink[]? links = null;
+            if (parentActivity != null)
+            {
+                links = new[] { new ActivityLink(parentActivity.Context) };
+            }
+
+            activity = _activitySource.StartActivity(traceName, ActivityKind.Producer, parentContext: default, links: links);
+            
+            return new OpenTelemetryTrace(activity, parentActivity);
+        }
+
+        /// <inheritdoc/>
+        public ITelemetryTrace Trace(string traceName, MessageEnvelope envelope)
+        {
+            var propogatedContext = Propagators.DefaultTextMapPropagator.Extract(default, envelope, ExtractTraceContextFromEnvelope);
+            Baggage.Current = propogatedContext.Baggage;
+
+            var activity = _activitySource.StartActivity(traceName, ActivityKind.Consumer, parentContext: propogatedContext.ActivityContext);
+            if (activity != null)
+            {
+                return new OpenTelemetryTrace(activity);
+            }
+
+            // If we initially failed to create an activity, attempt to force creation with 
+            // a link to the current activity, see https://opentelemetry.io/docs/instrumentation/net/manual/#creating-new-root-activities
+            var parentActivity = Activity.Current;
+            Activity.Current = null;
+            ActivityLink[]? links = null;
+            if (parentActivity != null)
+            {
+                links = new[] { new ActivityLink(parentActivity.Context) };
+            }
+
+            activity = _activitySource.StartActivity(traceName, ActivityKind.Consumer, parentContext: propogatedContext.ActivityContext, links: links);
+
+            return new OpenTelemetryTrace(activity, parentActivity);
+        }
+
+        /// <summary>
+        /// Extracts propogation context from a <see cref="MessageEnvelope"/>, meant to be used with <see cref="TextMapPropagator"/>
+        /// </summary>
+        /// <param name="envelope">Inbound message envelope</param>
+        /// <param name="key">Context key</param>
+        /// <returns>Context value</returns>
+        private IEnumerable<string> ExtractTraceContextFromEnvelope(MessageEnvelope envelope, string key)
+        {
+            if (envelope.Metadata.TryGetValue(key, out var value))
+            {               
+                if (value is JsonElement jsonValue)
+                {
+                    return new string[] { jsonValue.ToString() };
+                }
+                else if (value is string stringValue)
+                {
+                    return new string[] { stringValue };
+                }
+            }
+
+            return Enumerable.Empty<string>();
+        }
+    }
+}

--- a/src/AWS.Messaging.Telemetry.OpenTelemetry/OpenTelemetryTrace.cs
+++ b/src/AWS.Messaging.Telemetry.OpenTelemetry/OpenTelemetryTrace.cs
@@ -10,7 +10,7 @@ using OpenTelemetry.Trace;
 namespace AWS.Messaging.Telemetry.OpenTelemetry;
 
 /// <summary>
-/// An OpenTelemetry trace (wrapper around a <see cref="Activity"/>
+/// An OpenTelemetry trace (wrapper around a <see cref="Activity"/>)
 /// </summary>
 public class OpenTelemetryTrace : ITelemetryTrace
 {
@@ -57,7 +57,7 @@ public class OpenTelemetryTrace : ITelemetryTrace
             contextToInject = _activity.Context;
         }
         // Even if an "AWS.Messaging" activity was not created, we still
-        // propogate the the current activity (if it exists) through the message envelope
+        // propogate the current activity (if it exists) through the message envelope
         else if (Activity.Current != null)
         {
             contextToInject = Activity.Current.Context;
@@ -78,6 +78,7 @@ public class OpenTelemetryTrace : ITelemetryTrace
     }
 
     private bool _disposed;
+
     /// <summary>
     /// Disposes the inner <see cref="Activity"/>, and also restores the parent activity if set
     /// </summary>

--- a/src/AWS.Messaging.Telemetry.OpenTelemetry/OpenTelemetryTrace.cs
+++ b/src/AWS.Messaging.Telemetry.OpenTelemetry/OpenTelemetryTrace.cs
@@ -1,0 +1,104 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using OpenTelemetry;
+using OpenTelemetry.Context.Propagation;
+using OpenTelemetry.Trace;
+
+namespace AWS.Messaging.Telemetry.OpenTelemetry
+{
+    /// <summary>
+    /// An OpenTelemetry trace (wrapper around a <see cref="Activity"/>
+    /// </summary>
+    public class OpenTelemetryTrace : ITelemetryTrace
+    {
+        private readonly Activity? _activity;
+        private readonly Activity? _parentToRestore;
+
+        /// <summary>
+        /// Creates a new trace
+        /// </summary>
+        /// <param name="activity">New trace</param>
+        /// <param name="parentToRestore">Optional parent activity that will be set as <see cref="Activity.Current"/> when this trace is disposed</param>
+        public OpenTelemetryTrace(Activity? activity, Activity? parentToRestore = null)
+        {
+            _activity = activity;
+            _parentToRestore = parentToRestore;
+        }
+
+        /// <inheritdoc/>
+        public void AddException(Exception exception, bool fatal = true)
+        {
+            _activity?.RecordException(exception);
+
+            if (fatal)
+            {
+                _activity?.SetStatus(ActivityStatusCode.Error, exception.Message);
+            }
+        }
+
+        /// <inheritdoc/>
+        public void AddMetadata(string key, object value)
+        {
+            if (_activity != null && _activity.IsAllDataRequested)
+            {
+               _activity.SetTag(key, value);
+            }
+        }
+
+        /// <inheritdoc/>
+        public void RecordTelemetryContext(MessageEnvelope envelope)
+        {
+            ActivityContext contextToInject = default;
+            if (_activity != null)
+            {
+                contextToInject = _activity.Context;
+            }
+            // Even if an "AWS.Messaging" activity was not created, we still
+            // propogate the the current activity (if it exists) through the message envelope
+            else if (Activity.Current != null) 
+            {
+                contextToInject = Activity.Current.Context;
+            }
+
+            Propagators.DefaultTextMapPropagator.Inject(new PropagationContext(contextToInject, Baggage.Current), envelope, InjectTraceContextIntoEnvelope);
+        }
+
+        /// <summary>
+        /// Stores propagation context in the <see cref="MessageEnvelope"/>, meant to be used with <see cref="TextMapPropagator"/>
+        /// </summary>
+        /// <param name="envelope">Outbound message envelope</param>
+        /// <param name="key">Context key</param>
+        /// <param name="value">Context value</param>
+        private void InjectTraceContextIntoEnvelope(MessageEnvelope envelope, string key, string value)
+        {
+            envelope.Metadata[key] = value;
+        }
+
+        private bool _disposed;
+        /// <summary>
+        /// Disposes the inner <see cref="Activity"/>, and also restores the parent activity if set
+        /// </summary>
+        /// <param name="disposing">Indicates whether the call comes from Dispose (true) or a finalizer (false)</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                _activity?.Dispose();
+                if (_parentToRestore != null)
+                {
+                    Activity.Current = _parentToRestore;
+                }
+                _disposed = true;
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/AWS.Messaging.Telemetry.OpenTelemetry/OpenTelemetryTrace.cs
+++ b/src/AWS.Messaging.Telemetry.OpenTelemetry/OpenTelemetryTrace.cs
@@ -7,99 +7,98 @@ using OpenTelemetry;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Trace;
 
-namespace AWS.Messaging.Telemetry.OpenTelemetry
+namespace AWS.Messaging.Telemetry.OpenTelemetry;
+
+/// <summary>
+/// An OpenTelemetry trace (wrapper around a <see cref="Activity"/>
+/// </summary>
+public class OpenTelemetryTrace : ITelemetryTrace
 {
+    private readonly Activity? _activity;
+    private readonly Activity? _parentToRestore;
+
     /// <summary>
-    /// An OpenTelemetry trace (wrapper around a <see cref="Activity"/>
+    /// Creates a new trace
     /// </summary>
-    public class OpenTelemetryTrace : ITelemetryTrace
+    /// <param name="activity">New trace</param>
+    /// <param name="parentToRestore">Optional parent activity that will be set as <see cref="Activity.Current"/> when this trace is disposed</param>
+    public OpenTelemetryTrace(Activity? activity, Activity? parentToRestore = null)
     {
-        private readonly Activity? _activity;
-        private readonly Activity? _parentToRestore;
+        _activity = activity;
+        _parentToRestore = parentToRestore;
+    }
 
-        /// <summary>
-        /// Creates a new trace
-        /// </summary>
-        /// <param name="activity">New trace</param>
-        /// <param name="parentToRestore">Optional parent activity that will be set as <see cref="Activity.Current"/> when this trace is disposed</param>
-        public OpenTelemetryTrace(Activity? activity, Activity? parentToRestore = null)
+    /// <inheritdoc/>
+    public void AddException(Exception exception, bool fatal = true)
+    {
+        _activity?.RecordException(exception);
+
+        if (fatal)
         {
-            _activity = activity;
-            _parentToRestore = parentToRestore;
+            _activity?.SetStatus(ActivityStatusCode.Error, exception.Message);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void AddMetadata(string key, object value)
+    {
+        if (_activity != null && _activity.IsAllDataRequested)
+        {
+            _activity.SetTag(key, value);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void RecordTelemetryContext(MessageEnvelope envelope)
+    {
+        ActivityContext contextToInject = default;
+        if (_activity != null)
+        {
+            contextToInject = _activity.Context;
+        }
+        // Even if an "AWS.Messaging" activity was not created, we still
+        // propogate the the current activity (if it exists) through the message envelope
+        else if (Activity.Current != null)
+        {
+            contextToInject = Activity.Current.Context;
         }
 
-        /// <inheritdoc/>
-        public void AddException(Exception exception, bool fatal = true)
-        {
-            _activity?.RecordException(exception);
+        Propagators.DefaultTextMapPropagator.Inject(new PropagationContext(contextToInject, Baggage.Current), envelope, InjectTraceContextIntoEnvelope);
+    }
 
-            if (fatal)
+    /// <summary>
+    /// Stores propagation context in the <see cref="MessageEnvelope"/>, meant to be used with <see cref="TextMapPropagator"/>
+    /// </summary>
+    /// <param name="envelope">Outbound message envelope</param>
+    /// <param name="key">Context key</param>
+    /// <param name="value">Context value</param>
+    private void InjectTraceContextIntoEnvelope(MessageEnvelope envelope, string key, string value)
+    {
+        envelope.Metadata[key] = JsonSerializer.SerializeToElement(value);
+    }
+
+    private bool _disposed;
+    /// <summary>
+    /// Disposes the inner <see cref="Activity"/>, and also restores the parent activity if set
+    /// </summary>
+    /// <param name="disposing">Indicates whether the call comes from Dispose (true) or a finalizer (false)</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposed)
+        {
+            _activity?.Dispose();
+            if (_parentToRestore != null)
             {
-                _activity?.SetStatus(ActivityStatusCode.Error, exception.Message);
+                Activity.Current = _parentToRestore;
             }
+            _disposed = true;
         }
+    }
 
-        /// <inheritdoc/>
-        public void AddMetadata(string key, object value)
-        {
-            if (_activity != null && _activity.IsAllDataRequested)
-            {
-                _activity.SetTag(key, value);
-            }
-        }
-
-        /// <inheritdoc/>
-        public void RecordTelemetryContext(MessageEnvelope envelope)
-        {
-            ActivityContext contextToInject = default;
-            if (_activity != null)
-            {
-                contextToInject = _activity.Context;
-            }
-            // Even if an "AWS.Messaging" activity was not created, we still
-            // propogate the the current activity (if it exists) through the message envelope
-            else if (Activity.Current != null)
-            {
-                contextToInject = Activity.Current.Context;
-            }
-
-            Propagators.DefaultTextMapPropagator.Inject(new PropagationContext(contextToInject, Baggage.Current), envelope, InjectTraceContextIntoEnvelope);
-        }
-
-        /// <summary>
-        /// Stores propagation context in the <see cref="MessageEnvelope"/>, meant to be used with <see cref="TextMapPropagator"/>
-        /// </summary>
-        /// <param name="envelope">Outbound message envelope</param>
-        /// <param name="key">Context key</param>
-        /// <param name="value">Context value</param>
-        private void InjectTraceContextIntoEnvelope(MessageEnvelope envelope, string key, string value)
-        {
-            envelope.Metadata[key] = JsonSerializer.SerializeToElement(value);
-        }
-
-        private bool _disposed;
-        /// <summary>
-        /// Disposes the inner <see cref="Activity"/>, and also restores the parent activity if set
-        /// </summary>
-        /// <param name="disposing">Indicates whether the call comes from Dispose (true) or a finalizer (false)</param>
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!_disposed)
-            {
-                _activity?.Dispose();
-                if (_parentToRestore != null)
-                {
-                    Activity.Current = _parentToRestore;
-                }
-                _disposed = true;
-            }
-        }
-
-        /// <inheritdoc/>
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/AWS.Messaging.Telemetry.OpenTelemetry/OpenTelemetryTrace.cs
+++ b/src/AWS.Messaging.Telemetry.OpenTelemetry/OpenTelemetryTrace.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
+using System.Text.Json;
 using OpenTelemetry;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Trace;
@@ -43,7 +44,7 @@ namespace AWS.Messaging.Telemetry.OpenTelemetry
         {
             if (_activity != null && _activity.IsAllDataRequested)
             {
-               _activity.SetTag(key, value);
+                _activity.SetTag(key, value);
             }
         }
 
@@ -57,7 +58,7 @@ namespace AWS.Messaging.Telemetry.OpenTelemetry
             }
             // Even if an "AWS.Messaging" activity was not created, we still
             // propogate the the current activity (if it exists) through the message envelope
-            else if (Activity.Current != null) 
+            else if (Activity.Current != null)
             {
                 contextToInject = Activity.Current.Context;
             }
@@ -73,7 +74,7 @@ namespace AWS.Messaging.Telemetry.OpenTelemetry
         /// <param name="value">Context value</param>
         private void InjectTraceContextIntoEnvelope(MessageEnvelope envelope, string key, string value)
         {
-            envelope.Metadata[key] = value;
+            envelope.Metadata[key] = JsonSerializer.SerializeToElement(value);
         }
 
         private bool _disposed;

--- a/src/AWS.Messaging.Telemetry.OpenTelemetry/README.md
+++ b/src/AWS.Messaging.Telemetry.OpenTelemetry/README.md
@@ -1,0 +1,53 @@
+# OpenTelemetry plugin for AWS Message Processing Framework for .NET
+
+**Notice:** *This library is still in early active development and is not ready for use beyond experimentation.*
+
+This package is an [Instrumentation
+Library](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/glossary.md#instrumentation-library), which instruments the [AWS Message Processing Framework for .NET](https://github.com/awslabs/aws-dotnet-messaging) to collect traces about 
+messages that are sent and received.
+
+## Configuration
+
+### 1. Install Packages
+Add a reference to [`AWS.Messaging.Telemetry.OpenTelemetry`](https://www.nuget.org/packages/AWS.Messaging.Telemetry.OpenTelemetry) and [`OpenTelemetry.Extensions.Hosting`](https://www.nuget.org/packages/OpenTelemetry.Extensions.Hosting).
+
+You may also add a reference to one or more [exporters](https://opentelemetry.io/docs/instrumentation/net/exporters/) to visualize your telemetry data.
+
+```shell
+dotnet add package --prerelease AWS.Messaging.Telemetry.OpenTelemetry
+dotnet add package OpenTelemetry.Extensions.Hosting
+```
+
+### 2. Enable Instrumentation
+In the `Startup` class add a call to `AddOpenTelemetry` to configure OpenTelemetry. On the `TracerProviderBuilder`, call `AddAWSMessagingInstrumentation` to begin capturing traces for the AWS Message Processing Framework for .NET.
+
+```csharp
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddAWSMessageBus(builder =>
+        {
+            builder.AddSQSPoller("https://sqs.us-west-2.amazonaws.com/012345678910/MPF");
+            builder.AddMessageHandler<ChatMessageHandler, ChatMessage>("chatMessage");
+        });
+
+        services.AddOpenTelemetry()
+            .ConfigureResource(resource => resource.AddService("myApplication"))
+            .WithTracing(tracing => tracing
+                .AddAWSMessagingInstrumentation()
+                .AddConsoleExporter());
+    }
+}
+```
+
+# Useful Links
+* [AWS Message Processing Framework for .NET Design Document](../../docs/design/message-processing-framework-design.md)
+
+# Security
+
+See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
+
+# License
+
+This project is licensed under the Apache-2.0 License.

--- a/src/AWS.Messaging.Telemetry.OpenTelemetry/README.md
+++ b/src/AWS.Messaging.Telemetry.OpenTelemetry/README.md
@@ -11,6 +11,8 @@ messages that are sent and received.
 ### 1. Install Packages
 Add a reference to [`AWS.Messaging.Telemetry.OpenTelemetry`](https://www.nuget.org/packages/AWS.Messaging.Telemetry.OpenTelemetry) and [`OpenTelemetry.Extensions.Hosting`](https://www.nuget.org/packages/OpenTelemetry.Extensions.Hosting).
 
+In this example, we're going to configure OpenTelemetry on our `IServiceCollection`, so also add a reference to [`OpenTelemetry.Extensions.Hosting`](https://www.nuget.org/packages/OpenTelemetry.Extensions.Hosting). This is not required if starting and stopping tracing via `CreateTracerProviderBuilder`. 
+
 You may also add a reference to one or more [exporters](https://opentelemetry.io/docs/instrumentation/net/exporters/) to visualize your telemetry data.
 
 ```shell

--- a/src/AWS.Messaging.Telemetry.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/AWS.Messaging.Telemetry.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Trace;
+
+namespace AWS.Messaging.Telemetry.OpenTelemetry;
+
+/// <summary>
+/// Extensions for a <see cref="TracerProviderBuilder"/> to enable instrumentation for AWS Messaging
+/// </summary>
+public static class TracerProviderBuilderExtensions
+{
+    /// <summary>
+    /// Enables AWS Messaging Instrumentation for OpenTelemetry
+    /// </summary>
+    /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
+    /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
+    public static TracerProviderBuilder AddAWSMessagingInstrumentation(this TracerProviderBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            services.AddSingleton<ITelemetryProvider, OpenTelemetryProvider>();
+        });
+
+        builder.AddSource(TelemetryKeys.Source);
+
+        return builder;
+    }
+}

--- a/src/AWS.Messaging.Telemetry.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/AWS.Messaging.Telemetry.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -23,7 +23,7 @@ public static class TracerProviderBuilderExtensions
             services.AddSingleton<ITelemetryProvider, OpenTelemetryProvider>();
         });
 
-        builder.AddSource(TelemetryKeys.Source);
+        builder.AddSource(Constants.SourceName);
 
         return builder;
     }

--- a/src/AWS.Messaging/Configuration/AWSClientProvider.cs
+++ b/src/AWS.Messaging/Configuration/AWSClientProvider.cs
@@ -3,6 +3,7 @@
 
 using System.Reflection;
 using Amazon.Runtime;
+using AWS.Messaging.Telemetry;
 
 namespace AWS.Messaging.Configuration;
 
@@ -12,8 +13,7 @@ namespace AWS.Messaging.Configuration;
 internal class AWSClientProvider : IAWSClientProvider
 {
     private const string _userAgentHeader = "User-Agent";
-    private static readonly string _assemblyVersion = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? string.Empty;
-    private static readonly string _userAgentString = $"lib/aws-dotnet-messaging_{_assemblyVersion}";
+    private static readonly string _userAgentString = $"lib/aws-dotnet-messaging_{TelemetryKeys.AWSMessagingAssemblyVersion}";
 
     private readonly IServiceProvider _serviceProvider;
 

--- a/src/AWS.Messaging/MessageEnvelope.cs
+++ b/src/AWS.Messaging/MessageEnvelope.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace AWS.Messaging;
@@ -48,12 +49,8 @@ public abstract class MessageEnvelope
     /// These entries will also be serialized as top-level properties when sending the message, which
     /// can be used for CloudEvents Extension Attributes.
     /// </summary>
-    /// <remarks>
-    /// The framework does not attempt to deserialize values back to their original types for
-    /// received messages, so you may need to handle values as <see cref="System.Text.Json.JsonElement"/>.
-    /// </remarks>
     [JsonExtensionData]
-    public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
+    public Dictionary<string, JsonElement> Metadata { get; set; } = new Dictionary<string, JsonElement>();
 
     /// <summary>
     /// Stores metadata related to Amazon SQS.

--- a/src/AWS.Messaging/MessageEnvelope.cs
+++ b/src/AWS.Messaging/MessageEnvelope.cs
@@ -45,7 +45,13 @@ public abstract class MessageEnvelope
 
     /// <summary>
     /// This stores different metadata that is not modeled as a top-level property in MessageEnvelope class.
+    /// These entries will also be serialized as top-level properties when sending the message, which
+    /// can be used for CloudEvents Extension Attributes.
     /// </summary>
+    /// <remarks>
+    /// The framework does not attempt to deserialize values back to their original types for
+    /// received messages, so you may need to handle values as <see cref="System.Text.Json.JsonElement"/>.
+    /// </remarks>
     [JsonExtensionData]
     public Dictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 

--- a/src/AWS.Messaging/Serialization/EnvelopeSerializer.cs
+++ b/src/AWS.Messaging/Serialization/EnvelopeSerializer.cs
@@ -95,6 +95,17 @@ internal class EnvelopeSerializer : IEnvelopeSerializer
                 ["data"] = _messageSerializer.Serialize(message)
             };
 
+            // Write any Metadata as top-level keys
+            // This may be useful for any extensions defined in
+            // https://github.com/cloudevents/spec/tree/main/cloudevents/extensions
+            foreach (var key in envelope.Metadata.Keys)
+            {
+                if (!blob.ContainsKey(key)) // don't overwrite any reserved keys
+                {
+                    blob[key] = JsonSerializer.SerializeToNode(envelope.Metadata[key]);
+                }
+            }
+
             var jsonString = blob.ToJsonString();
             var serializedMessage = await InvokePostSerializationCallback(jsonString);
 

--- a/src/AWS.Messaging/Services/HandlerInvoker.cs
+++ b/src/AWS.Messaging/Services/HandlerInvoker.cs
@@ -49,6 +49,10 @@ public class HandlerInvoker : IHandlerInvoker
                 trace.AddMetadata(TelemetryKeys.MessageId, messageEnvelope.Id);
                 trace.AddMetadata(TelemetryKeys.MessageType, messageEnvelope.MessageTypeIdentifier);
                 trace.AddMetadata(TelemetryKeys.HandlerType, subscriberMapping.HandlerType.FullName!);
+                if (!string.IsNullOrEmpty(messageEnvelope.SQSMetadata?.MessageID))
+                {
+                    trace.AddMetadata(TelemetryKeys.SqsMessageId, messageEnvelope.SQSMetadata.MessageID);
+                }
 
                 using (var scope = _serviceProvider.CreateScope())
                 {

--- a/src/AWS.Messaging/Telemetry/TelemetryKeys.cs
+++ b/src/AWS.Messaging/Telemetry/TelemetryKeys.cs
@@ -1,11 +1,27 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Reflection;
+
 namespace AWS.Messaging.Telemetry;
 
-internal static class TelemetryKeys
+/// <summary>
+/// Constants related to telemetry
+/// </summary>
+public static class TelemetryKeys
 {
+    /// <summary>
+    /// OpenTelemetry activity source name
+    /// </summary>
+    public const string Source = "AWS.Messaging";
+
+    /// <summary>
+    /// Current version of the AWS.Messaging package
+    /// </summary>
+    public static string AWSMessagingAssemblyVersion = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? string.Empty;
+
     internal const string QueueUrl = "aws.messaging.sqs.queueurl";
+    internal const string SqsMessageId = "aws.messaging.sqs.messageId";
     internal const string TopicUrl = "aws.messaging.sns.topicUrl";
     internal const string EventBusName = "aws.messaging.eventBridge.eventBusName";
     internal const string ObjectType = "aws.messaging.objectType";

--- a/src/AWS.Messaging/Telemetry/TelemetryKeys.cs
+++ b/src/AWS.Messaging/Telemetry/TelemetryKeys.cs
@@ -11,11 +11,6 @@ namespace AWS.Messaging.Telemetry;
 public static class TelemetryKeys
 {
     /// <summary>
-    /// OpenTelemetry activity source name
-    /// </summary>
-    public const string Source = "AWS.Messaging";
-
-    /// <summary>
     /// Current version of the AWS.Messaging package
     /// </summary>
     public static string AWSMessagingAssemblyVersion = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? string.Empty;

--- a/test/AWS.Messaging.UnitTests/AWS.Messaging.UnitTests.csproj
+++ b/test/AWS.Messaging.UnitTests/AWS.Messaging.UnitTests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\AWS.Messaging.Telemetry.OpenTelemetry\AWS.Messaging.Telemetry.OpenTelemetry.csproj" />
     <ProjectReference Include="..\..\src\AWS.Messaging.Lambda\AWS.Messaging.Lambda.csproj" />
     <ProjectReference Include="..\..\src\AWS.Messaging\AWS.Messaging.csproj" />
     <ProjectReference Include="..\AWS.Messaging.Tests.Common\AWS.Messaging.Tests.Common.csproj" />
@@ -20,6 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.6.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/AWS.Messaging.UnitTests/OpenTelemetryTests.cs
+++ b/test/AWS.Messaging.UnitTests/OpenTelemetryTests.cs
@@ -88,7 +88,7 @@ public class OpenTelemetryTests
         var activities = new List<Activity>();
 
         using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSource(TelemetryKeys.Source)
+            .AddSource(Constants.SourceName)
             .ConfigureResource(resource => resource.AddService("unittest"))
             .AddInMemoryExporter(activities).Build())
         {
@@ -124,7 +124,7 @@ public class OpenTelemetryTests
         Activity.Current = existingActivity;
 
         using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSource(TelemetryKeys.Source)
+            .AddSource(Constants.SourceName)
             .ConfigureResource(resource => resource.AddService("unittest"))
             .AddInMemoryExporter(activities).Build())
         {
@@ -155,7 +155,7 @@ public class OpenTelemetryTests
         };
 
         using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSource(TelemetryKeys.Source)
+            .AddSource(Constants.SourceName)
             .ConfigureResource(resource => resource.AddService("unittest"))
             .AddInMemoryExporter(activities).Build())
         {
@@ -188,7 +188,7 @@ public class OpenTelemetryTests
             {
                 MessageID = "4567"
             },
-            Metadata = new Dictionary<string, object>
+            Metadata = new Dictionary<string, JsonElement>
             {
                 { "traceparent", JsonDocument.Parse("\"00-d2d8865217873923d2d74cf680a30ac3-d63e320582f9ff94-01\"").RootElement }
             },
@@ -196,7 +196,7 @@ public class OpenTelemetryTests
         };
 
         using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddSource(TelemetryKeys.Source)
+            .AddSource(Constants.SourceName)
             .ConfigureResource(resource => resource.AddService("unittest"))
             .AddInMemoryExporter(activities).Build())
         {

--- a/test/AWS.Messaging.UnitTests/OpenTelemetryTests.cs
+++ b/test/AWS.Messaging.UnitTests/OpenTelemetryTests.cs
@@ -164,7 +164,7 @@ public class OpenTelemetryTests
         }
 
         Assert.Single(activities);
-        Assert.Equal("AWS.Messaging: Process Message", activities[0].OperationName);
+        Assert.Equal("AWS.Messaging: Processing message", activities[0].OperationName);
         Assert.Equal(4, activities[0].Tags.Count());
         Assert.Contains(new KeyValuePair<string, string?>("aws.messaging.messageId", "1234"), activities[0].Tags);
         Assert.Contains(new KeyValuePair<string, string?>("aws.messaging.messageType", "AWS.Messaging.UnitTests.Models.ChatMessage"), activities[0].Tags);
@@ -205,7 +205,7 @@ public class OpenTelemetryTests
         }
 
         Assert.Single(activities);
-        Assert.Equal("AWS.Messaging: Process Message", activities[0].OperationName);
+        Assert.Equal("AWS.Messaging: Processing message", activities[0].OperationName);
 
         // The MPF activity's parent should be the one specified in envelope.Metadata above
         Assert.Equal("00-d2d8865217873923d2d74cf680a30ac3-d63e320582f9ff94-01", activities[0].ParentId);

--- a/test/AWS.Messaging.UnitTests/OpenTelemetryTests.cs
+++ b/test/AWS.Messaging.UnitTests/OpenTelemetryTests.cs
@@ -1,0 +1,213 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Amazon.SQS;
+using AWS.Messaging.Configuration;
+using AWS.Messaging.Publishers;
+using AWS.Messaging.Serialization;
+using AWS.Messaging.Services;
+using AWS.Messaging.Telemetry;
+using AWS.Messaging.Telemetry.OpenTelemetry;
+using AWS.Messaging.UnitTests.MessageHandlers;
+using AWS.Messaging.UnitTests.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using OpenTelemetry;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using Xunit;
+
+namespace AWS.Messaging.UnitTests;
+
+public class OpenTelemetryTests
+{
+    private readonly ServiceProvider _serviceProvider;
+    private readonly MessageRoutingPublisher _publisher;
+    private readonly HandlerInvoker _handler;
+    private readonly SubscriberMapping _subscriberMapping;
+
+    /// <summary>
+    /// Initializes all the services needed to publish and handle
+    /// messages without actually using SQS
+    /// </summary>
+    public OpenTelemetryTests()
+    {       
+        var envelopeSerializer = new Mock<IEnvelopeSerializer>();
+        var messageConfiguration = new Mock<IMessageConfiguration>();
+        var logger = new Mock<ILogger<IMessagePublisher>>();
+        var publisherMapping = new PublisherMapping(typeof(ChatMessage), new SQSPublisherConfiguration("endpoint"), PublisherTargetType.SQS_PUBLISHER);
+        _subscriberMapping = new SubscriberMapping(typeof(ChatMessageHandler), typeof(ChatMessage));
+
+        envelopeSerializer.SetReturnsDefault(ValueTask.FromResult(new MessageEnvelope<ChatMessage>()
+        {
+            Id = "1234",
+            Source = new Uri("/aws/messaging/unittest", UriKind.Relative)
+        }));     
+
+        messageConfiguration.Setup(x => x.GetPublisherMapping(typeof(ChatMessage))).Returns(publisherMapping);
+        messageConfiguration.Setup(x => x.GetSubscriberMapping(typeof(ChatMessage))).Returns(_subscriberMapping);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(new Mock<IAmazonSQS>().Object);
+        services.AddSingleton(logger.Object);
+        services.AddSingleton(messageConfiguration.Object);
+        services.AddSingleton(envelopeSerializer.Object);
+        services.AddSingleton<IAWSClientProvider, AWSClientProvider>();
+        services.AddSingleton<ITelemetryFactory, DefaultTelemetryFactory>();
+        services.AddSingleton<ITelemetryProvider, OpenTelemetryProvider>();
+        services.AddSingleton<ChatMessageHandler>();
+
+        _serviceProvider = services.BuildServiceProvider();
+
+        _publisher = new MessageRoutingPublisher(
+            _serviceProvider,
+            messageConfiguration.Object,
+            logger.Object,
+            new DefaultTelemetryFactory(_serviceProvider));
+
+        _handler = new HandlerInvoker(
+            _serviceProvider,
+            new NullLogger<HandlerInvoker>(),
+            new DefaultTelemetryFactory(_serviceProvider));
+    }
+
+    /// <summary>
+    /// Verifies that the expected traces and tags are created when publishing a message
+    /// </summary>
+    [Fact]
+    public async Task OpenTelemetry_Publisher_ExpectedTracesAndTags()
+    {
+        var activities = new List<Activity>();
+
+        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(TelemetryKeys.Source)
+            .ConfigureResource(resource => resource.AddService("unittest"))
+            .AddInMemoryExporter(activities).Build())
+        {
+
+            await _publisher.PublishAsync(new ChatMessage { MessageDescription = "Test Description" });
+        }
+
+        Assert.Equal(2, activities.Count);
+        Assert.Equal("AWS.Messaging: Publish to AWS SQS", activities[0].OperationName);
+        Assert.Equal(4, activities[0].Tags.Count());
+        Assert.Contains(new KeyValuePair<string, string?>("aws.messaging.objectType", "AWS.Messaging.UnitTests.Models.ChatMessage"), activities[0].Tags);
+        Assert.Contains(new KeyValuePair<string, string?>("aws.messaging.messageType", "AWS.Messaging.UnitTests.Models.ChatMessage"), activities[0].Tags);
+        Assert.Contains(new KeyValuePair<string, string?>("aws.messaging.sqs.queueurl", "endpoint"), activities[0].Tags);
+        Assert.Contains(new KeyValuePair<string, string?>("aws.messaging.messageId", "1234"), activities[0].Tags);
+
+        Assert.Equal("AWS.Messaging: Routing message to AWS service", activities[1].OperationName);
+        Assert.Equal(2, activities[1].Tags.Count());
+        Assert.Contains(new KeyValuePair<string, string?>("aws.messaging.objectType", "AWS.Messaging.UnitTests.Models.ChatMessage"), activities[1].Tags);
+        Assert.Contains(new KeyValuePair<string, string?>("aws.messaging.publishTargetType", "SQS"), activities[1].Tags);
+    }
+
+    /// <summary>
+    /// Verifies that when we need to manipulate <see cref="Activity.Current"/> in order
+    /// to force creation of our activity, that we reset the original activity at the end.
+    /// </summary>
+    [Fact]
+    public async Task OpenTelemetry_Publisher_ResetsParentActivity()
+    {
+        var activities = new List<Activity>();
+
+        // Start a non-MPF activity
+        var existingActivity = new Activity("current").Start();
+        Activity.Current = existingActivity;
+
+        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(TelemetryKeys.Source)
+            .ConfigureResource(resource => resource.AddService("unittest"))
+            .AddInMemoryExporter(activities).Build())
+        {
+            await _publisher.PublishAsync(new ChatMessage { MessageDescription = "Test Description" });
+        }
+
+        // We expect the top-level MPF activity to reset Activity.Current once disposed
+        Assert.Equal(existingActivity, Activity.Current);
+        existingActivity.Stop();
+    }
+
+    /// <summary>
+    /// Verifies that the expected traces and tags are created when handling a message
+    /// </summary>
+    [Fact]
+    public async Task OpenTelemetry_Handler_ExpectedTracesAndTags()
+    {
+        var activities = new List<Activity>();
+        var envelope = new MessageEnvelope<ChatMessage>()
+        {
+            MessageTypeIdentifier = "AWS.Messaging.UnitTests.Models.ChatMessage",
+            Id = "1234",
+            SQSMetadata = new SQSMetadata()
+            {
+                MessageID = "4567"
+            },
+            Message = new ChatMessage { MessageDescription = "Test Description" }
+        };
+
+        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(TelemetryKeys.Source)
+            .ConfigureResource(resource => resource.AddService("unittest"))
+            .AddInMemoryExporter(activities).Build())
+        {
+
+            await _handler.InvokeAsync(envelope, _subscriberMapping);
+        }
+
+        Assert.Single(activities);
+        Assert.Equal("AWS.Messaging: Process Message", activities[0].OperationName);
+        Assert.Equal(4, activities[0].Tags.Count());
+        Assert.Contains(new KeyValuePair<string, string?>("aws.messaging.messageId", "1234"), activities[0].Tags);
+        Assert.Contains(new KeyValuePair<string, string?>("aws.messaging.messageType", "AWS.Messaging.UnitTests.Models.ChatMessage"), activities[0].Tags);
+        Assert.Contains(new KeyValuePair<string, string?>("aws.messaging.handlerType", "AWS.Messaging.UnitTests.MessageHandlers.ChatMessageHandler"), activities[0].Tags);
+        Assert.Contains(new KeyValuePair<string, string?>("aws.messaging.sqs.messageId", "4567"), activities[0].Tags);
+    }
+
+    /// <summary>
+    /// Verifies that the handler trace has the correct parent when included
+    /// in the message envelope
+    /// </summary>
+    [Fact]
+    public async Task OpenTelemetry_Handler_ParentFromEnvelope()
+    {
+        var activities = new List<Activity>();
+        var envelope = new MessageEnvelope<ChatMessage>()
+        {
+            MessageTypeIdentifier = "AWS.Messaging.UnitTests.Models.ChatMessage",
+            Id = "1234",
+            SQSMetadata = new SQSMetadata()
+            {
+                MessageID = "4567"
+            },
+            Metadata = new Dictionary<string, object>
+            {
+                { "traceparent", JsonDocument.Parse("\"00-d2d8865217873923d2d74cf680a30ac3-d63e320582f9ff94-01\"").RootElement }
+            },
+            Message = new ChatMessage { MessageDescription = "Test Description" }
+        };
+
+        using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(TelemetryKeys.Source)
+            .ConfigureResource(resource => resource.AddService("unittest"))
+            .AddInMemoryExporter(activities).Build())
+        {
+
+            await _handler.InvokeAsync(envelope, _subscriberMapping);
+        }
+
+        Assert.Single(activities);
+        Assert.Equal("AWS.Messaging: Process Message", activities[0].OperationName);
+
+        // The MPF activity's parent should be the one specified in envelope.Metadata above
+        Assert.Equal("00-d2d8865217873923d2d74cf680a30ac3-d63e320582f9ff94-01", activities[0].ParentId);
+    }
+}

--- a/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
@@ -343,7 +343,7 @@ public class EnvelopeSerializerTests
         var serializedMessage = await envelopeSerializer.SerializeAsync(messageEnvelope);
 
         // ASSERT - Check expected base 64 encoded string
-        var expectedserializedMessage = "eyJpZCI6IjEyMyIsInNvdXJjZSI6Ii9hd3MvbWVzc2FnaW5nIiwic3BlY3ZlcnNpb24iOiIxLjAiLCJ0eXBlIjoiYWRkcmVzc0luZm8iLCJ0aW1lIjoiMjAwMC0xMi0wNVQxMDozMDo1NSswMDowMCIsImRhdGEiOiJ7XHUwMDIyVW5pdFx1MDAyMjoxMjMsXHUwMDIyU3RyZWV0XHUwMDIyOlx1MDAyMlByaW5jZSBTdFx1MDAyMixcdTAwMjJaaXBDb2RlXHUwMDIyOlx1MDAyMjAwMDAxXHUwMDIyfSJ9";
+        var expectedserializedMessage = "eyJpZCI6IjEyMyIsInNvdXJjZSI6Ii9hd3MvbWVzc2FnaW5nIiwic3BlY3ZlcnNpb24iOiIxLjAiLCJ0eXBlIjoiYWRkcmVzc0luZm8iLCJ0aW1lIjoiMjAwMC0xMi0wNVQxMDozMDo1NSswMDowMCIsImRhdGEiOiJ7XHUwMDIyVW5pdFx1MDAyMjoxMjMsXHUwMDIyU3RyZWV0XHUwMDIyOlx1MDAyMlByaW5jZSBTdFx1MDAyMixcdTAwMjJaaXBDb2RlXHUwMDIyOlx1MDAyMjAwMDAxXHUwMDIyfSIsIklzLURlbGl2ZXJlZCI6ZmFsc2V9";
         Assert.Equal(expectedserializedMessage, serializedMessage);
 
         // ACT - Convert To Envelope from base 64 Encoded Message

--- a/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
@@ -362,7 +362,7 @@ public class EnvelopeSerializerTests
         Assert.Equal("1.0", envelope.Version);
         Assert.Equal("/aws/messaging", envelope.Source?.ToString());
         Assert.Equal("addressInfo", envelope.MessageTypeIdentifier);
-        Assert.Equal(true, envelope.Metadata["Is-Delivered"]);
+        Assert.Equal(true, envelope.Metadata["Is-Delivered"].GetBoolean());
 
         var subscribeMapping = conversionResult.Mapping;
         Assert.NotNull(subscribeMapping);
@@ -376,7 +376,7 @@ public class MockSerializationCallback : ISerializationCallback
 {
     public ValueTask PreSerializationAsync(MessageEnvelope messageEnvelope)
     {
-        messageEnvelope.Metadata["Is-Delivered"] = false;
+        messageEnvelope.Metadata["Is-Delivered"] = JsonSerializer.SerializeToElement(false);
         return ValueTask.CompletedTask;
     }
 
@@ -396,7 +396,7 @@ public class MockSerializationCallback : ISerializationCallback
 
     public ValueTask PostDeserializationAsync(MessageEnvelope messageEnvelope)
     {
-        messageEnvelope.Metadata["Is-Delivered"] = true;
+        messageEnvelope.Metadata["Is-Delivered"] = JsonSerializer.SerializeToElement(true);
         return ValueTask.CompletedTask;
     }
 }

--- a/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
@@ -362,7 +362,7 @@ public class EnvelopeSerializerTests
         Assert.Equal("1.0", envelope.Version);
         Assert.Equal("/aws/messaging", envelope.Source?.ToString());
         Assert.Equal("addressInfo", envelope.MessageTypeIdentifier);
-        Assert.Equal(true, envelope.Metadata["Is-Delivered"].GetBoolean());
+        Assert.True(envelope.Metadata["Is-Delivered"].GetBoolean());
 
         var subscribeMapping = conversionResult.Mapping;
         Assert.NotNull(subscribeMapping);


### PR DESCRIPTION
*Issue #, if available:* DOTNET-7031

*Description of changes:*
* Adds `AWS.Messaging.Telemetry.OpenTelemetry`, which instruments the AWS Message Processing Framework for .NET for OpenTelemetry
    * Based heavily on @normj 's prototype in https://github.com/awslabs/aws-dotnet-messaging/tree/normj/telemetry
* Outside of OTel, the framework will now serialize `MessageEnvelope.Metadata` as top-level properties in the JSON envelope when sending messages. We're using this to telemetry, but us and customers can use for other CloudEvents extensions and/or custom attributes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
