### PR TITLE
Refine list of fatal exceptions when polling SQS

### DIFF
--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -124,7 +124,7 @@ public class MessageBusBuilder : IMessageBusBuilder
             VisibilityTimeoutExtensionThreshold = sqsMessagePollerOptions.VisibilityTimeoutExtensionThreshold,
             VisibilityTimeoutExtensionHeartbeatInterval = sqsMessagePollerOptions.VisibilityTimeoutExtensionHeartbeatInterval,
             WaitTimeSeconds = sqsMessagePollerOptions.WaitTimeSeconds,
-            IsSQSExceptionFatal = sqsMessagePollerOptions.IsSQSExceptionFatal
+            IsExceptionFatal = sqsMessagePollerOptions.IsExceptionFatal
 
         };
 

--- a/src/AWS.Messaging/Configuration/SQSMessagePollerOptions.cs
+++ b/src/AWS.Messaging/Configuration/SQSMessagePollerOptions.cs
@@ -25,10 +25,8 @@ public class SQSMessagePollerOptions
     /// <inheritdoc cref="SQSMessagePollerConfiguration.VisibilityTimeoutExtensionHeartbeatInterval"/>
     public int VisibilityTimeoutExtensionHeartbeatInterval { get; set; } = SQSMessagePollerConfiguration.DEFAULT_VISIBILITY_TIMEOUT_EXTENSION_HEARTBEAT_INTERVAL;
 
-    /// <summary>
-    /// <inheritdoc cref="SQSMessagePollerConfiguration.IsFatalException(AmazonSQSException)" />
-    /// </summary>
-    public Func<AmazonSQSException, bool> IsSQSExceptionFatal { get; set; } = SQSMessagePollerConfiguration.IsFatalException;
+    /// <inheritdoc cref="SQSMessagePollerConfiguration.IsExceptionFatal" />
+    public Func<Exception, bool> IsExceptionFatal { get; set; } = SQSMessagePollerConfiguration.DefaultIsExceptionFatal;
 
     /// <summary>
     /// Validates that the options are valid against the message framework's and/or SQS limits

--- a/src/AWS.Messaging/SQS/SQSMessagePoller.cs
+++ b/src/AWS.Messaging/SQS/SQSMessagePoller.cs
@@ -126,7 +126,7 @@ internal class SQSMessagePoller : IMessagePoller, ISQSMessageCommunication
 
                 // Rethrow the exception to fail fast for invalid configuration, permissioning, etc.
                 // TODO: explore a "cool down mode" for repeated exceptions
-                if (_configuration.IsSQSExceptionFatal(ex))
+                if (_configuration.IsExceptionFatal(ex))
                 {
                     throw;
                 }
@@ -135,6 +135,13 @@ internal class SQSMessagePoller : IMessagePoller, ISQSMessageCommunication
             {
                 // TODO: explore a "cool down mode" for repeated exceptions
                 _logger.LogError(ex, "An unknown exception occurred while polling {SubscriberEndpoint}", _configuration.SubscriberEndpoint);
+
+                // Rethrow the exception to fail fast for invalid configuration, permissioning, etc.
+                // TODO: explore a "cool down mode" for repeated exceptions
+                if (_configuration.IsExceptionFatal(ex))
+                {
+                    throw;
+                }
             }
 
             if (receivedMessages is null)
@@ -267,7 +274,7 @@ internal class SQSMessagePoller : IMessagePoller, ISQSMessageCommunication
                 string.Join(", ", messages.Select(x => x.Id)), _configuration.SubscriberEndpoint);
 
             // Rethrow the exception to fail fast for invalid configuration, permissioning, etc.
-            if (_configuration.IsSQSExceptionFatal(ex))
+            if (_configuration.IsExceptionFatal(ex))
             {
                 throw;
             }
@@ -275,6 +282,12 @@ internal class SQSMessagePoller : IMessagePoller, ISQSMessageCommunication
         catch (Exception ex)
         {
             _logger.LogError(ex, "An unexpected exception occurred while deleting messages from queue {SubscriberEndpoint}", _configuration.SubscriberEndpoint);
+
+            // Rethrow the exception to fail fast for invalid configuration, permissioning, etc.
+            if (_configuration.IsExceptionFatal(ex))
+            {
+                throw;
+            }
         }
     }
 
@@ -373,7 +386,7 @@ internal class SQSMessagePoller : IMessagePoller, ISQSMessageCommunication
                         string.Join(", ", messages.Select(x => x.Id)), _configuration.SubscriberEndpoint);
 
                     // Rethrow the exception to fail fast for invalid configuration, permissioning, etc.
-                    if (_configuration.IsSQSExceptionFatal(amazonEx))
+                    if (_configuration.IsExceptionFatal(amazonEx))
                     {
                         throw amazonEx;
                     }
@@ -381,6 +394,12 @@ internal class SQSMessagePoller : IMessagePoller, ISQSMessageCommunication
                 else if (changeMessageVisibilityBatchTask.Exception?.InnerException is Exception ex)
                 {
                     _logger.LogError(ex, "An unexpected exception occurred while extending message visibility on queue {SubscriberEndpoint}", _configuration.SubscriberEndpoint);
+
+                    // Rethrow the exception to fail fast for invalid configuration, permissioning, etc.
+                    if (_configuration.IsExceptionFatal(ex))
+                    {
+                        throw ex;
+                    }
                 }
             }
         }
@@ -392,5 +411,4 @@ internal class SQSMessagePoller : IMessagePoller, ISQSMessageCommunication
     {
         return ValueTask.CompletedTask;
     }
-      
 }


### PR DESCRIPTION
*Issue #, if available:* DOTNET-6819

*Description of changes:*
1. **BREAKING CHANGE**: Replaces `IsSQSExceptionFatal` with a more generic `IsExceptionFatal` to let users categorize non-SQS exceptions too.
    * I think the increased flexibility is worth the breaking change while we're still in preview, but let me know if you disagree.
2. Expands the list of exceptions derived from `AmazonSQSException` that we treat as fatal.
3. Classifies some of our own `AWSMessagingExceptions` as fatal.

My philosophy when classifying exceptions was:
* Anything that would likely always be unsuccessful should be fatal (e.g. invalid queue URL, inadequate permissions, invalid framework configuration)
* Anything either temporary (e.g. throttling) or on a per-message basis (e.g. deserialization) are non-fatal. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
