### PR TITLE
feat: add ability for users to enable data message logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,14 @@ We welcome community contributions and pull requests. See [CONTRIBUTING.md](./CO
 # Security
 The AWS Message Processing Framework for .NET relies on the [AWS SDK for .NET](https://github.com/aws/aws-sdk-net) for communicating with AWS. Refer to the [security section](https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/security.html) in the [AWS SDK for .NET Developer Guide](https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/welcome.html) for more information.
 
+The framework does not log data messages sent by the user for security purposes. If users want to enabled this functionality for debugging purposes, you need to call `EnableDataMessageLogging()` in the AWS Message Bus as follows:
+```csharp
+builder.Services.AddAWSMessageBus(bus =>
+{
+    builder.EnableDataMessageLogging();
+});
+```
+
 If you discover a potential security issue, refer to the [security policy](https://github.com/awslabs/aws-dotnet-messaging/security/policy) for reporting information.
 
 # Additional Resources

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ We welcome community contributions and pull requests. See [CONTRIBUTING.md](./CO
 # Security
 The AWS Message Processing Framework for .NET relies on the [AWS SDK for .NET](https://github.com/aws/aws-sdk-net) for communicating with AWS. Refer to the [security section](https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/security.html) in the [AWS SDK for .NET Developer Guide](https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/welcome.html) for more information.
 
-The framework does not log data messages sent by the user for security purposes. If users want to enabled this functionality for debugging purposes, you need to call `EnableDataMessageLogging()` in the AWS Message Bus as follows:
+The framework does not log data messages sent by the user for security purposes. If users want to enable this functionality for debugging purposes, you need to call `EnableDataMessageLogging()` in the AWS Message Bus as follows:
 ```csharp
 builder.Services.AddAWSMessageBus(bus =>
 {

--- a/sampleapps/PublisherAPI/Program.cs
+++ b/sampleapps/PublisherAPI/Program.cs
@@ -32,6 +32,9 @@ builder.Services.AddAWSMessageBus(bus =>
             PropertyNamingPolicy= JsonNamingPolicy.CamelCase,
         };
     });
+
+    // Logging data messages is disabled by default to protect sensitive user data. If you want this enabled, uncomment the line below.
+    // builder.EnableDataMessageLogging();
 });
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();

--- a/sampleapps/PublisherAPI/appsettings.json
+++ b/sampleapps/PublisherAPI/appsettings.json
@@ -40,6 +40,7 @@
                     "EndpointID": "default"
                 }
             }
-        ]
+        ],
+        "LogMessageContent": false
     }
 }

--- a/sampleapps/SubscriberService/Program.cs
+++ b/sampleapps/SubscriberService/Program.cs
@@ -39,6 +39,9 @@ await Host.CreateDefaultBuilder(args)
                     PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
                 };
             });
+
+            // Logging data messages is disabled by default to protect sensitive user data. If you want this enabled, uncomment the line below.
+            // builder.EnableDataMessageLogging();
         })
         .AddOpenTelemetry()
             .ConfigureResource(resource => resource.AddService("SubscriberService"))

--- a/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
@@ -96,5 +96,5 @@ public interface IMessageBusBuilder
     /// If this is enabled, messages sent by this framework will be visible in plain text across the framework's components.
     /// This means any sensitive user data sent by this framework will be visible in logs, any exceptions thrown and others.
     /// </summary>
-    IMessageBusBuilder EnableDataMessageLogging();
+    IMessageBusBuilder EnableMessageContentLogging();
 }

--- a/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
@@ -76,7 +76,7 @@ public interface IMessageBusBuilder
     /// </summary>
     /// <param name="suffix">The suffix to append to the message source.</param>
     IMessageBusBuilder AddMessageSourceSuffix(string suffix);
-    
+
     /// <summary>
     /// Retrieve the Message Processing Framework section from <see cref="IConfiguration"/>
     /// and apply the Message bus configuration based on that section.
@@ -90,4 +90,11 @@ public interface IMessageBusBuilder
     /// <param name="serviceDescriptor">The service descriptor for the added service.</param>
     /// <returns></returns>
     IMessageBusBuilder AddAdditionalService(ServiceDescriptor serviceDescriptor);
+
+    /// <summary>
+    /// Enables the visibility of data messages in the logging framework, exception handling and other areas.
+    /// If this is enabled, messages sent by this framework will be visible in plain text across the framework's components.
+    /// This means any sensitive user data sent by this framework will be visible in logs, any exceptions thrown and others.
+    /// </summary>
+    IMessageBusBuilder EnableDataMessageLogging();
 }

--- a/src/AWS.Messaging/Configuration/IMessageConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/IMessageConfiguration.cs
@@ -73,5 +73,5 @@ public interface IMessageConfiguration
     /// If this is enabled, messages sent by this framework will be visible in plain text across the framework's components.
     /// This means any sensitive user data sent by this framework will be visible in logs, any exceptions thrown and others.
     /// </summary>
-    bool DataMessageLogging { get; set; }
+    bool LogMessageContent { get; set; }
 }

--- a/src/AWS.Messaging/Configuration/IMessageConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/IMessageConfiguration.cs
@@ -67,4 +67,11 @@ public interface IMessageConfiguration
     /// computed by the framework in the absence of a user-defined one.
     /// </summary>
     string? SourceSuffix { get; set; }
+
+    /// <summary>
+    /// Controls the visibility of data messages in the logging framework, exception handling and other areas.
+    /// If this is enabled, messages sent by this framework will be visible in plain text across the framework's components.
+    /// This means any sensitive user data sent by this framework will be visible in logs, any exceptions thrown and others.
+    /// </summary>
+    bool DataMessageLogging { get; set; }
 }

--- a/src/AWS.Messaging/Configuration/Internal/ApplicationSettings.cs
+++ b/src/AWS.Messaging/Configuration/Internal/ApplicationSettings.cs
@@ -40,6 +40,13 @@ public class ApplicationSettings
     public ICollection<SQSPoller> SQSPollers { get; set; } = default!;
 
     /// <summary>
+    /// Controls the visibility of data messages in the logging framework, exception handling and other areas.
+    /// If this is enabled, messages sent by this framework will be visible in plain text across the framework's components.
+    /// This means any sensitive user data sent by this framework will be visible in logs, any exceptions thrown and others.
+    /// </summary>
+    public bool? LogMessageContent { get; set; } = default;
+
+    /// <summary>
     /// Represents an SQS publisher configuration.
     /// </summary>
     public class SQSPublisher

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -239,6 +239,9 @@ public class MessageBusBuilder : IMessageBusBuilder
             }
         }
 
+        if (settings.LogMessageContent != null)
+            _messageConfiguration.LogMessageContent = settings.LogMessageContent ?? false;
+
         return this;
     }
 
@@ -262,9 +265,9 @@ public class MessageBusBuilder : IMessageBusBuilder
     }
 
     /// <inheritdoc/>
-    public IMessageBusBuilder EnableDataMessageLogging()
+    public IMessageBusBuilder EnableMessageContentLogging()
     {
-        _messageConfiguration.DataMessageLogging = true;
+        _messageConfiguration.LogMessageContent = true;
         return this;
     }
 

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -125,7 +125,7 @@ public class MessageBusBuilder : IMessageBusBuilder
             VisibilityTimeoutExtensionHeartbeatInterval = sqsMessagePollerOptions.VisibilityTimeoutExtensionHeartbeatInterval,
             WaitTimeSeconds = sqsMessagePollerOptions.WaitTimeSeconds,
             IsSQSExceptionFatal = sqsMessagePollerOptions.IsSQSExceptionFatal
-            
+
         };
 
         _messageConfiguration.MessagePollerConfigurations.Add(sqsMessagePollerConfiguration);
@@ -159,7 +159,7 @@ public class MessageBusBuilder : IMessageBusBuilder
         _messageConfiguration.SourceSuffix = suffix;
         return this;
     }
-    
+
     /// <inheritdoc/>
     public IMessageBusBuilder LoadConfigurationFromSettings(IConfiguration configuration)
     {
@@ -258,6 +258,13 @@ public class MessageBusBuilder : IMessageBusBuilder
     public IMessageBusBuilder AddAdditionalService(ServiceDescriptor serviceDescriptor)
     {
         _additionalServices.Add(serviceDescriptor);
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public IMessageBusBuilder EnableDataMessageLogging()
+    {
+        _messageConfiguration.DataMessageLogging = true;
         return this;
     }
 

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -273,6 +273,8 @@ public class MessageBusBuilder : IMessageBusBuilder
 
     internal void Build(IServiceCollection services)
     {
+        LoadConfigurationFromEnvironment();
+
         // Make sure there is at least the default null implementation of the logger to injected so that
         // the DI constructors can be satisfied.
         services.TryAdd(ServiceDescriptor.Singleton<ILoggerFactory, NullLoggerFactory>());
@@ -339,5 +341,15 @@ public class MessageBusBuilder : IMessageBusBuilder
         {
             services.Add(service);
         }
+    }
+
+    /// <summary>
+    /// Retrieve Message Processing Framework configuration from environment variables.
+    /// </summary>
+    private void LoadConfigurationFromEnvironment()
+    {
+        var logMessageContentEnvVar = Environment.GetEnvironmentVariable("AWSMESSAGING_LOGMESSAGECONTENT");
+        if (!string.IsNullOrEmpty(logMessageContentEnvVar) && bool.TryParse(logMessageContentEnvVar, out var logMessageContent))
+            _messageConfiguration.LogMessageContent = logMessageContent;
     }
 }

--- a/src/AWS.Messaging/Configuration/MessageConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/MessageConfiguration.cs
@@ -53,5 +53,5 @@ public class MessageConfiguration : IMessageConfiguration
     public string? SourceSuffix { get; set; }
 
     /// <inheritdoc/>
-    public bool DataMessageLogging { get; set; }
+    public bool LogMessageContent { get; set; }
 }

--- a/src/AWS.Messaging/Configuration/MessageConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/MessageConfiguration.cs
@@ -51,4 +51,7 @@ public class MessageConfiguration : IMessageConfiguration
 
     /// <inheritdoc/>
     public string? SourceSuffix { get; set; }
-} 
+
+    /// <inheritdoc/>
+    public bool DataMessageLogging { get; set; }
+}

--- a/src/AWS.Messaging/Serialization/EnvelopeSerializer.cs
+++ b/src/AWS.Messaging/Serialization/EnvelopeSerializer.cs
@@ -109,7 +109,7 @@ internal class EnvelopeSerializer : IEnvelopeSerializer
             var jsonString = blob.ToJsonString();
             var serializedMessage = await InvokePostSerializationCallback(jsonString);
 
-            if (_messageConfiguration.DataMessageLogging)
+            if (_messageConfiguration.LogMessageContent)
             {
                 _logger.LogTrace("Serialized the MessageEnvelope object as the following raw string:\n{SerializedMessage}", serializedMessage);
             }
@@ -119,7 +119,7 @@ internal class EnvelopeSerializer : IEnvelopeSerializer
             }
             return serializedMessage;
         }
-        catch (JsonException) when (!_messageConfiguration.DataMessageLogging)
+        catch (JsonException) when (!_messageConfiguration.LogMessageContent)
         {
             _logger.LogError("Failed to serialize the MessageEnvelope into a raw string");
             throw new FailedToSerializeMessageEnvelopeException("Failed to serialize the MessageEnvelope into a raw string");
@@ -175,7 +175,7 @@ internal class EnvelopeSerializer : IEnvelopeSerializer
             _logger.LogTrace("Created a generic {MessageEnvelopeName} of type '{MessageEnvelopeType}'", nameof(MessageEnvelope), result.Envelope.GetType());
             return result;
         }
-        catch (JsonException) when (!_messageConfiguration.DataMessageLogging)
+        catch (JsonException) when (!_messageConfiguration.LogMessageContent)
         {
             _logger.LogError("Failed to create a {MessageEnvelopeName}", nameof(MessageEnvelope));
             throw new FailedToCreateMessageEnvelopeException($"Failed to create {nameof(MessageEnvelope)}");

--- a/src/AWS.Messaging/Serialization/MessageSerializer.cs
+++ b/src/AWS.Messaging/Serialization/MessageSerializer.cs
@@ -29,7 +29,7 @@ internal class MessageSerializer : IMessageSerializer
         try
         {
             var jsonSerializerOptions = _messageConfiguration.SerializationOptions.SystemTextJsonOptions;
-            if (_messageConfiguration.DataMessageLogging)
+            if (_messageConfiguration.LogMessageContent)
             {
                 _logger.LogTrace("Deserializing the following message into type '{DeserializedType}':\n{Message}", deserializedType, message);
             }
@@ -40,7 +40,7 @@ internal class MessageSerializer : IMessageSerializer
 
             return JsonSerializer.Deserialize(message, deserializedType, jsonSerializerOptions) ?? throw new JsonException("The deserialized application message is null.");
         }
-        catch (JsonException) when (!_messageConfiguration.DataMessageLogging)
+        catch (JsonException) when (!_messageConfiguration.LogMessageContent)
         {
             _logger.LogError("Failed to deserialize application message into an instance of {DeserializedType}.", deserializedType);
             throw new FailedToDeserializeApplicationMessageException($"Failed to deserialize application message into an instance of {deserializedType}.");
@@ -60,18 +60,18 @@ internal class MessageSerializer : IMessageSerializer
         {
             var jsonSerializerOptions = _messageConfiguration.SerializationOptions.SystemTextJsonOptions;
             var jsonString = JsonSerializer.Serialize(message, jsonSerializerOptions);
-            if (_messageConfiguration.DataMessageLogging)
+            if (_messageConfiguration.LogMessageContent)
             {
                 _logger.LogTrace("Serialized the message object as the following raw string:\n{JsonString}", jsonString);
             }
             else
             {
-                _logger.LogTrace("Serialized the message object to a raw string");
+                _logger.LogTrace("Serialized the message object to a raw string with a content length of {ContentLength}.", jsonString.Length);
             }
 
             return jsonString;
         }
-        catch (JsonException) when (!_messageConfiguration.DataMessageLogging)
+        catch (JsonException) when (!_messageConfiguration.LogMessageContent)
         {
             _logger.LogError("Failed to serialize application message into a string");
             throw new FailedToSerializeApplicationMessageException("Failed to serialize application message into a string");

--- a/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
@@ -427,7 +427,7 @@ public class EnvelopeSerializerTests
     public async Task SerializeAsync_DataMessageLogging_NoError(bool dataMessageLogging)
     {
         var logger = new Mock<ILogger<EnvelopeSerializer>>();
-        var messageConfiguration = new MessageConfiguration { DataMessageLogging = dataMessageLogging };
+        var messageConfiguration = new MessageConfiguration { LogMessageContent = dataMessageLogging };
         var messageSerializer = new Mock<IMessageSerializer>();
         var dateTimeHandler = new Mock<IDateTimeHandler>();
         var messageIdGenerator = new Mock<IMessageIdGenerator>();
@@ -478,7 +478,7 @@ public class EnvelopeSerializerTests
     public async Task SerializeAsync_DataMessageLogging_WithError(bool dataMessageLogging)
     {
         var logger = new Mock<ILogger<EnvelopeSerializer>>();
-        var messageConfiguration = new MessageConfiguration { DataMessageLogging = dataMessageLogging };
+        var messageConfiguration = new MessageConfiguration { LogMessageContent = dataMessageLogging };
         var messageSerializer = new Mock<IMessageSerializer>();
         var dateTimeHandler = new Mock<IDateTimeHandler>();
         var messageIdGenerator = new Mock<IMessageIdGenerator>();
@@ -521,7 +521,7 @@ public class EnvelopeSerializerTests
     public async Task ConvertToEnvelopeAsync_DataMessageLogging_WithError(bool dataMessageLogging)
     {
         var logger = new Mock<ILogger<EnvelopeSerializer>>();
-        var messageConfiguration = new MessageConfiguration { DataMessageLogging = dataMessageLogging };
+        var messageConfiguration = new MessageConfiguration { LogMessageContent = dataMessageLogging };
         var messageSerializer = new Mock<IMessageSerializer>();
         var dateTimeHandler = new Mock<IDateTimeHandler>();
         var messageIdGenerator = new Mock<IMessageIdGenerator>();

--- a/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
@@ -7,12 +7,14 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Amazon.SQS.Model;
+using AWS.Messaging.Configuration;
 using AWS.Messaging.Serialization;
 using AWS.Messaging.Services;
 using AWS.Messaging.UnitTests.MessageHandlers;
 using AWS.Messaging.UnitTests.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 
@@ -417,6 +419,150 @@ public class EnvelopeSerializerTests
         Assert.Equal("addressInfo", subscribeMapping.MessageTypeIdentifier);
         Assert.Equal(typeof(AddressInfo), subscribeMapping.MessageType);
         Assert.Equal(typeof(AddressInfoHandler), subscribeMapping.HandlerType);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task SerializeAsync_DataMessageLogging_NoError(bool dataMessageLogging)
+    {
+        var logger = new Mock<ILogger<EnvelopeSerializer>>();
+        var messageConfiguration = new MessageConfiguration { DataMessageLogging = dataMessageLogging };
+        var messageSerializer = new Mock<IMessageSerializer>();
+        var dateTimeHandler = new Mock<IDateTimeHandler>();
+        var messageIdGenerator = new Mock<IMessageIdGenerator>();
+        var messageSourceHandler = new Mock<IMessageSourceHandler>();
+        var envelopeSerializer = new EnvelopeSerializer(logger.Object, messageConfiguration, messageSerializer.Object, dateTimeHandler.Object, messageIdGenerator.Object, messageSourceHandler.Object);
+        var messageEnvelope = new MessageEnvelope<AddressInfo>
+        {
+            Id = "123",
+            Source = new Uri("/aws/messaging", UriKind.Relative),
+            Version = "1.0",
+            MessageTypeIdentifier = "addressInfo",
+            TimeStamp = _testdate,
+            Message = new AddressInfo
+            {
+                Street = "Prince St",
+                Unit = 123,
+                ZipCode = "00001"
+            }
+        };
+
+        await envelopeSerializer.SerializeAsync(messageEnvelope);
+
+        if (dataMessageLogging)
+        {
+            logger.Verify(log => log.Log(
+                    It.Is<LogLevel>(logLevel => logLevel == LogLevel.Trace),
+                    It.Is<EventId>(eventId => eventId.Id == 0),
+                    It.Is<It.IsAnyType>((@object, @type) => @object.ToString() == "Serialized the MessageEnvelope object as the following raw string:\n{\"id\":\"123\",\"source\":\"/aws/messaging\",\"specversion\":\"1.0\",\"type\":\"addressInfo\",\"time\":\"2000-12-05T10:30:55+00:00\",\"data\":null}"),
+                    null,
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+        }
+        else
+        {
+            logger.Verify(log => log.Log(
+                    It.Is<LogLevel>(logLevel => logLevel == LogLevel.Trace),
+                    It.Is<EventId>(eventId => eventId.Id == 0),
+                    It.Is<It.IsAnyType>((@object, @type) => @object.ToString() == "Serialized the MessageEnvelope object to a raw string"),
+                    null,
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task SerializeAsync_DataMessageLogging_WithError(bool dataMessageLogging)
+    {
+        var logger = new Mock<ILogger<EnvelopeSerializer>>();
+        var messageConfiguration = new MessageConfiguration { DataMessageLogging = dataMessageLogging };
+        var messageSerializer = new Mock<IMessageSerializer>();
+        var dateTimeHandler = new Mock<IDateTimeHandler>();
+        var messageIdGenerator = new Mock<IMessageIdGenerator>();
+        var messageSourceHandler = new Mock<IMessageSourceHandler>();
+        var envelopeSerializer = new EnvelopeSerializer(logger.Object, messageConfiguration, messageSerializer.Object, dateTimeHandler.Object, messageIdGenerator.Object, messageSourceHandler.Object);
+        var messageEnvelope = new MessageEnvelope<MessageEnvelope>
+        {
+            Id = "123",
+            Source = new Uri("/aws/messaging", UriKind.Relative),
+            Version = "1.0",
+            MessageTypeIdentifier = "addressInfo",
+            TimeStamp = _testdate,
+            Message = new MessageEnvelope<MessageEnvelope>
+            {
+                Id = "123",
+                Source = new Uri("/aws/messaging", UriKind.Relative),
+                Version = "1.0",
+                MessageTypeIdentifier = "addressInfo",
+                TimeStamp = _testdate
+            }
+        };
+        messageSerializer.Setup(x => x.Serialize(It.IsAny<object>())).Throws(new JsonException("Test exception"));
+
+        var exception = await Assert.ThrowsAsync<FailedToSerializeMessageEnvelopeException>(async () => await envelopeSerializer.SerializeAsync(messageEnvelope));
+
+        Assert.Equal("Failed to serialize the MessageEnvelope into a raw string", exception.Message);
+        if (dataMessageLogging)
+        {
+            Assert.NotNull(exception.InnerException);
+        }
+        else
+        {
+            Assert.Null(exception.InnerException);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ConvertToEnvelopeAsync_DataMessageLogging_WithError(bool dataMessageLogging)
+    {
+        var logger = new Mock<ILogger<EnvelopeSerializer>>();
+        var messageConfiguration = new MessageConfiguration { DataMessageLogging = dataMessageLogging };
+        var messageSerializer = new Mock<IMessageSerializer>();
+        var dateTimeHandler = new Mock<IDateTimeHandler>();
+        var messageIdGenerator = new Mock<IMessageIdGenerator>();
+        var messageSourceHandler = new Mock<IMessageSourceHandler>();
+        var envelopeSerializer = new EnvelopeSerializer(logger.Object, messageConfiguration, messageSerializer.Object, dateTimeHandler.Object, messageIdGenerator.Object, messageSourceHandler.Object);
+        var messageEnvelope = new MessageEnvelope<MessageEnvelope>
+        {
+            Id = "123",
+            Source = new Uri("/aws/messaging", UriKind.Relative),
+            Version = "1.0",
+            MessageTypeIdentifier = "addressInfo",
+            TimeStamp = _testdate,
+            Message = new MessageEnvelope<string>
+            {
+                Id = "123",
+                Source = new Uri("/aws/messaging", UriKind.Relative),
+                Version = "1.0",
+                MessageTypeIdentifier = "addressInfo",
+                TimeStamp = _testdate,
+                Message = "Test"
+            }
+        };
+        var sqsMessage = new Message
+        {
+            Body = JsonSerializer.Serialize(messageEnvelope),
+            ReceiptHandle = "receipt-handle"
+        };
+        messageSerializer.Setup(x => x.Serialize(It.IsAny<object>())).Returns(@"{}");
+        messageSerializer.Setup(x => x.Deserialize(It.IsAny<string>(), It.IsAny<Type>())).Throws(new JsonException("Test exception"));
+
+        var exception = await Assert.ThrowsAsync<FailedToCreateMessageEnvelopeException>(async () => await envelopeSerializer.ConvertToEnvelopeAsync(sqsMessage));
+
+        Assert.Equal("Failed to create MessageEnvelope", exception.Message);
+        if (dataMessageLogging)
+        {
+            Assert.NotNull(exception.InnerException);
+        }
+        else
+        {
+            Assert.Null(exception.InnerException);
+        }
     }
 }
 

--- a/test/AWS.Messaging.UnitTests/SerializationTests/MessageSerializerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SerializationTests/MessageSerializerTests.cs
@@ -1,17 +1,28 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Text.Json.Serialization;
 using AWS.Messaging.Configuration;
 using AWS.Messaging.Serialization;
 using AWS.Messaging.UnitTests.Models;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace AWS.Messaging.UnitTests.SerializationTests;
 
 public class MessageSerializerTests
 {
+    private readonly Mock<ILogger<MessageSerializer>> _logger;
+
+    public MessageSerializerTests()
+    {
+        _logger = new Mock<ILogger<MessageSerializer>>();
+    }
+
     [Fact]
     public void Serialize()
     {
@@ -37,6 +48,112 @@ public class MessageSerializerTests
         // ASSERT
         var expectedString = "{\"FirstName\":\"Bob\",\"LastName\":\"Stone\",\"Age\":30,\"Gender\":\"Male\",\"Address\":{\"Unit\":12,\"Street\":\"Prince St\",\"ZipCode\":\"00001\"}}";
         Assert.Equal(expectedString, jsonString);
+    }
+
+    [Fact]
+    public void Serialize_NoDataMessageLogging_NoError()
+    {
+        var messageConfiguration = new MessageConfiguration();
+        IMessageSerializer serializer = new MessageSerializer(_logger.Object, messageConfiguration);
+
+        var person = new PersonInfo
+        {
+            FirstName= "Bob",
+            LastName = "Stone",
+            Age= 30,
+            Gender = Gender.Male,
+            Address= new AddressInfo
+            {
+                Unit = 12,
+                Street = "Prince St",
+                ZipCode = "00001"
+            }
+        };
+
+        serializer.Serialize(person);
+
+        _logger.Verify(logger => logger.Log(
+                It.Is<LogLevel>(logLevel => logLevel == LogLevel.Trace),
+                It.Is<EventId>(eventId => eventId.Id == 0),
+                It.Is<It.IsAnyType>((@object, @type) => @object.ToString() == "Serialized the message object to a raw string"),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void Serialize_DataMessageLogging_NoError()
+    {
+        var messageConfiguration = new MessageConfiguration{ DataMessageLogging = true };
+        IMessageSerializer serializer = new MessageSerializer(_logger.Object, messageConfiguration);
+
+        var person = new PersonInfo
+        {
+            FirstName= "Bob",
+            LastName = "Stone",
+            Age= 30,
+            Gender = Gender.Male,
+            Address= new AddressInfo
+            {
+                Unit = 12,
+                Street = "Prince St",
+                ZipCode = "00001"
+            }
+        };
+
+        serializer.Serialize(person);
+
+        _logger.Verify(logger => logger.Log(
+                It.Is<LogLevel>(logLevel => logLevel == LogLevel.Trace),
+                It.Is<EventId>(eventId => eventId.Id == 0),
+                It.Is<It.IsAnyType>((@object, @type) =>
+                    @object.ToString() ==
+                    "Serialized the message object as the following raw string:\n{\"FirstName\":\"Bob\",\"LastName\":\"Stone\",\"Age\":30,\"Gender\":\"Male\",\"Address\":{\"Unit\":12,\"Street\":\"Prince St\",\"ZipCode\":\"00001\"}}"),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    private class UnsupportedType
+    {
+        public string? Name { get; set; }
+        public UnsupportedType? Type { get; set; }
+    }
+
+    [Fact]
+    public void Serialize_NoDataMessageLogging_WithError()
+    {
+        var messageConfiguration = new MessageConfiguration();
+        IMessageSerializer serializer = new MessageSerializer(_logger.Object, messageConfiguration);
+
+        // Creating an object with circular dependency to force an exception in the JsonSerializer.Serialize method.
+        var unsupportedType1 = new UnsupportedType { Name = "type1" };
+        var unsupportedType2 = new UnsupportedType { Name = "type2" };
+        unsupportedType1.Type = unsupportedType2;
+        unsupportedType2.Type = unsupportedType1;
+
+        var exception = Assert.Throws<FailedToSerializeApplicationMessageException>(() => serializer.Serialize(unsupportedType1));
+
+        Assert.Equal("Failed to serialize application message into a string", exception.Message);
+        Assert.Null(exception.InnerException);
+    }
+
+    [Fact]
+    public void Serialize_DataMessageLogging_WithError()
+    {
+        var messageConfiguration = new MessageConfiguration{ DataMessageLogging = true };
+        IMessageSerializer serializer = new MessageSerializer(_logger.Object, messageConfiguration);
+
+        // Creating an object with circular dependency to force an exception in the JsonSerializer.Serialize method.
+        var unsupportedType1 = new UnsupportedType { Name = "type1" };
+        var unsupportedType2 = new UnsupportedType { Name = "type2" };
+        unsupportedType1.Type = unsupportedType2;
+        unsupportedType2.Type = unsupportedType1;
+
+        var exception = Assert.Throws<FailedToSerializeApplicationMessageException>(() => serializer.Serialize(unsupportedType1));
+
+        Assert.Equal("Failed to serialize application message into a string", exception.Message);
+        Assert.NotNull(exception.InnerException);
     }
 
     [Fact]
@@ -68,5 +185,84 @@ public class MessageSerializerTests
         Assert.Equal(12, message.Address?.Unit);
         Assert.Equal("Prince St", message.Address?.Street);
         Assert.Equal("00001", message.Address?.ZipCode);
+    }
+
+    [Fact]
+    public void Deserialize_NoDataMessageLogging_NoError()
+    {
+        var messageConfiguration = new MessageConfiguration();
+        IMessageSerializer serializer = new MessageSerializer(_logger.Object, messageConfiguration);
+
+        var jsonString =
+            @"{
+                   ""FirstName"":""Bob"",
+                   ""LastName"":""Stone"",
+                   ""Age"":30,
+                   ""Gender"":""Male"",
+                   ""Address"":{
+                      ""Unit"":12,
+                      ""Street"":""Prince St"",
+                      ""ZipCode"":""00001""
+                   }
+                }";
+
+        serializer.Deserialize<PersonInfo>(jsonString);
+
+        _logger.Verify(logger => logger.Log(
+                It.Is<LogLevel>(logLevel => logLevel == LogLevel.Trace),
+                It.Is<EventId>(eventId => eventId.Id == 0),
+                It.Is<It.IsAnyType>((@object, @type) => @object.ToString() == "Deserializing the following message into type 'AWS.Messaging.UnitTests.Models.PersonInfo'"),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void Deserialize_DataMessageLogging_NoError()
+    {
+        var messageConfiguration = new MessageConfiguration{ DataMessageLogging = true };
+        IMessageSerializer serializer = new MessageSerializer(_logger.Object, messageConfiguration);
+
+        var jsonString =
+            @"{""FirstName"":""Bob""}";
+
+        serializer.Deserialize<PersonInfo>(jsonString);
+
+        _logger.Verify(logger => logger.Log(
+                It.Is<LogLevel>(logLevel => logLevel == LogLevel.Trace),
+                It.Is<EventId>(eventId => eventId.Id == 0),
+                It.Is<It.IsAnyType>((@object, @type) => @object.ToString() == "Deserializing the following message into type 'AWS.Messaging.UnitTests.Models.PersonInfo':\n" +
+                    @"{""FirstName"":""Bob""}"),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void Deserialize_NoDataMessageLogging_WithError()
+    {
+        var messageConfiguration = new MessageConfiguration();
+        IMessageSerializer serializer = new MessageSerializer(_logger.Object, messageConfiguration);
+
+        var jsonString = "{'FirstName':'Bob'}";
+
+        var exception = Assert.Throws<FailedToDeserializeApplicationMessageException>(() => serializer.Deserialize<PersonInfo>(jsonString));
+
+        Assert.Equal("Failed to deserialize application message into an instance of AWS.Messaging.UnitTests.Models.PersonInfo.", exception.Message);
+        Assert.Null(exception.InnerException);
+    }
+
+    [Fact]
+    public void Deserialize_DataMessageLogging_WithError()
+    {
+        var messageConfiguration = new MessageConfiguration{ DataMessageLogging = true };
+        IMessageSerializer serializer = new MessageSerializer(_logger.Object, messageConfiguration);
+
+        var jsonString = "{'FirstName':'Bob'}";
+
+        var exception = Assert.Throws<FailedToDeserializeApplicationMessageException>(() => serializer.Deserialize<PersonInfo>(jsonString));
+
+        Assert.Equal("Failed to deserialize application message into an instance of AWS.Messaging.UnitTests.Models.PersonInfo.", exception.Message);
+        Assert.NotNull(exception.InnerException);
     }
 }

--- a/test/AWS.Messaging.UnitTests/SerializationTests/MessageSerializerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SerializationTests/MessageSerializerTests.cs
@@ -70,12 +70,12 @@ public class MessageSerializerTests
             }
         };
 
-        serializer.Serialize(person);
+        var jsonString = serializer.Serialize(person);
 
         _logger.Verify(logger => logger.Log(
                 It.Is<LogLevel>(logLevel => logLevel == LogLevel.Trace),
                 It.Is<EventId>(eventId => eventId.Id == 0),
-                It.Is<It.IsAnyType>((@object, @type) => @object.ToString() == "Serialized the message object to a raw string"),
+                It.Is<It.IsAnyType>((@object, @type) => @object.ToString() == $"Serialized the message object to a raw string with a content length of {jsonString.Length}."),
                 null,
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
@@ -84,7 +84,7 @@ public class MessageSerializerTests
     [Fact]
     public void Serialize_DataMessageLogging_NoError()
     {
-        var messageConfiguration = new MessageConfiguration{ DataMessageLogging = true };
+        var messageConfiguration = new MessageConfiguration{ LogMessageContent = true };
         IMessageSerializer serializer = new MessageSerializer(_logger.Object, messageConfiguration);
 
         var person = new PersonInfo
@@ -141,7 +141,7 @@ public class MessageSerializerTests
     [Fact]
     public void Serialize_DataMessageLogging_WithError()
     {
-        var messageConfiguration = new MessageConfiguration{ DataMessageLogging = true };
+        var messageConfiguration = new MessageConfiguration{ LogMessageContent = true };
         IMessageSerializer serializer = new MessageSerializer(_logger.Object, messageConfiguration);
 
         // Creating an object with circular dependency to force an exception in the JsonSerializer.Serialize method.
@@ -220,7 +220,7 @@ public class MessageSerializerTests
     [Fact]
     public void Deserialize_DataMessageLogging_NoError()
     {
-        var messageConfiguration = new MessageConfiguration{ DataMessageLogging = true };
+        var messageConfiguration = new MessageConfiguration{ LogMessageContent = true };
         IMessageSerializer serializer = new MessageSerializer(_logger.Object, messageConfiguration);
 
         var jsonString =
@@ -255,7 +255,7 @@ public class MessageSerializerTests
     [Fact]
     public void Deserialize_DataMessageLogging_WithError()
     {
-        var messageConfiguration = new MessageConfiguration{ DataMessageLogging = true };
+        var messageConfiguration = new MessageConfiguration{ LogMessageContent = true };
         IMessageSerializer serializer = new MessageSerializer(_logger.Object, messageConfiguration);
 
         var jsonString = "{'FirstName':'Bob'}";


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7340
DOTNET-7342

*Description of changes:*
* Added a new method `EnableDataMessageLogging` in the message bus builder that would enable data messages to be logged as well as appear in any exceptions thrown.
* Added tests, updated the sample apps and README

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
