### PR TITLE
docs: Improve documentation and examples around IMessagePublisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ public class PublisherController : ControllerBase
             return BadRequest("The MessageDescription cannot be null or empty.");
         }
 
-        // Publish the ChatMessage to SQS using the injected ISQSPublisher, with SQS-specific options
+        // Send the ChatMessage to SQS using the injected ISQSPublisher, with SQS-specific options
         await _sqsPublisher.SendAsync(message, new SQSOptions
         {
             DelaySeconds = <delay-in-seconds>,

--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ builder.Services.AddAWSMessageBus(builder =>
 });
 ```
 
-Once you have registered the framework during startup, inject the `IMessagePublisher` into your code and call its `PublishAsync` method to publish a message. In the following example, an ASP.NET MVC controller receives a `ChatMessage` from the user and then publishes that same object to SQS.
+Once you have registered the framework during startup, inject the generic `IMessagePublisher` into your code. Call its `PublishAsync` method to publish any of the message types that were configured above. The generic publisher will determine the destination to route the message to based on its type.
+
+In the following example, an ASP.NET MVC controller receives both `ChatMessage` messages and `OrderInfo` events from users, and then publishes them to SQS and SNS respectively.
 
 ```csharp
 [ApiController]
@@ -92,7 +94,21 @@ public class PublisherController : ControllerBase
             return BadRequest("The MessageDescription cannot be null or empty.");
         }
 
-        // Publish the message to SQS, using the injected IMessagePublisher
+        // Publish the ChatMessage to SQS, using the generic publisher
+        await _messagePublisher.PublishAsync(message);
+
+        return Ok();
+    }
+
+    [HttpPost("order", Name = "Order")]
+    public async Task<IActionResult> PublishOrder([FromBody] OrderInfo message)
+    {
+        if (message == null)
+        {
+            return BadRequest("An order was not submitted.");
+        }
+
+        // Publish the OrderInfo to SNS, using the generic publisher
         await _messagePublisher.PublishAsync(message);
 
         return Ok();
@@ -101,7 +117,7 @@ public class PublisherController : ControllerBase
 ```
 ## Service-specific publishers
 
-The  example shown above uses the generic `IMessagePublisher`, which can publish to any supported AWS service based on the configured message type. The framework also provides *service-specific publishers* for SQS, SNS and EventBridge. These specific publishers expose options that only apply to that service, and can be injected using the types `ISQSPublisher`, `ISNSPublisher` and `IEventBridgePublisher`. 
+The example shown above uses the generic `IMessagePublisher`, which can publish to any supported AWS service based on the configured message type. The framework also provides *service-specific publishers* for SQS, SNS and EventBridge. These specific publishers expose options that only apply to that service, and can be injected using the types `ISQSPublisher`, `ISNSPublisher` and `IEventBridgePublisher`. 
 
 For example, when publishing messages to an SQS FIFO queue, you must set the appropriate [message group ID](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-key-terms.html). The following code shows the `ChatMessage` example again, but now using an `ISQSPublisher` to set SQS-specific options.
 ```csharp
@@ -127,7 +143,7 @@ public class PublisherController : ControllerBase
             return BadRequest("The MessageDescription cannot be null or empty.");
         }
 
-        // Publish the message to SQS using the injected ISQSPublisher, with SQS-specific options
+        // Publish the ChatMessage to SQS using the injected ISQSPublisher, with SQS-specific options
         await _sqsPublisher.SendAsync(message, new SQSOptions
         {
             DelaySeconds = <delay-in-seconds>,

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ builder.Services.AddAWSMessageBus(builder =>
 
 Once you have registered the framework during startup, inject the generic `IMessagePublisher` into your code. Call its `PublishAsync` method to publish any of the message types that were configured above. The generic publisher will determine the destination to route the message to based on its type.
 
-In the following example, an ASP.NET MVC controller receives both `ChatMessage` messages and `OrderInfo` events from users, and then publishes them to SQS and SNS respectively.
+In the following example, an ASP.NET MVC controller receives both `ChatMessage` messages and `OrderInfo` events from users, and then publishes them to SQS and SNS respectively. Both message types can be published using the generic publisher that was configured above.
 
 ```csharp
 [ApiController]

--- a/sampleapps/PublisherAPI/Controllers/PublisherController.cs
+++ b/sampleapps/PublisherAPI/Controllers/PublisherController.cs
@@ -21,7 +21,7 @@ public class PublisherController : ControllerBase
 
     /// <summary>
     /// SQS-specific publisher to use when you need to set SQS-specific options,
-    /// such as when publishing to a FIFO queue so that you can set the message group ID.
+    /// such as when sending to a FIFO queue so that you can set the message group ID.
     /// </summary>
     private readonly ISQSPublisher _sqsPublisher;
 

--- a/sampleapps/PublisherAPI/Controllers/PublisherController.cs
+++ b/sampleapps/PublisherAPI/Controllers/PublisherController.cs
@@ -20,14 +20,14 @@ public class PublisherController : ControllerBase
     private readonly IMessagePublisher _messagePublisher;
 
     /// <summary>
-    /// SQS-specific publisher to use when publishing to a 
-    /// FIFO queue below so that you can set the message group ID.
+    /// SQS-specific publisher to use when you need to set SQS-specific options,
+    /// such as when publishing to a FIFO queue so that you can set the message group ID.
     /// </summary>
     private readonly ISQSPublisher _sqsPublisher;
 
     /// <summary>
-    /// SNS-specific publisher to use when publishing to a 
-    /// FIFO topic below so that you can set the message group ID.
+    /// SNS-specific publisher to use when you need to set SNS-specific options,
+    /// such as when publishing to a FIFO topic so that you can set the message group ID.
     /// </summary>
     private readonly ISNSPublisher _snsPublisher;
 

--- a/sampleapps/PublisherAPI/Controllers/PublisherController.cs
+++ b/sampleapps/PublisherAPI/Controllers/PublisherController.cs
@@ -13,8 +13,22 @@ namespace PublisherAPI.Controllers;
 [Route("[controller]")]
 public class PublisherController : ControllerBase
 {
+    /// <summary>
+    /// Generic publisher, which you can use to publish any of the configured
+    /// message types when you don't need to specify any service-specific options.
+    /// </summary>
     private readonly IMessagePublisher _messagePublisher;
+
+    /// <summary>
+    /// SQS-specific publisher to use when publishing to a 
+    /// FIFO queue below so that you can set the message group ID.
+    /// </summary>
     private readonly ISQSPublisher _sqsPublisher;
+
+    /// <summary>
+    /// SNS-specific publisher to use when publishing to a 
+    /// FIFO topic below so that you can set the message group ID.
+    /// </summary>
     private readonly ISNSPublisher _snsPublisher;
 
     public PublisherController(IMessagePublisher messagePublisher, ISQSPublisher sqsPubliser, ISNSPublisher snsPublisher)
@@ -36,6 +50,7 @@ public class PublisherController : ControllerBase
             return BadRequest("The MessageDescription cannot be null or empty.");
         }
 
+        // Publish using the generic publisher
         await _messagePublisher.PublishAsync(message);
 
         return Ok();
@@ -53,6 +68,7 @@ public class PublisherController : ControllerBase
             return BadRequest("The MessageDescription cannot be null or empty.");
         }
 
+        // Publish using the generic publisher
         await _messagePublisher.PublishAsync(message);
 
         return Ok();
@@ -70,6 +86,7 @@ public class PublisherController : ControllerBase
             return BadRequest("The MessageDescription cannot be null or empty.");
         }
 
+        // Publish using the generic publisher
         await _messagePublisher.PublishAsync(message);
 
         return Ok();
@@ -87,6 +104,8 @@ public class PublisherController : ControllerBase
             return BadRequest("The TransactionId cannot be null or empty.");
         }
 
+        // TransactionInfo messages are mapped to a FIFO queue, so use the
+        // SQS-specific publisher which allows setting the message group ID.
         await _sqsPublisher.SendAsync(transactionInfo, new SQSOptions
         {
             MessageGroupId = "group-123"
@@ -107,6 +126,8 @@ public class PublisherController : ControllerBase
             return BadRequest("The BidId cannot be null or empty.");
         }
 
+        // BidInfo messages are mapped to a FIFO SNS topic, so use the
+        // SNS-specific publisher which allows setting the message group ID.
         await _snsPublisher.PublishAsync(bidInfo, new SNSOptions
         {
             MessageGroupId = "group-123"

--- a/src/AWS.Messaging/IMessagePublisher.cs
+++ b/src/AWS.Messaging/IMessagePublisher.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using AWS.Messaging.Configuration;
+using AWS.Messaging.Publishers.SQS;
 
 namespace AWS.Messaging;
 
@@ -11,6 +12,11 @@ namespace AWS.Messaging;
 /// and looks up the corresponding <see cref="PublisherMapping"/> in order to route it to the appropriate AWS services.
 /// Using dependency injection, this interface is available to inject anywhere in the code.
 /// </summary>
+/// <remarks>
+/// This is the generic publisher, which can publish multiple message types to any of the 
+/// supported AWS services. To set service-specific options when publishing, use the service-specific
+/// publisher interface (such as <see cref="ISQSPublisher"/> for SQS) instead.
+/// </remarks>
 public interface IMessagePublisher
 {
     /// <summary>


### PR DESCRIPTION
*Issue #, if available:* #61, DOTNET-7334

*Description of changes:* This expands the documentation, examples, and README content for `IMessagePublisher` to clarify that it can be used to publish multiple message types to multiple services.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
