### PR TITLE
Make sure all logging calls use Pascal casing

### DIFF
--- a/src/AWS.Messaging.Lambda/AWS.Messaging.Lambda.csproj
+++ b/src/AWS.Messaging.Lambda/AWS.Messaging.Lambda.csproj
@@ -8,6 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RollForward>Major</RollForward>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <WarningsAsErrors>CA1727</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AWS.Messaging.Lambda/DefaultLambdaMessaging.cs
+++ b/src/AWS.Messaging.Lambda/DefaultLambdaMessaging.cs
@@ -138,7 +138,7 @@ internal class DefaultLambdaMessaging : ILambdaMessaging
         Arn arn;
         if (!Arn.TryParse(queueArn, out arn))
         {
-            _logger.LogError("{queueArn} is not a valid SQS queue ARN", queueArn);
+            _logger.LogError("{QueueArn} is not a valid SQS queue ARN", queueArn);
             throw new InvalidSQSQueueArnException($"{queueArn} is not a valid SQS queue ARN");
         }
 

--- a/src/AWS.Messaging/AWS.Messaging.csproj
+++ b/src/AWS.Messaging/AWS.Messaging.csproj
@@ -8,6 +8,8 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RollForward>Major</RollForward>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
+    <WarningsAsErrors>CA1727</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AWS.Messaging/Services/DefaultMessageManager.cs
+++ b/src/AWS.Messaging/Services/DefaultMessageManager.cs
@@ -139,7 +139,7 @@ public class DefaultMessageManager : IMessageManager
                 if (!isSuccessful)
                 {
                     // If the handler invocation fails for any message, skip processing subsequent messages in the group.
-                    _logger.LogError("Handler invocation failed for a message belonging to message group '{groupdId}' having message ID '{messageID}'. Skipping processing of {remaining} messages from the same group.", groupId, message.Envelope.Id, remaining);
+                    _logger.LogError("Handler invocation failed for a message belonging to message group '{GroupdId}' having message ID '{MessageID}'. Skipping processing of {Remaining} messages from the same group.", groupId, message.Envelope.Id, remaining);
                     break;
                 }
                 remaining -= 1;
@@ -181,7 +181,7 @@ public class DefaultMessageManager : IMessageManager
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "An exception has been thrown from handler '{handlerType}' while processing message with ID '{messageId}'", subscriberMapping.HandlerType.Name, messageEnvelope.Id);
+            _logger.LogError(ex, "An exception has been thrown from handler '{HandlerType}' while processing message with ID '{MessageId}'", subscriberMapping.HandlerType.Name, messageEnvelope.Id);
         }
 
         _inFlightMessageMetadata.Remove(messageEnvelope, out _);
@@ -202,7 +202,7 @@ public class DefaultMessageManager : IMessageManager
         }
         else if (handlerTask.IsFaulted)
         {
-            _logger.LogError(handlerTask.Exception, "An exception has been thrown from handler '{handlerType}' while processing message with ID '{messageId}'", subscriberMapping.HandlerType.Name, messageEnvelope.Id);
+            _logger.LogError(handlerTask.Exception, "An exception has been thrown from handler '{HandlerType}' while processing message with ID '{MessageId}'", subscriberMapping.HandlerType.Name, messageEnvelope.Id);
             await _sqsMessageCommunication.ReportMessageFailureAsync(messageEnvelope);
         }
 
@@ -224,7 +224,7 @@ public class DefaultMessageManager : IMessageManager
                 {
                     _visibilityTimeoutExtensionTask = ExtendUnfinishedMessageVisibilityTimeoutBatch(token);
 
-                    _logger.LogTrace("Started task with id {id} to extend the visibility timeout of in flight messages", _visibilityTimeoutExtensionTask.Id);
+                    _logger.LogTrace("Started task with id {Id} to extend the visibility timeout of in flight messages", _visibilityTimeoutExtensionTask.Id);
                 }
             }
         }


### PR DESCRIPTION
*Description of changes:*
We were not being consistent with the casing of the log parameters in the library. I enabled the code analyzer as an error when not using Pascal casing and then updated all of the areas where we were not using Pascal casing.

@ashovlin You should add the `<WarningsAsErrors>CA1727</WarningsAsErrors>` to your PR for the OTel provider.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
