### PR TITLE
Harden Lambda FIFO integration tests.

### DIFF
--- a/test/AWS.Messaging.IntegrationTests/LambdaTests.cs
+++ b/test/AWS.Messaging.IntegrationTests/LambdaTests.cs
@@ -454,13 +454,14 @@ public class LambdaFifoTests : IAsyncLifetime
             }
         }
 
-        await Task.Delay(TimeSpan.FromSeconds(15));
+        // Wait for the Lambda to handle the messages and write the IDs to CloudWatch
+        await Task.Delay(TimeSpan.FromSeconds(20));
 
         // Extract the CloudWatch Logs lines that are logged for each message, and sort by timestamp
         var logs = await AWSUtilities.GetMostRecentLambdaLogs(_cloudWatchLogsClient, LambdaIntegrationTestFixture.FunctionPackageName, publishTimestamp);
         var handlerLogLines = logs
             .Where(logEvent => logEvent.Message.Contains("Processed message with Id: "))
-            .OrderBy(logEvent => logEvent.IngestionTime)
+            .OrderBy(logEvent => logEvent.Timestamp)
             .ToList();
 
         // Assert that the Lambda handled the number of messages that were published


### PR DESCRIPTION
*Issue #, if available:* N/A, follow-up to #71

*Description of changes:* @96malhar pointed out that the new Lambda FIFO integration test failed on his PR #77. Ran them continually locally, and saw failures in the 5-10 iteration range.

I'm now able to get to 10 iterations without failures (at which point I stopped) with these changes:
* For the FIFO messages logged to CloudWatch by the Lambda, we sort based on `Timestamp` instead of `IngestionTime`. I believe that is more accurate for when the Lambda function handled the message.
* Increased the period we're waiting for the logs from 15 to 20 seconds. Saw an iteration where there were 0 messages in the logs at the point we tried to assert them.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
