### PR TITLE
chore: Add additional unit tests and update project dependencies

### DIFF
--- a/sampleapps/LambdaMessaging/LambdaMessaging.csproj
+++ b/sampleapps/LambdaMessaging/LambdaMessaging.csproj
@@ -11,10 +11,10 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.1" />
-    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.1.0" />
-    <PackageReference Include="Amazon.Lambda.Annotations" Version="0.13.3" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />
+    <PackageReference Include="Amazon.Lambda.Annotations" Version="1.1.0" />
     <PackageReference Include="Amazon.Lambda.Logging.AspNetCore" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
   </ItemGroup>

--- a/sampleapps/LambdaMessaging/LambdaMessaging.csproj
+++ b/sampleapps/LambdaMessaging/LambdaMessaging.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.Annotations" Version="1.1.0" />
     <PackageReference Include="Amazon.Lambda.Logging.AspNetCore" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\AWS.Messaging.Lambda\AWS.Messaging.Lambda.csproj" />

--- a/sampleapps/LambdaMessaging/serverless.template
+++ b/sampleapps/LambdaMessaging/serverless.template
@@ -1,7 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Transform": "AWS::Serverless-2016-10-31",
-  "Description": "This template is partially managed by Amazon.Lambda.Annotations (v0.13.3.0).",
+  "Description": "This template is partially managed by Amazon.Lambda.Annotations (v1.0.0.0).",
   "Resources": {
     "ChatQueue": {
       "Type": "AWS::SQS::Queue",

--- a/sampleapps/PublisherAPI/PublisherAPI.csproj
+++ b/sampleapps/PublisherAPI/PublisherAPI.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.6.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sampleapps/SubscriberService/SubscriberService.csproj
+++ b/sampleapps/SubscriberService/SubscriberService.csproj
@@ -18,8 +18,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.*" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.6.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
   </ItemGroup>

--- a/src/AWS.Messaging.Lambda/AWS.Messaging.Lambda.csproj
+++ b/src/AWS.Messaging.Lambda/AWS.Messaging.Lambda.csproj
@@ -15,8 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
+    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AWS.Messaging/AWS.Messaging.csproj
+++ b/src/AWS.Messaging/AWS.Messaging.csproj
@@ -16,10 +16,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.EventBridge" Version="3.7.101.7" />
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.2" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.101.5" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.69" />
+    <PackageReference Include="AWSSDK.EventBridge" Version="3.7.301.8" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.300" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.300.13" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.300.13" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />

--- a/src/AWS.Messaging/AWS.Messaging.csproj
+++ b/src/AWS.Messaging/AWS.Messaging.csproj
@@ -20,11 +20,11 @@
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.300" />
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.300.13" />
     <PackageReference Include="AWSSDK.SQS" Version="3.7.300.13" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.*" />
   </ItemGroup>
   
   <ItemGroup>

--- a/test/AWS.Messaging.IntegrationTests/AWS.Messaging.IntegrationTests.csproj
+++ b/test/AWS.Messaging.IntegrationTests/AWS.Messaging.IntegrationTests.csproj
@@ -14,9 +14,9 @@
     <PackageReference Include="AWSSDK.Lambda" Version="3.7.303.9" />
     <PackageReference Include="AWSSDK.S3" Version="3.7.304.3" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.15" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.*" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.300" />
     <PackageReference Include="AWSSDK.SQS" Version="3.7.300.14" />
     <PackageReference Include="xunit" Version="2.6.2" />

--- a/test/AWS.Messaging.IntegrationTests/AWS.Messaging.IntegrationTests.csproj
+++ b/test/AWS.Messaging.IntegrationTests/AWS.Messaging.IntegrationTests.csproj
@@ -9,26 +9,26 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.7.104.72" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.100.128" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.7.109.6" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.104.13" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.101.47" />
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.7.301.6" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.300.14" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.7.303.9" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.304.3" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.15" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.5" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.110" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.300" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.300.14" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/AWS.Messaging.Tests.Common/AWS.Messaging.Tests.Common.csproj
+++ b/test/AWS.Messaging.Tests.Common/AWS.Messaging.Tests.Common.csproj
@@ -15,9 +15,9 @@
     <PackageReference Include="AWSSDK.S3" Version="3.7.304.3" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.15" />
     <PackageReference Include="AWSSDK.SQS" Version="3.7.300.14" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/AWS.Messaging.Tests.Common/AWS.Messaging.Tests.Common.csproj
+++ b/test/AWS.Messaging.Tests.Common/AWS.Messaging.Tests.Common.csproj
@@ -9,12 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.7.104.72" />
-    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.100.128" />
-    <PackageReference Include="AWSSDK.Lambda" Version="3.7.109.6" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.104.13" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.101.47" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.110" />
+    <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.7.301.6" />
+    <PackageReference Include="AWSSDK.IdentityManagement" Version="3.7.300.14" />
+    <PackageReference Include="AWSSDK.Lambda" Version="3.7.303.9" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.304.3" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.15" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.300.14" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />

--- a/test/AWS.Messaging.Tests.Common/AWSUtilities.cs
+++ b/test/AWS.Messaging.Tests.Common/AWSUtilities.cs
@@ -244,7 +244,7 @@ public static class AWSUtilities
             do
             {
                 response = await lambdaClient.GetFunctionConfigurationAsync(request);
-                if (response.LastUpdateStatus != LastUpdateStatus.InProgress && response.State != State.Pending)
+                if (response.LastUpdateStatus != LastUpdateStatus.InProgress && response.State != Amazon.Lambda.State.Pending)
                 {
                     if (response.LastUpdateStatus == LastUpdateStatus.Failed)
                     {

--- a/test/AWS.Messaging.Tests.LambdaFunctions/AWS.Messaging.Tests.LambdaFunctions.csproj
+++ b/test/AWS.Messaging.Tests.LambdaFunctions/AWS.Messaging.Tests.LambdaFunctions.csproj
@@ -11,9 +11,9 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.1" />
-    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
+    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />

--- a/test/AWS.Messaging.Tests.LambdaFunctions/AWS.Messaging.Tests.LambdaFunctions.csproj
+++ b/test/AWS.Messaging.Tests.LambdaFunctions/AWS.Messaging.Tests.LambdaFunctions.csproj
@@ -14,9 +14,9 @@
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.0" />
     <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\AWS.Messaging.Lambda\AWS.Messaging.Lambda.csproj" />

--- a/test/AWS.Messaging.UnitTests/AWS.Messaging.UnitTests.csproj
+++ b/test/AWS.Messaging.UnitTests/AWS.Messaging.UnitTests.csproj
@@ -21,15 +21,15 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.6.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/AWS.Messaging.UnitTests/AWS.Messaging.UnitTests.csproj
+++ b/test/AWS.Messaging.UnitTests/AWS.Messaging.UnitTests.csproj
@@ -17,10 +17,10 @@
 
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.6.0" />

--- a/test/AWS.Messaging.UnitTests/MessageBusBuilderTests.cs
+++ b/test/AWS.Messaging.UnitTests/MessageBusBuilderTests.cs
@@ -348,7 +348,7 @@ public class MessageBusBuilderTests
         var messageConfiguration = serviceProvider.GetService<IMessageConfiguration>();
 
         Assert.NotNull(messageConfiguration);
-        Assert.Equal(1, messageConfiguration.SerializationCallbacks.Count);
+        Assert.Single(messageConfiguration.SerializationCallbacks);
     }
 
     /// <summary>
@@ -434,6 +434,23 @@ public class MessageBusBuilderTests
             _serviceCollection.AddAWSMessageBus(builder =>
             {
                 builder.AddSQSPoller("queueUrl", options);
+            }));
+    }
+
+    /// <summary>
+    /// Tests that an exception is thrown when configuring Lambda message processor with invalid options.
+    /// </summary>
+    [Fact]
+    public void lambdaMessageProcessorConfiguration_LambdaMessagingOptions_Invalid()
+    {
+        Assert.Throws<InvalidLambdaMessagingOptionsException>(() =>
+            _serviceCollection.AddAWSMessageBus(builder =>
+            {
+                builder.AddLambdaMessageProcessor(options =>
+                {
+                    // Any value <= 0 is invalid
+                    options.MaxNumberOfConcurrentMessages = -1;
+                });
             }));
     }
 


### PR DESCRIPTION
*Description of changes:*
1. Update all NuGet package references to their latest versions
2. Added unit tests that assert the following:
    * Exceptions are thrown while creating a `MessageEnvelope` if `PublisherMapping` or `SubscriberMapping` are missing.
    * An exception is thrown when configuring Lambda message processor with invalid options.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
