### PR TITLE
feat: Add support for specifying the message destination and AWS service client when publishing a specific message.

### DIFF
--- a/src/AWS.Messaging/Configuration/AWSClientProvider.cs
+++ b/src/AWS.Messaging/Configuration/AWSClientProvider.cs
@@ -36,7 +36,7 @@ internal class AWSClientProvider : IAWSClientProvider
         return (T)serviceClient;
     }
 
-    private static void AWSServiceClient_BeforeServiceRequest(object sender, RequestEventArgs e)
+    internal static void AWSServiceClient_BeforeServiceRequest(object sender, RequestEventArgs e)
     {
         if (e is not WebServiceRequestEventArgs args || !args.Headers.ContainsKey(_userAgentHeader) || args.Headers[_userAgentHeader].Contains(_userAgentString))
             return;

--- a/src/AWS.Messaging/Configuration/EventBridgePublisherConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/EventBridgePublisherConfiguration.cs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using AWS.Messaging.Publishers.EventBridge;
+
 namespace AWS.Messaging.Configuration;
 
 /// <summary>
@@ -11,17 +13,27 @@ public class EventBridgePublisherConfiguration : IMessagePublisherConfiguration
     /// <summary>
     /// Retrieves the EventBridge Event Bus name or ARN which the publisher will use to route the message.
     /// </summary>
+    /// <remarks>
+    /// If the event bus name is null, a message-specific event bus must be set on the
+    /// <see cref="EventBridgeOptions"/> when sending an event.
+    /// </remarks>
     public string? PublisherEndpoint { get; set; }
 
     /// <summary>
     /// The ID of the global EventBridge endpoint.
     /// </summary>
+     /// <remarks>
+    /// If the endpoint ID is null, a message-specific event bus may be set on the
+    /// <see cref="EventBridgeOptions"/> when sending an event.
+    /// </remarks>
     public string? EndpointID { get; set; }
 
     /// <summary>
     /// Creates an instance of <see cref="EventBridgePublisherConfiguration"/>.
     /// </summary>
-    /// <param name="eventBusName">The name or the ARN of the event bus where the message is published</param>
+    /// <param name="eventBusName">The name or the ARN of the event bus where the message is published.
+    /// If the event bus name is null, a message-specific event bus must be set on the
+    /// <see cref="EventBridgeOptions"/> when sending an event.</param>
     public EventBridgePublisherConfiguration(string? eventBusName)
     {
         PublisherEndpoint = eventBusName;

--- a/src/AWS.Messaging/Configuration/EventBridgePublisherConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/EventBridgePublisherConfiguration.cs
@@ -11,7 +11,7 @@ public class EventBridgePublisherConfiguration : IMessagePublisherConfiguration
     /// <summary>
     /// Retrieves the EventBridge Event Bus name or ARN which the publisher will use to route the message.
     /// </summary>
-    public string PublisherEndpoint { get; set; }
+    public string? PublisherEndpoint { get; set; }
 
     /// <summary>
     /// The ID of the global EventBridge endpoint.
@@ -22,11 +22,8 @@ public class EventBridgePublisherConfiguration : IMessagePublisherConfiguration
     /// Creates an instance of <see cref="EventBridgePublisherConfiguration"/>.
     /// </summary>
     /// <param name="eventBusName">The name or the ARN of the event bus where the message is published</param>
-    public EventBridgePublisherConfiguration(string eventBusName)
+    public EventBridgePublisherConfiguration(string? eventBusName)
     {
-        if (string.IsNullOrEmpty(eventBusName))
-            throw new InvalidPublisherEndpointException("The event bus name cannot be empty.");
-
         PublisherEndpoint = eventBusName;
     }
 }

--- a/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
@@ -18,7 +18,7 @@ public interface IMessageBusBuilder
     /// </summary>
     /// <param name="queueUrl">The SQS queue URL to publish the message to.</param>
     /// <param name="messageTypeIdentifier">The language-agnostic message type identifier. If not specified, the .NET type will be used.</param>
-    IMessageBusBuilder AddSQSPublisher<TMessage>(string queueUrl, string? messageTypeIdentifier = null);
+    IMessageBusBuilder AddSQSPublisher<TMessage>(string? queueUrl, string? messageTypeIdentifier = null);
 
     /// <summary>
     /// Adds an SNS Publisher to the framework which will handle publishing
@@ -26,7 +26,7 @@ public interface IMessageBusBuilder
     /// </summary>
     /// <param name="topicUrl">The SNS topic URL to publish the message to.</param>
     /// <param name="messageTypeIdentifier">The language-agnostic message type identifier. If not specified, the .NET type will be used.</param>
-    IMessageBusBuilder AddSNSPublisher<TMessage>(string topicUrl, string? messageTypeIdentifier = null);
+    IMessageBusBuilder AddSNSPublisher<TMessage>(string? topicUrl, string? messageTypeIdentifier = null);
 
     /// <summary>
     /// Adds an EventBridge Publisher to the framework which will handle publishing the defined message type to the specified EventBridge event bus name.
@@ -35,7 +35,7 @@ public interface IMessageBusBuilder
     /// <param name="eventBusName">The EventBridge event bus name or ARN where the message will be published.</param>
     /// <param name="messageTypeIdentifier">The language-agnostic message type identifier. If not specified, the .NET type will be used.</param>
     /// <param name="options">Contains additional properties that can be set while configuring an EventBridge publisher</param>
-    IMessageBusBuilder AddEventBridgePublisher<TMessage>(string eventBusName, string? messageTypeIdentifier = null, EventBridgePublishOptions? options = null);
+    IMessageBusBuilder AddEventBridgePublisher<TMessage>(string? eventBusName, string? messageTypeIdentifier = null, EventBridgePublishOptions? options = null);
 
     /// <summary>
     /// Add a message handler for a given message type.

--- a/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
@@ -1,6 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using AWS.Messaging.Publishers.EventBridge;
+using AWS.Messaging.Publishers.SNS;
+using AWS.Messaging.Publishers.SQS;
 using AWS.Messaging.Serialization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,7 +19,8 @@ public interface IMessageBusBuilder
     /// Adds an SQS Publisher to the framework which will handle publishing
     /// the defined message type to the specified SQS queues URL.
     /// </summary>
-    /// <param name="queueUrl">The SQS queue URL to publish the message to.</param>
+    /// <param name="queueUrl">The SQS queue URL to publish the message to. If the queue URL is null, a message-specific queue
+    /// URL must be specified on the <see cref="SQSOptions"/> when sending a message.</param>
     /// <param name="messageTypeIdentifier">The language-agnostic message type identifier. If not specified, the .NET type will be used.</param>
     IMessageBusBuilder AddSQSPublisher<TMessage>(string? queueUrl, string? messageTypeIdentifier = null);
 
@@ -24,7 +28,8 @@ public interface IMessageBusBuilder
     /// Adds an SNS Publisher to the framework which will handle publishing
     /// the defined message type to the specified SNS topic URL.
     /// </summary>
-    /// <param name="topicUrl">The SNS topic URL to publish the message to.</param>
+    /// <param name="topicUrl">The SNS topic URL to publish the message to. If the topic URL is null, a message-specific
+    /// topic URL must be set on the <see cref="SNSOptions"/> when publishing a message.</param>
     /// <param name="messageTypeIdentifier">The language-agnostic message type identifier. If not specified, the .NET type will be used.</param>
     IMessageBusBuilder AddSNSPublisher<TMessage>(string? topicUrl, string? messageTypeIdentifier = null);
 
@@ -32,7 +37,8 @@ public interface IMessageBusBuilder
     /// Adds an EventBridge Publisher to the framework which will handle publishing the defined message type to the specified EventBridge event bus name.
     /// If you are specifying a global endpoint ID via <see cref="EventBridgePublishOptions"/>, then you must also include the <see href="https://www.nuget.org/packages/AWSSDK.Extensions.CrtIntegration">AWSSDK.Extensions.CrtIntegration</see> package in your application.
     /// </summary>
-    /// <param name="eventBusName">The EventBridge event bus name or ARN where the message will be published.</param>
+    /// <param name="eventBusName">The EventBridge event bus name or ARN where the message will be published. If the event bus name is null,
+    /// a message-specific event bus must be set on the <see cref="EventBridgeOptions"/> when sending an event.</param>
     /// <param name="messageTypeIdentifier">The language-agnostic message type identifier. If not specified, the .NET type will be used.</param>
     /// <param name="options">Contains additional properties that can be set while configuring an EventBridge publisher</param>
     IMessageBusBuilder AddEventBridgePublisher<TMessage>(string? eventBusName, string? messageTypeIdentifier = null, EventBridgePublishOptions? options = null);

--- a/src/AWS.Messaging/Configuration/IMessagePublisherConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/IMessagePublisherConfiguration.cs
@@ -11,5 +11,5 @@ public interface IMessagePublisherConfiguration
     /// <summary>
     /// Retrieves the AWS service-specific endpoint URL which the publisher will use to route the message.
     /// </summary>
-    string PublisherEndpoint { get; set; }
+    string? PublisherEndpoint { get; set; }
 }

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -35,36 +35,36 @@ public class MessageBusBuilder : IMessageBusBuilder
     }
 
     /// <inheritdoc/>
-    public IMessageBusBuilder AddSQSPublisher<TMessage>(string queueUrl, string? messageTypeIdentifier = null)
+    public IMessageBusBuilder AddSQSPublisher<TMessage>(string? queueUrl, string? messageTypeIdentifier = null)
     {
         return AddSQSPublisher(typeof(TMessage), queueUrl, messageTypeIdentifier);
     }
 
-    private IMessageBusBuilder AddSQSPublisher(Type messageType, string queueUrl, string? messageTypeIdentifier = null)
+    private IMessageBusBuilder AddSQSPublisher(Type messageType, string? queueUrl, string? messageTypeIdentifier = null)
     {
         var sqsPublisherConfiguration = new SQSPublisherConfiguration(queueUrl);
         return AddPublisher(messageType, sqsPublisherConfiguration, PublisherTargetType.SQS_PUBLISHER, messageTypeIdentifier);
     }
 
     /// <inheritdoc/>
-    public IMessageBusBuilder AddSNSPublisher<TMessage>(string topicUrl, string? messageTypeIdentifier = null)
+    public IMessageBusBuilder AddSNSPublisher<TMessage>(string? topicUrl, string? messageTypeIdentifier = null)
     {
         return AddSNSPublisher(typeof(TMessage), topicUrl, messageTypeIdentifier);
     }
 
-    private IMessageBusBuilder AddSNSPublisher(Type messageType, string topicUrl, string? messageTypeIdentifier = null)
+    private IMessageBusBuilder AddSNSPublisher(Type messageType, string? topicUrl, string? messageTypeIdentifier = null)
     {
         var snsPublisherConfiguration = new SNSPublisherConfiguration(topicUrl);
         return AddPublisher(messageType, snsPublisherConfiguration, PublisherTargetType.SNS_PUBLISHER, messageTypeIdentifier);
     }
 
     /// <inheritdoc/>
-    public IMessageBusBuilder AddEventBridgePublisher<TMessage>(string eventBusName, string? messageTypeIdentifier = null, EventBridgePublishOptions? options = null)
+    public IMessageBusBuilder AddEventBridgePublisher<TMessage>(string? eventBusName, string? messageTypeIdentifier = null, EventBridgePublishOptions? options = null)
     {
         return AddEventBridgePublisher(typeof(TMessage), eventBusName, messageTypeIdentifier, options);
     }
 
-    private IMessageBusBuilder AddEventBridgePublisher(Type messageType, string eventBusName, string? messageTypeIdentifier = null, EventBridgePublishOptions? options = null)
+    private IMessageBusBuilder AddEventBridgePublisher(Type messageType, string? eventBusName, string? messageTypeIdentifier = null, EventBridgePublishOptions? options = null)
     {
         var eventBridgePublisherConfiguration = new EventBridgePublisherConfiguration(eventBusName)
         {

--- a/src/AWS.Messaging/Configuration/SNSPublisherConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/SNSPublisherConfiguration.cs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using AWS.Messaging.Publishers.SNS;
+
 namespace AWS.Messaging.Configuration;
 
 /// <summary>
@@ -11,12 +13,17 @@ public class SNSPublisherConfiguration : IMessagePublisherConfiguration
     /// <summary>
     /// Retrieves the SNS Topic URL which the publisher will use to route the message.
     /// </summary>
+    /// <remarks>
+    /// If the topic URL is null, a message-specific topic URL must be set on the
+    /// <see cref="SNSOptions"/> when publishing a message.
+    /// </remarks>
     public string? PublisherEndpoint { get; set; }
 
     /// <summary>
     /// Creates an instance of <see cref="SNSPublisherConfiguration"/>.
     /// </summary>
-    /// <param name="topicUrl">The SNS Topic URL</param>
+    /// <param name="topicUrl">The SNS Topic URL. If the topic URL is null, a message-specific topic URL must be set on the
+    /// <see cref="SNSOptions"/> when publishing a message.</param>
     public SNSPublisherConfiguration(string? topicUrl)
     {
         PublisherEndpoint = topicUrl;

--- a/src/AWS.Messaging/Configuration/SNSPublisherConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/SNSPublisherConfiguration.cs
@@ -11,17 +11,14 @@ public class SNSPublisherConfiguration : IMessagePublisherConfiguration
     /// <summary>
     /// Retrieves the SNS Topic URL which the publisher will use to route the message.
     /// </summary>
-    public string PublisherEndpoint { get; set; }
+    public string? PublisherEndpoint { get; set; }
 
     /// <summary>
     /// Creates an instance of <see cref="SNSPublisherConfiguration"/>.
     /// </summary>
     /// <param name="topicUrl">The SNS Topic URL</param>
-    public SNSPublisherConfiguration(string topicUrl)
+    public SNSPublisherConfiguration(string? topicUrl)
     {
-        if (string.IsNullOrEmpty(topicUrl))
-            throw new InvalidPublisherEndpointException("The SNS Topic URL cannot be empty.");
-
         PublisherEndpoint = topicUrl;
     }
 }

--- a/src/AWS.Messaging/Configuration/SQSPublisherConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/SQSPublisherConfiguration.cs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using AWS.Messaging.Publishers.SQS;
+
 namespace AWS.Messaging.Configuration;
 
 /// <summary>
@@ -11,12 +13,17 @@ public class SQSPublisherConfiguration : IMessagePublisherConfiguration
     /// <summary>
     /// Retrieves the SQS Queue URL which the publisher will use to route the message.
     /// </summary>
+    /// <remarks>
+    /// If the queue URL is null, a message-specific queue URL must be specified on the
+    /// <see cref="SQSOptions"/> when sending a message.
+    /// </remarks>
     public string? PublisherEndpoint { get; set; }
 
     /// <summary>
     /// Creates an instance of <see cref="SQSPublisherConfiguration"/>.
     /// </summary>
-    /// <param name="queueUrl">The SQS Queue URL</param>
+    /// <param name="queueUrl">The SQS Queue URL. If the queue URL is null, a message-specific queue
+    /// URL must be specified on the <see cref="SQSOptions"/> when sending a message.</param>
     public SQSPublisherConfiguration(string? queueUrl)
     {
         PublisherEndpoint = queueUrl;

--- a/src/AWS.Messaging/Configuration/SQSPublisherConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/SQSPublisherConfiguration.cs
@@ -11,17 +11,14 @@ public class SQSPublisherConfiguration : IMessagePublisherConfiguration
     /// <summary>
     /// Retrieves the SQS Queue URL which the publisher will use to route the message.
     /// </summary>
-    public string PublisherEndpoint { get; set; }
+    public string? PublisherEndpoint { get; set; }
 
     /// <summary>
     /// Creates an instance of <see cref="SQSPublisherConfiguration"/>.
     /// </summary>
     /// <param name="queueUrl">The SQS Queue URL</param>
-    public SQSPublisherConfiguration(string queueUrl)
+    public SQSPublisherConfiguration(string? queueUrl)
     {
-        if (string.IsNullOrEmpty(queueUrl))
-            throw new InvalidPublisherEndpointException("The SQS Queue URL cannot be empty.");
-
         PublisherEndpoint = queueUrl;
     }
 }

--- a/src/AWS.Messaging/Publishers/EventBridge/EventBridgeOptions.cs
+++ b/src/AWS.Messaging/Publishers/EventBridge/EventBridgeOptions.cs
@@ -1,6 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using Amazon.EventBridge;
+using AWS.Messaging.Configuration;
+
 namespace AWS.Messaging.Publishers.EventBridge
 {
     /// <summary>
@@ -33,5 +36,24 @@ namespace AWS.Messaging.Publishers.EventBridge
         /// Contains a list of Amazon Resource Names that the event primarily concerns.
         /// </summary>
         public List<string>? Resources { get; set; }
+
+        /// <summary>
+        /// The EventBridge Event Bus name or ARN which the publisher will use to route the message.
+        /// This can be used to override the EventBusName that is configured for a given message
+        /// type when publishing a specific message.
+        /// </summary>
+        public string? EventBusName { get; set; }
+
+        /// <summary>
+        /// The ID of the global EventBridge endpoint. This can be used to override the EndpointID
+        /// that is configured for a given message type when publishing a specific message.
+        /// </summary>
+        public string? EndpointID { get; set; }
+
+        /// <summary>
+        /// An alternative EventBridge client that can be used to publish a specific message,
+        /// instead of the client provided by the registered <see cref="IAWSClientProvider"/> implementation.
+        /// </summary>
+        public IAmazonEventBridge? OverrideClient { get; set; }
     }
 }

--- a/src/AWS.Messaging/Publishers/EventBridge/EventBridgePublisher.cs
+++ b/src/AWS.Messaging/Publishers/EventBridge/EventBridgePublisher.cs
@@ -97,12 +97,6 @@ internal class EventBridgePublisher : IMessagePublisher, IEventBridgePublisher
                 {
                     // Use the user-provided client
                     client = eventBridgeOptions.OverrideClient;
-
-                    // But still update the user agent to match the built-in client
-                    if (client is AmazonServiceClient)
-                    {
-                        ((AmazonServiceClient)client).BeforeRequestEvent += AWSClientProvider.AWSServiceClient_BeforeServiceRequest;
-                    }
                 }
 
                 _logger.LogDebug("Sending the message of type '{MessageType}' to EventBridge. Publisher Endpoint: {Endpoint}", typeof(T), eventBusName);

--- a/src/AWS.Messaging/Publishers/EventBridge/EventBridgePublisher.cs
+++ b/src/AWS.Messaging/Publishers/EventBridge/EventBridgePublisher.cs
@@ -134,7 +134,7 @@ internal class EventBridgePublisher : IMessagePublisher, IEventBridgePublisher
 
         var putEventsRequest = new PutEventsRequest
         {
-            // Give precendence to the endpoint ID if specified on the message-specific eventBridgeOptions,
+            // Give precedence to the endpoint ID if specified on the message-specific eventBridgeOptions,
             // otherwise fallback to the publisher level
             EndpointId = eventBridgeOptions?.EndpointID ?? publisherConfiguration.EndpointID,
             Entries = new() { requestEntry }

--- a/src/AWS.Messaging/Publishers/SNS/SNSOptions.cs
+++ b/src/AWS.Messaging/Publishers/SNS/SNSOptions.cs
@@ -1,7 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
+using AWS.Messaging.Configuration;
 
 namespace AWS.Messaging.Publishers.SNS
 {
@@ -39,5 +41,16 @@ namespace AWS.Messaging.Publishers.SNS
         /// It must be less than 100 characters long.
         /// </summary>
         public string? Subject { get; set; }
+
+        /// <summary>
+        /// The SNS Topic Arn
+        /// </summary>
+        public string? TopicArn { get; set; }
+
+        /// <summary>
+        /// An alternative SNS client that can be used to publish a specific message,
+        /// instead of the client provided by the registered <see cref="IAWSClientProvider"/> implementation.
+        /// </summary>
+        public IAmazonSimpleNotificationService? OverrideClient { get; set; }
     }
 }

--- a/src/AWS.Messaging/Publishers/SNS/SNSPublisher.cs
+++ b/src/AWS.Messaging/Publishers/SNS/SNSPublisher.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using Amazon.Runtime;
 using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
 using AWS.Messaging.Configuration;
@@ -76,7 +77,7 @@ internal class SNSPublisher : IMessagePublisher, ISNSPublisher
                     throw new InvalidMessageException("The message cannot be null.");
                 }
 
-                var publisherEndpoint = GetPublisherEndpoint(trace, typeof(T));
+                var topicArn = GetPublisherEndpoint(trace, typeof(T), snsOptions);
 
                 _logger.LogDebug("Creating the message envelope for the message of type '{MessageType}'.", typeof(T));
                 var messageEnvelope = await _envelopeSerializer.CreateEnvelopeAsync(message);
@@ -86,9 +87,22 @@ internal class SNSPublisher : IMessagePublisher, ISNSPublisher
 
                 var messageBody = await _envelopeSerializer.SerializeAsync(messageEnvelope);
 
-                _logger.LogDebug("Sending the message of type '{MessageType}' to SNS. Publisher Endpoint: {Endpoint}", typeof(T), publisherEndpoint);
-                var request = CreatePublishRequest(publisherEndpoint, messageBody, snsOptions);
-                await _snsClient.PublishAsync(request, token);
+                var client = _snsClient;
+                if (snsOptions?.OverrideClient != null)
+                {
+                    // Use the user-provided client
+                    client = snsOptions.OverrideClient;
+
+                    // But still update the user agent to match the built-in client
+                    if (client is AmazonServiceClient)
+                    {
+                        ((AmazonServiceClient)client).BeforeRequestEvent += AWSClientProvider.AWSServiceClient_BeforeServiceRequest;
+                    }
+                }
+
+                _logger.LogDebug("Sending the message of type '{MessageType}' to SNS. Publisher Endpoint: {Endpoint}", typeof(T), topicArn);
+                var request = CreatePublishRequest(topicArn, messageBody, snsOptions);
+                await client.PublishAsync(request, token);
                 _logger.LogDebug("The message of type '{MessageType}' has been pushed to SNS.", typeof(T));
             }
             catch (Exception ex)
@@ -135,7 +149,7 @@ internal class SNSPublisher : IMessagePublisher, ISNSPublisher
         return request;
     }
 
-    private string GetPublisherEndpoint(ITelemetryTrace trace, Type messageType)
+    private string GetPublisherEndpoint(ITelemetryTrace trace, Type messageType, SNSOptions? snsOptions)
     {
         var mapping = _messageConfiguration.GetPublisherMapping(messageType);
         if (mapping is null)
@@ -149,9 +163,23 @@ internal class SNSPublisher : IMessagePublisher, ISNSPublisher
             throw new MissingMessageTypeConfigurationException($"Messages of type '{messageType.FullName}' are not configured for publishing to SNS.");
         }
 
-        trace.AddMetadata(TelemetryKeys.MessageType, mapping.MessageTypeIdentifier);
-        trace.AddMetadata(TelemetryKeys.TopicUrl, mapping.PublisherConfiguration.PublisherEndpoint);
+        var topicArn = mapping.PublisherConfiguration.PublisherEndpoint;
 
-        return mapping.PublisherConfiguration.PublisherEndpoint;
+        // Check if the topic was overriden on this message-specific publishing options
+        if (!string.IsNullOrEmpty(snsOptions?.TopicArn))
+        {
+            topicArn = snsOptions.TopicArn;
+        }
+
+        if (string.IsNullOrEmpty(topicArn))
+        {
+            _logger.LogError("Unable to determine a destination topic for message of type '{MessageType}'.", messageType.FullName);
+            throw new InvalidPublisherEndpointException($"Unable to determine a destination topic for message of type '{messageType.FullName}'.");
+        }
+
+        trace.AddMetadata(TelemetryKeys.MessageType, mapping.MessageTypeIdentifier);
+        trace.AddMetadata(TelemetryKeys.TopicUrl, topicArn);
+
+        return topicArn;
     }
 }

--- a/src/AWS.Messaging/Publishers/SNS/SNSPublisher.cs
+++ b/src/AWS.Messaging/Publishers/SNS/SNSPublisher.cs
@@ -92,12 +92,6 @@ internal class SNSPublisher : IMessagePublisher, ISNSPublisher
                 {
                     // Use the user-provided client
                     client = snsOptions.OverrideClient;
-
-                    // But still update the user agent to match the built-in client
-                    if (client is AmazonServiceClient)
-                    {
-                        ((AmazonServiceClient)client).BeforeRequestEvent += AWSClientProvider.AWSServiceClient_BeforeServiceRequest;
-                    }
                 }
 
                 _logger.LogDebug("Sending the message of type '{MessageType}' to SNS. Publisher Endpoint: {Endpoint}", typeof(T), topicArn);

--- a/src/AWS.Messaging/Publishers/SQS/SQSOptions.cs
+++ b/src/AWS.Messaging/Publishers/SQS/SQSOptions.cs
@@ -1,7 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using Amazon.SQS;
 using Amazon.SQS.Model;
+using AWS.Messaging.Configuration;
 
 namespace AWS.Messaging.Publishers.SQS
 {
@@ -44,5 +46,17 @@ namespace AWS.Messaging.Publishers.SQS
         /// Refer to the <see href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagegroupid-property.html">SQS developer guide</see> for best practices while using MessageGroupId.
         /// </summary>
         public string? MessageGroupId { get; set; }
+
+        /// <summary>
+        /// The SQS queue URL which the publisher will use to route the message. This can be used to override the queue URL
+        /// that is configured for a given message type when publishing a specific message.
+        /// </summary>
+        public string? QueueUrl { get; set; }
+
+        /// <summary>
+        /// An alternative SQS client that can be used to publish a specific message,
+        /// instead of the client provided by the registered <see cref="IAWSClientProvider"/> implementation.
+        /// </summary>
+        public IAmazonSQS? OverrideClient { get; set; }
     }
 }

--- a/src/AWS.Messaging/Publishers/SQS/SQSPublisher.cs
+++ b/src/AWS.Messaging/Publishers/SQS/SQSPublisher.cs
@@ -93,12 +93,6 @@ internal class SQSPublisher : IMessagePublisher, ISQSPublisher
                 {
                     // Use the user-provided client
                     client = sqsOptions.OverrideClient;
-
-                    // But still update the user agent to match the built-in client
-                    if (client is AmazonServiceClient)
-                    {
-                        ((AmazonServiceClient)client).BeforeRequestEvent += AWSClientProvider.AWSServiceClient_BeforeServiceRequest;
-                    }
                 }
 
                 _logger.LogDebug("Sending the message of type '{MessageType}' to SQS. Publisher Endpoint: {Endpoint}", typeof(T), queueUrl);

--- a/test/AWS.Messaging.UnitTests/AppSettingsConfigurationTests.cs
+++ b/test/AWS.Messaging.UnitTests/AppSettingsConfigurationTests.cs
@@ -73,26 +73,6 @@ public class AppSettingsConfigurationTests
     }
 
     [Fact]
-    public void AddSQSPublisher_MissingRequiredField()
-    {
-        var json = @"
-            {
-                ""AWS.Messaging"": {
-                    ""SQSPublishers"": [
-                        {
-                            ""MessageType"": ""AWS.Messaging.UnitTests.Models.ChatMessage""
-                        }
-                    ]
-                }
-            }";
-
-        Assert.ThrowsAny<Exception>(() =>
-        {
-            SetupConfigurationAndServices(json);
-        });
-    }
-
-    [Fact]
     public void AddSNSPublisher_NoIdentifier()
     {
         var json = @"
@@ -145,26 +125,6 @@ public class AppSettingsConfigurationTests
     }
 
     [Fact]
-    public void AddSNSPublisher_MissingRequiredField()
-    {
-        var json = @"
-            {
-                ""AWS.Messaging"": {
-                    ""SNSPublishers"": [
-                        {
-                            ""MessageType"": ""AWS.Messaging.UnitTests.Models.ChatMessage""
-                        }
-                    ]
-                }
-            }";
-
-        Assert.ThrowsAny<Exception>(() =>
-        {
-            SetupConfigurationAndServices(json);
-        });
-    }
-
-    [Fact]
     public void AddEventBridgePublisher_NoIdentifier()
     {
         var json = @"
@@ -214,26 +174,6 @@ public class AppSettingsConfigurationTests
         Assert.Equal(PublisherTargetType.EVENTBRIDGE_PUBLISHER, publisherMapping.PublishTargetType);
         Assert.Equal("arn:aws:events:us-west-2:012345678910:event-bus/default", publisherMapping.PublisherConfiguration.PublisherEndpoint);
         Assert.Equal("chatmessage", publisherMapping.MessageTypeIdentifier);
-    }
-
-    [Fact]
-    public void AddEventBridgePublisher_MissingRequiredField()
-    {
-        var json = @"
-            {
-                ""AWS.Messaging"": {
-                    ""EventBridgePublishers"": [
-                        {
-                            ""MessageType"": ""AWS.Messaging.UnitTests.Models.ChatMessage""
-                        }
-                    ]
-                }
-            }";
-
-        Assert.ThrowsAny<Exception>(() =>
-        {
-            SetupConfigurationAndServices(json);
-        });
     }
 
     [Fact]


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-dotnet-messaging/issues/90, DOTNET-7333

*Description of changes:* This adds support for configuring the destination and AWS client at the point of publishing. This may be useful for multi-tenant applications as described in #90 , where the destination of the message (and therefore the credentials required to publish it) aren't known until building the message.

For configuring the publisher without a destination in advance, I considered:
1. A new method, like `AddGenericSQSPublisher`, (or maybe `Destinationless`? `Unknown`?) 
    * **Why not?** Couldn't think of a good name
2. Leaving the signature as is, but requiring users to register a fake destination `AddSQSPublisher("WILL_OVERRIDE_LATER")`
    * **Why not?** Don't want to end up in a state where a user forgets to set the message-specific destination and we're sending requests to a bad/unknown endpoint.
3. Flipping our existing `string queueURL` parameter to `string? queueURL` so allowing `AddSQSPublisher(null)`
     * **Why ?** Seems like a balance between options 1 and 2 above.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
