### PR TITLE
chore: add validation to the ECS Task Metadata

### DIFF
--- a/src/AWS.Messaging/Configuration/Internal/TaskMetadataResponse.cs
+++ b/src/AWS.Messaging/Configuration/Internal/TaskMetadataResponse.cs
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Configuration.Internal;
+
+/// <summary>
+/// Represents the tasks metadata provided by Amazon ECS container agent.
+/// </summary>
+public class TaskMetadataResponse
+{
+    /// <summary>
+    /// The Amazon Resource Name (ARN) or short name of the Amazon ECS cluster to which the task belongs.
+    /// </summary>
+    public string Cluster { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The full Amazon Resource Name (ARN) of the task to which the container belongs.
+    /// </summary>
+    public string TaskARN { get; set; } = string.Empty;
+}

--- a/src/AWS.Messaging/Services/ECSContainerMetadataManager.cs
+++ b/src/AWS.Messaging/Services/ECSContainerMetadataManager.cs
@@ -47,18 +47,26 @@ internal class ECSContainerMetadataManager : IECSContainerMetadataManager
 
             var response = await client.GetAsync(new Uri($"{ecsMetadataUri}/task"));
             if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogError("Unable to retrieve task metadata from the ECS container.");
                 return null;
+            }
 
             var taskMetadataJson = await response.Content.ReadAsStringAsync();
             var taskMetadata = JsonSerializer.Deserialize<TaskMetadataResponse>(taskMetadataJson);
-            return
-                ValidateContainerTaskMetadata(taskMetadata) ?
-                    taskMetadata :
-                    null;
+            if (ValidateContainerTaskMetadata(taskMetadata))
+            {
+                return taskMetadata;
+            }
+            else
+            {
+                _logger.LogError("The retrieved task metadata from the ECS container is invalid.");
+                return null;
+            }
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Unable to retrieve Task Arn from ECS container metadata.");
+            _logger.LogError(ex, "Unable to retrieve task metadata from the ECS container.");
             return null;
         }
     }

--- a/src/AWS.Messaging/Services/ECSContainerMetadataManager.cs
+++ b/src/AWS.Messaging/Services/ECSContainerMetadataManager.cs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Text.Json;
+using System.Text.RegularExpressions;
+using Amazon;
+using AWS.Messaging.Configuration.Internal;
 using Microsoft.Extensions.Logging;
 
 namespace AWS.Messaging.Services;
@@ -13,12 +16,14 @@ internal class ECSContainerMetadataManager : IECSContainerMetadataManager
 {
     private readonly IEnvironmentManager _environmentManager;
     private readonly IHttpClientFactory _httpClientFactory;
-    private readonly ILogger<MessageSourceHandler> _logger;
+    private readonly ILogger<ECSContainerMetadataManager> _logger;
+
+    private readonly string EcsContainerHostAddress = "169.254.170.2";
 
     public ECSContainerMetadataManager(
         IEnvironmentManager environmentManager,
         IHttpClientFactory httpClientFactory,
-        ILogger<MessageSourceHandler> logger)
+        ILogger<ECSContainerMetadataManager> logger)
     {
         _environmentManager = environmentManager;
         _httpClientFactory = httpClientFactory;
@@ -26,30 +31,71 @@ internal class ECSContainerMetadataManager : IECSContainerMetadataManager
     }
 
     /// <inheritdoc/>
-    public async Task<Dictionary<string, object>> GetContainerTaskMetadata()
+    public async Task<TaskMetadataResponse?> GetContainerTaskMetadata()
     {
-        var metadata = new Dictionary<string, object>();
+        var ecsMetadataUri = _environmentManager.GetEnvironmentVariable("ECS_CONTAINER_METADATA_URI");
+        if (string.IsNullOrEmpty(ecsMetadataUri))
+            return null;
 
-        var ecsMetadataURI = _environmentManager.GetEnvironmentVariable("ECS_CONTAINER_METADATA_URI");
-        if (string.IsNullOrEmpty(ecsMetadataURI))
-            return metadata;
+        var resolvedUri = new Uri(ecsMetadataUri);
+        if (!EcsContainerHostAddress.Equals(resolvedUri.Host))
+            return null;
 
         try
         {
             var client = _httpClientFactory.CreateClient("ECSMetadataClient");
 
-            var response = await client.GetAsync(new Uri($"{ecsMetadataURI}/task"));
+            var response = await client.GetAsync(new Uri($"{ecsMetadataUri}/task"));
             if (!response.IsSuccessStatusCode)
-                return metadata;
+                return null;
 
             var taskMetadataJson = await response.Content.ReadAsStringAsync();
-            return JsonSerializer.Deserialize<Dictionary<string, object>>(taskMetadataJson) ??
-                metadata;
+            var taskMetadata = JsonSerializer.Deserialize<TaskMetadataResponse>(taskMetadataJson);
+            return
+                ValidateContainerTaskMetadata(taskMetadata) ?
+                    taskMetadata :
+                    null;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Unable to retrieve Task Arn from ECS container metadata.");
-            return metadata;
+            return null;
         }
+    }
+
+    /// <summary>
+    /// Runs validation checks on the information returned from the task metadata endpoint.
+    /// </summary>
+    /// <param name="metadata">The container task metadata.</param>
+    /// <returns>Whether the response is valid or not.</returns>
+    private bool ValidateContainerTaskMetadata(TaskMetadataResponse? metadata)
+    {
+        if (metadata == null)
+            return false;
+
+        // Use the .NET SDK to parse the Cluster to check if it is an ARN or Short Name
+        if (!Arn.TryParse(metadata.Cluster, out _))
+        {
+            // Validate the Cluster name which has the following validation rule:
+            // There can be a maximum of 255 characters. The valid characters are letters (uppercase and lowercase), numbers, hyphens, and underscores.
+            if (string.IsNullOrEmpty(metadata.Cluster))
+                return false;
+
+            // Check if the string length is within the allowed limit (255 characters)
+            if (metadata.Cluster.Length > 255)
+                return false;
+
+            // Use a regular expression to validate the characters
+            // Valid characters include letters (uppercase and lowercase), numbers, hyphens, and underscores
+            Regex validPattern = new Regex(@"^[A-Za-z0-9\-_]+$");
+            if (!validPattern.IsMatch(metadata.Cluster))
+                return false;
+        }
+
+        // Use the .NET SDK to parse the Task ARN to check if it is valid
+        if (!Arn.TryParse(metadata.TaskARN, out _))
+            return false;
+
+        return true;
     }
 }

--- a/src/AWS.Messaging/Services/IECSContainerMetadataManager.cs
+++ b/src/AWS.Messaging/Services/IECSContainerMetadataManager.cs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using AWS.Messaging.Configuration.Internal;
+
 namespace AWS.Messaging.Services;
 
 /// <summary>
@@ -13,5 +15,5 @@ internal interface IECSContainerMetadataManager
     /// To retrieve the TaskArn related to an ECS task we can issue a GET request to ${ECS_CONTAINER_METADATA_URI}/task.
     /// </summary>
     /// <returns>Task metadata as a dictionary</returns>
-    Task<Dictionary<string, object>> GetContainerTaskMetadata();
+    Task<TaskMetadataResponse?> GetContainerTaskMetadata();
 }

--- a/src/AWS.Messaging/Services/MessageSourceHandler.cs
+++ b/src/AWS.Messaging/Services/MessageSourceHandler.cs
@@ -138,15 +138,13 @@ internal class MessageSourceHandler : IMessageSourceHandler
         _logger.LogTrace("Checking if process if running in Amazon ECS...");
 
         var taskMetadata = await _ecsContainerMetadataManager.GetContainerTaskMetadata();
-
-        if (!taskMetadata.TryGetValue("Cluster", out var clusterName) ||
-            string.IsNullOrEmpty(clusterName?.ToString()))
-            return null;
-        if (!taskMetadata.TryGetValue("TaskARN", out var taskArn) ||
-            string.IsNullOrEmpty(taskArn?.ToString()))
+        if (taskMetadata == null)
             return null;
 
-        return $"/AmazonECS/{clusterName}/{taskArn}";
+        var clusterName = taskMetadata.Cluster.Split('/').Last();
+        var taskId = taskMetadata.TaskARN.Split('/').Last();
+
+        return $"/AmazonECS/{clusterName}/{taskId}";
     }
 
     /// <summary>

--- a/test/AWS.Messaging.UnitTests/ECSContainerMetadataManagerTests.cs
+++ b/test/AWS.Messaging.UnitTests/ECSContainerMetadataManagerTests.cs
@@ -113,7 +113,7 @@ public class ECSContainerMetadataManagerTests
         _logger.Verify(logger => logger.Log(
                 It.Is<LogLevel>(logLevel => logLevel == LogLevel.Error),
                 It.Is<EventId>(eventId => eventId.Id == 0),
-                It.Is<It.IsAnyType>((@object, @type) => @object.ToString() == "Unable to retrieve Task Arn from ECS container metadata."),
+                It.Is<It.IsAnyType>((@object, @type) => @object.ToString() == "Unable to retrieve task metadata from the ECS container."),
                 It.IsAny<Exception>(),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);

--- a/test/AWS.Messaging.UnitTests/ECSContainerMetadataManagerTests.cs
+++ b/test/AWS.Messaging.UnitTests/ECSContainerMetadataManagerTests.cs
@@ -1,0 +1,200 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using AWS.Messaging.Configuration.Internal;
+using AWS.Messaging.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace AWS.Messaging.UnitTests;
+
+public class ECSContainerMetadataManagerTests
+{
+    private readonly Mock<IEnvironmentManager> _environmentManager = new();
+    private readonly Mock<IHttpClientFactory> _httpClientFactory = new();
+    private readonly Mock<ILogger<ECSContainerMetadataManager>> _logger = new();
+    private readonly Mock<HttpMessageHandler> _httpMessageHandler = new(MockBehavior.Strict);
+
+    private readonly string _taskMetadataEnvironmentVariable = "ECS_CONTAINER_METADATA_URI";
+
+    [Fact]
+    public async Task GetContainerTaskMetadata_NoEnvironmentVariableSet()
+    {
+        var ecsContainerMetadataManager = new ECSContainerMetadataManager(
+            _environmentManager.Object,
+            _httpClientFactory.Object,
+            _logger.Object);
+
+        var metadata = await ecsContainerMetadataManager.GetContainerTaskMetadata();
+
+        Assert.Null(metadata);
+    }
+
+    [Fact]
+    public async Task GetContainerTaskMetadata_InvalidUri()
+    {
+        _environmentManager.Setup(x => x.GetEnvironmentVariable(_taskMetadataEnvironmentVariable)).Returns("http://invalidhost.com/");
+
+        var ecsContainerMetadataManager = new ECSContainerMetadataManager(
+            _environmentManager.Object,
+            _httpClientFactory.Object,
+            _logger.Object);
+
+        var metadata = await ecsContainerMetadataManager.GetContainerTaskMetadata();
+
+        Assert.Null(metadata);
+    }
+
+    [Fact]
+    public async Task GetContainerTaskMetadata_NoSuccessHttpCall()
+    {
+        _environmentManager.Setup(x => x.GetEnvironmentVariable(_taskMetadataEnvironmentVariable)).Returns("http://169.254.170.2/");
+        _httpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.InternalServerError
+            });
+        var httpClient = new HttpClient(_httpMessageHandler.Object);
+        _httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+
+        var ecsContainerMetadataManager = new ECSContainerMetadataManager(
+            _environmentManager.Object,
+            _httpClientFactory.Object,
+            _logger.Object);
+
+        var metadata = await ecsContainerMetadataManager.GetContainerTaskMetadata();
+
+        Assert.Null(metadata);
+    }
+
+    [Fact]
+    public async Task GetContainerTaskMetadata_InvalidJsonReturned()
+    {
+        _environmentManager.Setup(x => x.GetEnvironmentVariable(_taskMetadataEnvironmentVariable)).Returns("http://169.254.170.2/");
+        _httpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("Invalid content")
+            });
+        var httpClient = new HttpClient(_httpMessageHandler.Object);
+        _httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+
+        var ecsContainerMetadataManager = new ECSContainerMetadataManager(
+            _environmentManager.Object,
+            _httpClientFactory.Object,
+            _logger.Object);
+
+        var metadata = await ecsContainerMetadataManager.GetContainerTaskMetadata();
+
+        _logger.Verify(logger => logger.Log(
+                It.Is<LogLevel>(logLevel => logLevel == LogLevel.Error),
+                It.Is<EventId>(eventId => eventId.Id == 0),
+                It.Is<It.IsAnyType>((@object, @type) => @object.ToString() == "Unable to retrieve Task Arn from ECS container metadata."),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+        Assert.Null(metadata);
+    }
+
+    [Theory]
+    [InlineData("", "arn:aws:ecs:us-west-2:012345678910:task/Cluster/123abc")]
+    [InlineData("cluster$", "arn:aws:ecs:us-west-2:012345678910:task/Cluster/123abc")]
+    [InlineData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "arn:aws:ecs:us-west-2:012345678910:task/Cluster/123abc")]
+    [InlineData("cluster", "")]
+    [InlineData("cluster", "task")]
+    public async Task GetContainerTaskMetadata_ValidationErrors(string cluster, string taskArn)
+    {
+        _environmentManager.Setup(x => x.GetEnvironmentVariable(_taskMetadataEnvironmentVariable)).Returns("http://169.254.170.2/");
+        _httpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(JsonSerializer.Serialize(new TaskMetadataResponse
+                {
+                    Cluster = cluster,
+                    TaskARN = taskArn
+                }))
+            });
+        var httpClient = new HttpClient(_httpMessageHandler.Object);
+        _httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+
+        var ecsContainerMetadataManager = new ECSContainerMetadataManager(
+            _environmentManager.Object,
+            _httpClientFactory.Object,
+            _logger.Object);
+
+        var metadata = await ecsContainerMetadataManager.GetContainerTaskMetadata();
+
+        Assert.Null(metadata);
+    }
+
+    [Theory]
+    [InlineData("cluster", "arn:aws:ecs:us-west-2:012345678910:task/Cluster/123abc")]
+    [InlineData("arn:aws:ecs:us-west-2:012345678910:task/Cluster", "arn:aws:ecs:us-west-2:012345678910:task/Cluster/123abc")]
+    public async Task GetContainerTaskMetadata_NoValidationErrors(string cluster, string taskArn)
+    {
+        _environmentManager.Setup(x => x.GetEnvironmentVariable(_taskMetadataEnvironmentVariable)).Returns("http://169.254.170.2/");
+        _httpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(JsonSerializer.Serialize(new TaskMetadataResponse
+                {
+                    Cluster = cluster,
+                    TaskARN = taskArn
+                }))
+            });
+        var httpClient = new HttpClient(_httpMessageHandler.Object);
+        _httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+
+        var ecsContainerMetadataManager = new ECSContainerMetadataManager(
+            _environmentManager.Object,
+            _httpClientFactory.Object,
+            _logger.Object);
+
+        var metadata = await ecsContainerMetadataManager.GetContainerTaskMetadata();
+
+        Assert.NotNull(metadata);
+        Assert.Equal(cluster, metadata.Cluster);
+        Assert.Equal(taskArn, metadata.TaskARN);
+    }
+}

--- a/test/AWS.Messaging.UnitTests/MessageSourceHandlerTests.cs
+++ b/test/AWS.Messaging.UnitTests/MessageSourceHandlerTests.cs
@@ -1,10 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using AWS.Messaging.Configuration;
+using AWS.Messaging.Configuration.Internal;
 using AWS.Messaging.Services;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -96,7 +95,7 @@ public class MessageSourceHandlerTests
     [Fact]
     public async Task MessageSourceNotSet_RunningLocally()
     {
-        _ecsContainerMetadataManager.Setup(x => x.GetContainerTaskMetadata()).ReturnsAsync(new Dictionary<string, object>());
+        _ecsContainerMetadataManager.Setup(x => x.GetContainerTaskMetadata()).ReturnsAsync((TaskMetadataResponse?) null);
 
         var messageSourceHandler = GetMessageSourceHandler();
 
@@ -109,7 +108,7 @@ public class MessageSourceHandlerTests
     public async Task MessageSourceNotSet_SuffixSet_RunningLocally()
     {
         _messageConfiguration.SourceSuffix = "/suffix";
-        _ecsContainerMetadataManager.Setup(x => x.GetContainerTaskMetadata()).ReturnsAsync(new Dictionary<string, object>());
+        _ecsContainerMetadataManager.Setup(x => x.GetContainerTaskMetadata()).ReturnsAsync((TaskMetadataResponse?) null);
 
         var messageSourceHandler = GetMessageSourceHandler();
 
@@ -133,11 +132,12 @@ public class MessageSourceHandlerTests
     [Fact]
     public async Task MessageSourceNotSet_RunningInECS()
     {
-        _ecsContainerMetadataManager.Setup(x => x.GetContainerTaskMetadata()).ReturnsAsync(new Dictionary<string, object>
+        var taskMetadata = new TaskMetadataResponse
         {
-            { "Cluster", "cluster" },
-            { "TaskARN", "taskArn" }
-        });
+            Cluster = "cluster",
+            TaskARN = "taskArn"
+        };
+        _ecsContainerMetadataManager.Setup(x => x.GetContainerTaskMetadata()).ReturnsAsync(taskMetadata);
 
         var messageSourceHandler = GetMessageSourceHandler();
 
@@ -149,7 +149,7 @@ public class MessageSourceHandlerTests
     [Fact]
     public async Task MessageSourceNotSet_RunningInEC2()
     {
-        _ecsContainerMetadataManager.Setup(x => x.GetContainerTaskMetadata()).ReturnsAsync(new Dictionary<string, object>());
+        _ecsContainerMetadataManager.Setup(x => x.GetContainerTaskMetadata()).ReturnsAsync((TaskMetadataResponse?) null);
         _ec2InstanceMetadataManager.Setup(x => x.InstanceId).Returns("instanceId");
 
         var messageSourceHandler = GetMessageSourceHandler();


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7341

*Description of changes:*
* Added validation for the ECS Metadata endpoint to look for the IP `169.254.170.2`
* Added a POCO that represents the data returned by the endpoint which adds more validation on the structure of the data
* Added validation to the Cluster and TaskARN returned

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
