### PR TITLE
chore: follow design patterns for publishers

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ public class PublisherController : ControllerBase
         }
 
         // Publish the message to SQS using the injected ISQSPublisher, with SQS-specific options
-        await _sqsPublisher.PublishAsync(message, new SQSOptions
+        await _sqsPublisher.SendAsync(message, new SQSOptions
         {
             DelaySeconds = <delay-in-seconds>,
             MessageAttributes = <message-attributes>,

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -104,7 +104,7 @@ public class PublisherController : ControllerBase
         }
 
         // Publish the message to SQS using the injected ISQSPublisher, with SQS-specific options
-        await _sqsPublisher.PublishAsync(message, new SQSOptions
+        await _sqsPublisher.SendAsync(message, new SQSOptions
         {
             DelaySeconds = <delay-in-seconds>,
             MessageAttributes = <message-attributes>,

--- a/sampleapps/PublisherAPI/Controllers/PublisherController.cs
+++ b/sampleapps/PublisherAPI/Controllers/PublisherController.cs
@@ -57,7 +57,7 @@ public class PublisherController : ControllerBase
 
         return Ok();
     }
-    
+
     [HttpPost("fooditem", Name = "Food Item")]
     public async Task<IActionResult> PublishFoodItem([FromBody] FoodItem message)
     {
@@ -87,7 +87,7 @@ public class PublisherController : ControllerBase
             return BadRequest("The TransactionId cannot be null or empty.");
         }
 
-        await _sqsPublisher.PublishAsync(transactionInfo, new SQSOptions
+        await _sqsPublisher.SendAsync(transactionInfo, new SQSOptions
         {
             MessageGroupId = "group-123"
         });

--- a/src/AWS.Messaging/Publishers/EventBridge/IEventBridgePublisher.cs
+++ b/src/AWS.Messaging/Publishers/EventBridge/IEventBridgePublisher.cs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using AWS.Messaging.Services;
+
 namespace AWS.Messaging.Publishers.EventBridge
 {
     /// <summary>
@@ -8,7 +10,7 @@ namespace AWS.Messaging.Publishers.EventBridge
     /// It exposes the <see cref="PublishAsync{T}(T, EventBridgeOptions?, CancellationToken)"/> method which takes in a user-defined message, and <see cref="EventBridgeOptions"/> to set additonal parameters while publishing messages to EventBridge.
     /// Using dependency injection, this interface is available to inject anywhere in the code.
     /// </summary>
-    public interface IEventBridgePublisher
+    public interface IEventBridgePublisher : IEventPublisher
     {
         /// <summary>
         /// Publishes the application message to SNS.

--- a/src/AWS.Messaging/Publishers/SNS/ISNSPublisher.cs
+++ b/src/AWS.Messaging/Publishers/SNS/ISNSPublisher.cs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using AWS.Messaging.Services;
+
 namespace AWS.Messaging.Publishers.SNS
 {
     /// <summary>
@@ -8,7 +10,7 @@ namespace AWS.Messaging.Publishers.SNS
     /// It exposes the <see cref="PublishAsync{T}(T, SNSOptions?, CancellationToken)"/> method which takes in a user-defined message, and <see cref="SNSOptions"/> to set additonal parameters while publishing messages to SNS.
     /// Using dependency injection, this interface is available to inject anywhere in the code.
     /// </summary>
-    public interface ISNSPublisher
+    public interface ISNSPublisher : IEventPublisher
     {
         /// <summary>
         /// Publishes the application message to SNS.

--- a/src/AWS.Messaging/Publishers/SQS/ISQSPublisher.cs
+++ b/src/AWS.Messaging/Publishers/SQS/ISQSPublisher.cs
@@ -1,21 +1,23 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using AWS.Messaging.Services;
+
 namespace AWS.Messaging.Publishers.SQS
 {
     /// <summary>
-    /// This interface allows publishing messages from application code to Amazon SQS.
-    /// It exposes the <see cref="PublishAsync{T}(T, SQSOptions?, CancellationToken)"/> method which takes in a user-defined message, and <see cref="SQSOptions"/> to set additonal parameters while publishing messages to SQS.
+    /// This interface allows sending messages from application code to Amazon SQS.
+    /// It exposes the <see cref="SendAsync{T}(T, SQSOptions?, CancellationToken)"/> method which takes in a user-defined message, and <see cref="SQSOptions"/> to set additional parameters while sending messages to SQS.
     /// Using dependency injection, this interface is available to inject anywhere in the code.
     /// </summary>
-    public interface ISQSPublisher
+    public interface ISQSPublisher : ICommandPublisher
     {
         /// <summary>
-        /// Publishes the application message to SQS.
+        /// Sends the application message to SQS.
         /// </summary>
         /// <param name="message">The application message that will be serialized and sent to an SQS queue</param>
         /// <param name="sqsOptions">Contains additional parameters that can be set while sending a message to an SQS queue</param>
         /// <param name="token">The cancellation token used to cancel the request.</param>
-        Task PublishAsync<T>(T message, SQSOptions? sqsOptions, CancellationToken token = default);
+        Task SendAsync<T>(T message, SQSOptions? sqsOptions, CancellationToken token = default);
     }
 }

--- a/src/AWS.Messaging/Publishers/SQS/SQSPublisher.cs
+++ b/src/AWS.Messaging/Publishers/SQS/SQSPublisher.cs
@@ -11,12 +11,12 @@ using Microsoft.Extensions.Logging;
 namespace AWS.Messaging.Publishers.SQS;
 
 /// <summary>
-/// The SQS message publisher allows publishing messages to AWS SQS.
+/// The SQS message publisher allows sending messages to AWS SQS.
 /// </summary>
-internal class SQSPublisher : IMessagePublisher, ISQSPublisher
+internal class SQSPublisher : ISQSPublisher
 {
     private readonly IAWSClientProvider _awsClientProvider;
-    private readonly ILogger<IMessagePublisher> _logger;
+    private readonly ILogger<ISQSPublisher> _logger;
     private readonly IMessageConfiguration _messageConfiguration;
     private readonly IEnvelopeSerializer _envelopeSerializer;
     private readonly ITelemetryFactory _telemetryFactory;
@@ -29,7 +29,7 @@ internal class SQSPublisher : IMessagePublisher, ISQSPublisher
     /// </summary>
     public SQSPublisher(
         IAWSClientProvider awsClientProvider,
-        ILogger<IMessagePublisher> logger,
+        ILogger<ISQSPublisher> logger,
         IMessageConfiguration messageConfiguration,
         IEnvelopeSerializer envelopeSerializer,
         ITelemetryFactory telemetryFactory)
@@ -48,9 +48,9 @@ internal class SQSPublisher : IMessagePublisher, ISQSPublisher
     /// <param name="token">The cancellation token used to cancel the request.</param>
     /// <exception cref="InvalidMessageException">If the message is null or invalid.</exception>
     /// <exception cref="MissingMessageTypeConfigurationException">If cannot find the publisher configuration for the message type.</exception>
-    public async Task PublishAsync<T>(T message, CancellationToken token = default)
+    public async Task SendAsync<T>(T message, CancellationToken token = default)
     {
-        await PublishAsync(message, null, token);
+        await SendAsync(message, null, token);
     }
 
     /// <summary>
@@ -61,7 +61,7 @@ internal class SQSPublisher : IMessagePublisher, ISQSPublisher
     /// <param name="token">The cancellation token used to cancel the request.</param>
     /// <exception cref="InvalidMessageException">If the message is null or invalid.</exception>
     /// <exception cref="MissingMessageTypeConfigurationException">If cannot find the publisher configuration for the message type.</exception>
-    public async Task PublishAsync<T>(T message, SQSOptions? sqsOptions, CancellationToken token = default)
+    public async Task SendAsync<T>(T message, SQSOptions? sqsOptions, CancellationToken token = default)
     {
         using (var trace = _telemetryFactory.Trace("Publish to AWS SQS"))
         {
@@ -127,9 +127,9 @@ internal class SQSPublisher : IMessagePublisher, ISQSPublisher
         if (queueUrl.EndsWith(FIFO_SUFFIX) && string.IsNullOrEmpty(sqsOptions?.MessageGroupId))
         {
             var errorMessage =
-                $"You are attempting to publish to a FIFO SQS queue but the request does not include a message group ID. " +
-                $"Please use {nameof(ISQSPublisher)} from the service collection to publish to FIFO queues. " +
-                $"It exposes a {nameof(PublishAsync)} method that accepts {nameof(SQSOptions)} as a parameter. " +
+                $"You are attempting to send to a FIFO SQS queue but the request does not include a message group ID. " +
+                $"Please use {nameof(ISQSPublisher)} from the service collection to send to FIFO queues. " +
+                $"It exposes a {nameof(SendAsync)} method that accepts {nameof(SQSOptions)} as a parameter. " +
                 $"A message group ID must be specified via {nameof(SQSOptions.MessageGroupId)}. " +
                 $"Additionally, {nameof(SQSOptions.MessageDeduplicationId)} must also be specified if content based de-duplication is not enabled on the queue.";
 

--- a/src/AWS.Messaging/Services/ICommandPublisher.cs
+++ b/src/AWS.Messaging/Services/ICommandPublisher.cs
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Services;
+
+/// <summary>
+/// This interface allows sending messages from application code to recipient-specific Amazon services.
+/// It exposes the <see cref="SendAsync{T}(T, CancellationToken)"/> method which takes in a user-defined message to send to a recipient-specific Amazon service.
+/// </summary>
+public interface ICommandPublisher
+{
+    /// <summary>
+    /// Sends the application message to a recipient-specific Amazon service.
+    /// </summary>
+    /// <param name="message">The application message that will be serialized and sent.</param>
+    /// <param name="token">The cancellation token used to cancel the request.</param>
+    Task SendAsync<T>(T message, CancellationToken token = default);
+}

--- a/src/AWS.Messaging/Services/IEventPublisher.cs
+++ b/src/AWS.Messaging/Services/IEventPublisher.cs
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Services;
+
+/// <summary>
+/// This interface allows publishing messages from application code to event-based Amazon services.
+/// It exposes the <see cref="PublishAsync{T}(T, CancellationToken)"/> method which takes in a user-defined message to publish to an event-based Amazon service.
+/// </summary>
+public interface IEventPublisher
+{
+    /// <summary>
+    /// Publishes the application message to an event-based Amazon service.
+    /// </summary>
+    /// <param name="message">The application message that will be serialized and published.</param>
+    /// <param name="token">The cancellation token used to cancel the request.</param>
+    Task PublishAsync<T>(T message, CancellationToken token = default);
+}

--- a/test/AWS.Messaging.Benchmarks/Program.cs
+++ b/test/AWS.Messaging.Benchmarks/Program.cs
@@ -155,7 +155,7 @@ internal class Program
         {
             DisplayData(benchmarkCollector.PublishTimes, publishElapsedTime, numberOfMessages, "Publishing");
             DisplayData(benchmarkCollector.ReceptionTimes, handlingElapsedTime, numberOfMessages, "Receiving");
-        }     
+        }
 
         host.Dispose();
         return benchmarkCollector;
@@ -218,7 +218,7 @@ internal class Program
         await Parallel.ForEachAsync(Enumerable.Range(0, messageCount), options, async (messageNumber, token) =>
         {
             var start = stopwatch.Elapsed;
-            await publisher.PublishAsync(new BenchmarkMessage { SentTime = DateTime.UtcNow }, null, token);
+            await publisher.SendAsync(new BenchmarkMessage { SentTime = DateTime.UtcNow }, null, token);
             var publishDuration = stopwatch.Elapsed - start;
 
             benchmarkCollector.RecordMessagePublish(publishDuration);

--- a/test/AWS.Messaging.IntegrationTests/FifoSubscriberTests.cs
+++ b/test/AWS.Messaging.IntegrationTests/FifoSubscriberTests.cs
@@ -234,7 +234,7 @@ public class FifoSubscriberTests : IAsyncLifetime
                 transactionInfo.ShouldFail = true;
             }
 
-            await sqsPublisher.PublishAsync(transactionInfo, new SQSOptions
+            await sqsPublisher.SendAsync(transactionInfo, new SQSOptions
             {
                 MessageGroupId = userId
             });

--- a/test/AWS.Messaging.IntegrationTests/LambdaTests.cs
+++ b/test/AWS.Messaging.IntegrationTests/LambdaTests.cs
@@ -439,7 +439,7 @@ public class LambdaFifoTests : IAsyncLifetime
 
                 expectedMessagesPerGroup[groupId].Add(transactionInfo);
 
-                await _publisher!.PublishAsync(transactionInfo, new SQSOptions
+                await _publisher!.SendAsync(transactionInfo, new SQSOptions
                 {
                     MessageGroupId = groupId
                 });


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7370, #89 

*Description of changes:*
* Add `ICommandPublisher` and `IEventPublisher` to represent publishers that send to specific recipients and publishers that publish to unknown recipients. This was needed to allow extending publishers in the future and adding more of them. A command publisher has a `SendAsync` while an event publisher has a `PublishAsync`.
* Updated tests, sample apps and docs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
