### PR TITLE
chore: Add beta suffix to the package version numbers

### DIFF
--- a/src/AWS.Messaging.Lambda/AWS.Messaging.Lambda.csproj
+++ b/src/AWS.Messaging.Lambda/AWS.Messaging.Lambda.csproj
@@ -11,7 +11,7 @@
     <WarningsAsErrors>CA1727</WarningsAsErrors>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\public.snk</AssemblyOriginatorKeyFile>
-    <Version>0.1.0</Version>
+    <Version>0.1.0-beta</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AWS.Messaging.Telemetry.OpenTelemetry/AWS.Messaging.Telemetry.OpenTelemetry.csproj
+++ b/src/AWS.Messaging.Telemetry.OpenTelemetry/AWS.Messaging.Telemetry.OpenTelemetry.csproj
@@ -13,7 +13,7 @@
     <WarningsAsErrors>CA1727</WarningsAsErrors>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\public.snk</AssemblyOriginatorKeyFile>
-    <Version>0.1.0</Version>
+    <Version>0.1.0-beta</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AWS.Messaging/AWS.Messaging.csproj
+++ b/src/AWS.Messaging/AWS.Messaging.csproj
@@ -12,7 +12,7 @@
     <WarningsAsErrors>CA1727</WarningsAsErrors>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\public.snk</AssemblyOriginatorKeyFile>
-    <Version>0.1.0</Version>
+    <Version>0.1.0-beta</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
*Description of changes:*
This PR adds the `beta` suffix to the package version numbers. NuGet treats any version number suffix to denote a pre-release version and also reflects the same on the package homepage. 

Example - https://www.nuget.org/packages/Amazon.Lambda.Annotations/0.10.0-preview
![image](https://github.com/awslabs/aws-dotnet-messaging/assets/36622308/a2eae779-7f98-4af5-a5af-40b5f63f92d9)


See [here](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning#pre-release-versions) to read more about pre-release versioning.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
