### PR TITLE
Update AWS.Messaging version for 0.2.0-beta

### DIFF
--- a/src/AWS.Messaging/AWS.Messaging.csproj
+++ b/src/AWS.Messaging/AWS.Messaging.csproj
@@ -17,7 +17,7 @@
     <WarningsAsErrors>CA1727</WarningsAsErrors>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\public.snk</AssemblyOriginatorKeyFile>
-    <Version>0.1.0-beta</Version>
+    <Version>0.2.0-beta</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Preparing for a release of what we have staged on `dev`

Proposed changelog:
* BREAKING CHANGE: Message content is no longer included by default in logs or exceptions. Call `EnableDataMessageLogging` during setup to re-enable.
* BREAKING CHANGE: Replaced `IsSQSExceptionFatal` with `IsExceptionFatal` to allow classifying a broader range of exceptions. Expanded the default list of fatal exceptions.
* BREAKING CHANGE: Renamed `PublishAsync` to `SendAsync on the SQS-specific publisher, and create separate interface definitions to clarify "publishing" vs. "sending" depending on the destination service.
* Allow overriding the destination and AWS service client on the service-specific publishers. This allows you to set the destination and credentials on a per-message basis, which may be useful for multi-tenant applications.
* Improved validation on ECS task metadata when deriving the default value for the message source on ECS.
* Improved documentation and examples around `IMessagePublisher`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
