### PR TITLE
feat: add backoff logic to the SQS Poller

### DIFF
--- a/AWS.Messaging.sln
+++ b/AWS.Messaging.sln
@@ -37,6 +37,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWS.Messaging.Tests.LambdaF
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWS.Messaging.Benchmarks", "test\AWS.Messaging.Benchmarks\AWS.Messaging.Benchmarks.csproj", "{143DC3E0-A1C6-4670-86F4-E7CD4C8F52CB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PollyIntegration", "sampleapps\PollyIntegration\PollyIntegration.csproj", "{86896246-B032-4D34-82BE-CD5ACB6E43F9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -87,6 +89,10 @@ Global
 		{143DC3E0-A1C6-4670-86F4-E7CD4C8F52CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{143DC3E0-A1C6-4670-86F4-E7CD4C8F52CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{143DC3E0-A1C6-4670-86F4-E7CD4C8F52CB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{86896246-B032-4D34-82BE-CD5ACB6E43F9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86896246-B032-4D34-82BE-CD5ACB6E43F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86896246-B032-4D34-82BE-CD5ACB6E43F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{86896246-B032-4D34-82BE-CD5ACB6E43F9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -103,6 +109,7 @@ Global
 		{C529DC6E-72DA-49ED-908A-21DBC40F26C0} = {2D0A561B-0B97-4259-8603-3AF5437BB652}
 		{F7A1B9DE-86DE-4F70-A2CD-628E56FE5BAD} = {80DB2C77-6ADD-4A60-B27D-763BDF9659D3}
 		{143DC3E0-A1C6-4670-86F4-E7CD4C8F52CB} = {80DB2C77-6ADD-4A60-B27D-763BDF9659D3}
+		{86896246-B032-4D34-82BE-CD5ACB6E43F9} = {1AA8985B-897C-4BD5-9735-FD8B33FEBFFB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7B2B759D-6455-4089-8173-3F1619567B36}

--- a/README.md
+++ b/README.md
@@ -316,13 +316,13 @@ services.AddAWSMessageBus(builder =>
         // Interval backoff policy
         options.UseIntervalBackoff(x =>
         {
-            x.FixedInterval = 1000;
+            x.FixedInterval = 1;
         });
 
         // Capped exponential backoff policy
         options.UseCappedExponentialBackoff(x =>
         {
-            x.CapBackoffTime = 3600000;
+            x.CapBackoffTime = 3600;
         });
     });
 });

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ services.AddAWSMessageBus(builder =>
         // Capped exponential backoff policy
         options.UseCappedExponentialBackoff(x =>
         {
-            x.CapBackoffTime = 3600;
+            x.CapBackoffTime = 60;
         });
     });
 });

--- a/sampleapps/PollyIntegration/MessageHandlers/ChatMessageHandler.cs
+++ b/sampleapps/PollyIntegration/MessageHandlers/ChatMessageHandler.cs
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Messaging;
+using PollyIntegration.Models;
+
+namespace PollyIntegration.MessageHandlers;
+
+public class ChatMessageHandler : IMessageHandler<ChatMessage>
+{
+    public Task<MessageProcessStatus> HandleAsync(MessageEnvelope<ChatMessage> messageEnvelope, CancellationToken token = default)
+    {
+        if (messageEnvelope == null)
+        {
+            return Task.FromResult(MessageProcessStatus.Failed());
+        }
+
+        if (messageEnvelope.Message == null)
+        {
+            return Task.FromResult(MessageProcessStatus.Failed());
+        }
+
+        var message = messageEnvelope.Message;
+
+        Console.WriteLine($"Message Description: {message.MessageDescription}");
+
+        return Task.FromResult(MessageProcessStatus.Success());
+    }
+}

--- a/sampleapps/PollyIntegration/Models/ChatMessage.cs
+++ b/sampleapps/PollyIntegration/Models/ChatMessage.cs
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+namespace PollyIntegration.Models;
+
+public class ChatMessage
+{
+    public string MessageDescription { get; set; } = string.Empty;
+}

--- a/sampleapps/PollyIntegration/PollyBackoffHandler.cs
+++ b/sampleapps/PollyIntegration/PollyBackoffHandler.cs
@@ -17,15 +17,12 @@ public class PollyBackoffHandler : IBackoffHandler
         _resiliencePipelineProvider = resiliencePipelineProvider;
     }
 
-    public async Task BackoffAsync(Func<Task> task, SQSMessagePollerConfiguration configuration, CancellationToken token)
+    public async Task<T> BackoffAsync<T>(Func<Task<T>> task, SQSMessagePollerConfiguration configuration, CancellationToken token)
     {
         ResiliencePipeline pipeline = _resiliencePipelineProvider.GetPipeline("my-pipeline");
 
         // Execute the pipeline
-        await pipeline.ExecuteAsync(async cancellationToken =>
-            {
-                await task.Invoke();
-            },
+        return await pipeline.ExecuteAsync(async cancellationToken => await task.Invoke(),
             token);
     }
 }

--- a/sampleapps/PollyIntegration/PollyBackoffHandler.cs
+++ b/sampleapps/PollyIntegration/PollyBackoffHandler.cs
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Messaging.Configuration;
+using AWS.Messaging.Services.Backoff;
+using Polly;
+using Polly.Registry;
+
+namespace PollyIntegration;
+
+public class PollyBackoffHandler : IBackoffHandler
+{
+    private readonly ResiliencePipelineProvider<string> _resiliencePipelineProvider;
+
+    public PollyBackoffHandler(ResiliencePipelineProvider<string> resiliencePipelineProvider)
+    {
+        _resiliencePipelineProvider = resiliencePipelineProvider;
+    }
+
+    public async Task BackoffAsync(Func<Task> task, SQSMessagePollerConfiguration configuration, CancellationToken token)
+    {
+        ResiliencePipeline pipeline = _resiliencePipelineProvider.GetPipeline("my-pipeline");
+
+        // Execute the pipeline
+        await pipeline.ExecuteAsync(async cancellationToken =>
+            {
+                await task.Invoke();
+            },
+            token);
+    }
+}

--- a/sampleapps/PollyIntegration/PollyIntegration.csproj
+++ b/sampleapps/PollyIntegration/PollyIntegration.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <None Remove="appsettings.json" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="appsettings.json">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.*" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.6.0" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
+        <PackageReference Include="Polly.Core" Version="8.1.0" />
+        <PackageReference Include="Polly.Extensions" Version="8.1.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\AWS.Messaging.Telemetry.OpenTelemetry\AWS.Messaging.Telemetry.OpenTelemetry.csproj" />
+        <ProjectReference Include="..\..\src\AWS.Messaging\AWS.Messaging.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/sampleapps/PollyIntegration/Program.cs
+++ b/sampleapps/PollyIntegration/Program.cs
@@ -1,0 +1,55 @@
+﻿using AWS.Messaging.Services.Backoff;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using AWS.Messaging.Telemetry.OpenTelemetry;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using Polly;
+using Polly.Retry;
+using PollyIntegration;
+using PollyIntegration.MessageHandlers;
+using PollyIntegration.Models;
+
+await Host.CreateDefaultBuilder(args)
+    .ConfigureLogging(logging =>
+    {
+        logging.ClearProviders();
+        logging.AddConsole().SetMinimumLevel(LogLevel.Debug);
+    })
+    .ConfigureAppConfiguration(configuration =>
+    {
+        configuration.AddJsonFile("appsettings.json");
+    })
+    .ConfigureServices((context, services) =>
+    {
+        services.AddResiliencePipeline("my-pipeline", builder =>
+        {
+            builder
+                .AddRetry(new RetryStrategyOptions())
+                .AddTimeout(TimeSpan.FromSeconds(10));
+        });
+
+        services.TryAddSingleton<IBackoffHandler, PollyBackoffHandler>();
+
+        services.AddAWSMessageBus(builder =>
+            {
+                // To load the configuration from appsettings.json instead of the code below, uncomment this and remove the following lines.
+                // builder.LoadConfigurationFromSettings(context.Configuration);
+
+                builder.AddSQSPoller("https://sqs.us-west-2.amazonaws.com/012345678910/MPF");
+                builder.AddMessageHandler<ChatMessageHandler, ChatMessage>("chatMessage");
+
+                // Logging data messages is disabled by default to protect sensitive user data. If you want this enabled, uncomment the line below.
+                // builder.EnableMessageContentLogging();
+            })
+            .AddOpenTelemetry()
+            .ConfigureResource(resource => resource.AddService("PollyIntegration"))
+            .WithTracing(tracing => tracing
+                .AddAWSMessagingInstrumentation()
+                .AddConsoleExporter());
+    })
+    .Build()
+    .RunAsync();

--- a/sampleapps/PollyIntegration/appsettings.json
+++ b/sampleapps/PollyIntegration/appsettings.json
@@ -1,0 +1,27 @@
+{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    },
+    "AllowedHosts": "*",
+    "AWS.Messaging": {
+        "MessageHandlers": [
+            {
+                "HandlerType": "PollyIntegration.MessageHandlers.ChatMessageHandler",
+                "MessageType": "PollyIntegration.Models.ChatMessage",
+                "MessageTypeIdentifier": "chatMessage"
+            }
+        ],
+        "SQSPollers": [
+            {
+                "QueueUrl": "https://sqs.us-west-2.amazonaws.com/012345678910/MPF"
+            }
+        ],
+        "BackoffPolicy": "CappedExponential",
+        "CappedExponentialBackoffOptions": {
+            "CapBackoffTime": 2000
+        }
+    }
+}

--- a/sampleapps/PollyIntegration/appsettings.json
+++ b/sampleapps/PollyIntegration/appsettings.json
@@ -21,7 +21,7 @@
         ],
         "BackoffPolicy": "CappedExponential",
         "CappedExponentialBackoffOptions": {
-            "CapBackoffTime": 2000
+            "CapBackoffTime": 2
         }
     }
 }

--- a/sampleapps/PublisherAPI/Program.cs
+++ b/sampleapps/PublisherAPI/Program.cs
@@ -34,7 +34,7 @@ builder.Services.AddAWSMessageBus(bus =>
     });
 
     // Logging data messages is disabled by default to protect sensitive user data. If you want this enabled, uncomment the line below.
-    // builder.EnableDataMessageLogging();
+    // bus.EnableMessageContentLogging();
 });
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();

--- a/sampleapps/PublisherAPI/appsettings.json
+++ b/sampleapps/PublisherAPI/appsettings.json
@@ -41,6 +41,7 @@
                 }
             }
         ],
-        "LogMessageContent": false
+        "LogMessageContent": false,
+        "BackoffPolicy": "CappedExponential"
     }
 }

--- a/sampleapps/SubscriberService/Program.cs
+++ b/sampleapps/SubscriberService/Program.cs
@@ -2,9 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Text.Json;
+using Amazon;
+using Amazon.Extensions.NETCore.Setup;
+using Amazon.Runtime;
+using Amazon.SQS;
 using AWS.Messaging.Telemetry.OpenTelemetry;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Resources;
@@ -24,6 +29,16 @@ await Host.CreateDefaultBuilder(args)
     })
     .ConfigureServices((context, services) =>
     {
+        AWSConfigs.LoggingConfig.LogTo = LoggingOptions.Console;
+        AWSConfigs.LoggingConfig.LogMetricsFormat = LogMetricsFormatOption.JSON;
+        AWSConfigs.LoggingConfig.LogResponses = ResponseLoggingOption.Always;
+        AWSConfigs.LoggingConfig.LogMetrics = true;
+
+        var sqsClient = new AmazonSQSClient(new AmazonSQSConfig
+        {
+            MaxErrorRetry = 0
+        });
+        services.TryAddSingleton<IAmazonSQS>(sqsClient);
         services.AddAWSMessageBus(builder =>
         {
             // To load the configuration from appsettings.json instead of the code below, uncomment this and remove the following lines.
@@ -32,22 +47,18 @@ await Host.CreateDefaultBuilder(args)
             builder.AddSQSPoller("https://sqs.us-west-2.amazonaws.com/012345678910/MPF");
             builder.AddMessageHandler<ChatMessageHandler, ChatMessage>("chatMessage");
 
-            builder.ConfigureSerializationOptions(options =>
+            // Optional: Configure the backoff policy used by the SQS Poller.
+            builder.ConfigureBackoffPolicy(options =>
             {
-                options.SystemTextJsonOptions = new JsonSerializerOptions
+                options.UseCappedExponentialBackoff(x =>
                 {
-                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                };
+                    x.CapBackoffTime = 3600000;
+                });
             });
 
             // Logging data messages is disabled by default to protect sensitive user data. If you want this enabled, uncomment the line below.
-            // builder.EnableDataMessageLogging();
-        })
-        .AddOpenTelemetry()
-            .ConfigureResource(resource => resource.AddService("SubscriberService"))
-            .WithTracing(tracing => tracing
-                .AddAWSMessagingInstrumentation()
-                .AddConsoleExporter());
+            // builder.EnableMessageContentLogging();
+        });
     })
     .Build()
     .RunAsync();

--- a/sampleapps/SubscriberService/Program.cs
+++ b/sampleapps/SubscriberService/Program.cs
@@ -45,7 +45,7 @@ await Host.CreateDefaultBuilder(args)
             {
                 options.UseCappedExponentialBackoff(x =>
                 {
-                    x.CapBackoffTime = 3600;
+                    x.CapBackoffTime = 60;
                 });
             });
 

--- a/sampleapps/SubscriberService/Program.cs
+++ b/sampleapps/SubscriberService/Program.cs
@@ -2,14 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Text.Json;
-using Amazon;
-using Amazon.Extensions.NETCore.Setup;
-using Amazon.Runtime;
-using Amazon.SQS;
 using AWS.Messaging.Telemetry.OpenTelemetry;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Resources;
@@ -29,16 +24,6 @@ await Host.CreateDefaultBuilder(args)
     })
     .ConfigureServices((context, services) =>
     {
-        AWSConfigs.LoggingConfig.LogTo = LoggingOptions.Console;
-        AWSConfigs.LoggingConfig.LogMetricsFormat = LogMetricsFormatOption.JSON;
-        AWSConfigs.LoggingConfig.LogResponses = ResponseLoggingOption.Always;
-        AWSConfigs.LoggingConfig.LogMetrics = true;
-
-        var sqsClient = new AmazonSQSClient(new AmazonSQSConfig
-        {
-            MaxErrorRetry = 0
-        });
-        services.TryAddSingleton<IAmazonSQS>(sqsClient);
         services.AddAWSMessageBus(builder =>
         {
             // To load the configuration from appsettings.json instead of the code below, uncomment this and remove the following lines.
@@ -47,18 +32,31 @@ await Host.CreateDefaultBuilder(args)
             builder.AddSQSPoller("https://sqs.us-west-2.amazonaws.com/012345678910/MPF");
             builder.AddMessageHandler<ChatMessageHandler, ChatMessage>("chatMessage");
 
+            builder.ConfigureSerializationOptions(options =>
+            {
+                options.SystemTextJsonOptions = new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                };
+            });
+
             // Optional: Configure the backoff policy used by the SQS Poller.
             builder.ConfigureBackoffPolicy(options =>
             {
                 options.UseCappedExponentialBackoff(x =>
                 {
-                    x.CapBackoffTime = 3600000;
+                    x.CapBackoffTime = 3600;
                 });
             });
 
             // Logging data messages is disabled by default to protect sensitive user data. If you want this enabled, uncomment the line below.
             // builder.EnableMessageContentLogging();
-        });
+        })
+        .AddOpenTelemetry()
+            .ConfigureResource(resource => resource.AddService("SubscriberService"))
+            .WithTracing(tracing => tracing
+                .AddAWSMessagingInstrumentation()
+                .AddConsoleExporter());
     })
     .Build()
     .RunAsync();

--- a/sampleapps/SubscriberService/appsettings.json
+++ b/sampleapps/SubscriberService/appsettings.json
@@ -25,6 +25,7 @@
                     "VisibilityTimeoutExtensionThreshold": 5
                 }
             }
-        ]
+        ],
+        "BackoffPolicy": "CappedExponential"
     }
 }

--- a/src/AWS.Messaging/Configuration/BackoffPolicyBuilder.cs
+++ b/src/AWS.Messaging/Configuration/BackoffPolicyBuilder.cs
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Messaging.Configuration.Internal;
+using AWS.Messaging.Services.Backoff.Policies.Options;
+
+namespace AWS.Messaging.Configuration;
+
+/// <summary>
+/// This builder is used to configure the backoff policy and it's options.
+/// </summary>
+public class BackoffPolicyBuilder : IBackoffPolicyBuilder
+{
+    private readonly MessageConfiguration _messageConfiguration;
+
+    /// <summary>
+    /// Creates an instance of <see cref="BackoffPolicyBuilder"/>.
+    /// </summary>
+    public BackoffPolicyBuilder(MessageConfiguration messageConfiguration)
+    {
+        _messageConfiguration = messageConfiguration;
+    }
+
+    /// <inheritdoc/>
+    public void UseNoBackoff()
+    {
+        _messageConfiguration.BackoffPolicy = BackoffPolicy.None;
+    }
+
+    /// <inheritdoc/>
+    public void UseIntervalBackoff(Action<IntervalBackoffOptions>? options = null)
+    {
+        _messageConfiguration.BackoffPolicy = BackoffPolicy.Interval;
+        options?.Invoke(_messageConfiguration.IntervalBackoffOptions);
+
+        _messageConfiguration.IntervalBackoffOptions.Validate();
+    }
+
+    /// <inheritdoc/>
+    public void UseCappedExponentialBackoff(Action<CappedExponentialBackoffOptions>? options = null)
+    {
+        _messageConfiguration.BackoffPolicy = BackoffPolicy.CappedExponential;
+        options?.Invoke(_messageConfiguration.CappedExponentialBackoffOptions);
+
+        _messageConfiguration.CappedExponentialBackoffOptions.Validate();
+    }
+}

--- a/src/AWS.Messaging/Configuration/BackoffPolicyBuilder.cs
+++ b/src/AWS.Messaging/Configuration/BackoffPolicyBuilder.cs
@@ -7,7 +7,7 @@ using AWS.Messaging.Services.Backoff.Policies.Options;
 namespace AWS.Messaging.Configuration;
 
 /// <summary>
-/// This builder is used to configure the backoff policy and it's options.
+/// This builder is used to configure the backoff policy and its options.
 /// </summary>
 public class BackoffPolicyBuilder : IBackoffPolicyBuilder
 {

--- a/src/AWS.Messaging/Configuration/IBackoffPolicyBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IBackoffPolicyBuilder.cs
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Messaging.Services.Backoff.Policies;
+using AWS.Messaging.Services.Backoff.Policies.Options;
+
+namespace AWS.Messaging.Configuration;
+
+/// <summary>
+/// This builder interface is used to configure the backoff policy and it's options.
+/// </summary>
+public interface IBackoffPolicyBuilder
+{
+    /// <summary>
+    /// Sets the backoff policy to <see cref="NoBackoffPolicy"/>, effectively disabling back-offs.
+    /// </summary>
+    void UseNoBackoff();
+
+    /// <summary>
+    /// Sets the backoff policy to <see cref="IntervalBackoffPolicy"/> and allows it's configuration.
+    /// </summary>
+    void UseIntervalBackoff(Action<IntervalBackoffOptions> options);
+
+    /// <summary>
+    /// Sets the backoff policy to <see cref="CappedExponentialBackoffPolicy"/> and allows it's configuration.
+    /// </summary>
+    void UseCappedExponentialBackoff(Action<CappedExponentialBackoffOptions> options);
+}

--- a/src/AWS.Messaging/Configuration/IBackoffPolicyBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IBackoffPolicyBuilder.cs
@@ -7,7 +7,7 @@ using AWS.Messaging.Services.Backoff.Policies.Options;
 namespace AWS.Messaging.Configuration;
 
 /// <summary>
-/// This builder interface is used to configure the backoff policy and it's options.
+/// This builder interface is used to configure the backoff policy and its options.
 /// </summary>
 public interface IBackoffPolicyBuilder
 {
@@ -17,12 +17,12 @@ public interface IBackoffPolicyBuilder
     void UseNoBackoff();
 
     /// <summary>
-    /// Sets the backoff policy to <see cref="IntervalBackoffPolicy"/> and allows it's configuration.
+    /// Sets the backoff policy to <see cref="IntervalBackoffPolicy"/> and allows its configuration.
     /// </summary>
     void UseIntervalBackoff(Action<IntervalBackoffOptions> options);
 
     /// <summary>
-    /// Sets the backoff policy to <see cref="CappedExponentialBackoffPolicy"/> and allows it's configuration.
+    /// Sets the backoff policy to <see cref="CappedExponentialBackoffPolicy"/> and allows its configuration.
     /// </summary>
     void UseCappedExponentialBackoff(Action<CappedExponentialBackoffOptions> options);
 }

--- a/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
@@ -5,6 +5,7 @@ using AWS.Messaging.Publishers.EventBridge;
 using AWS.Messaging.Publishers.SNS;
 using AWS.Messaging.Publishers.SQS;
 using AWS.Messaging.Serialization;
+using AWS.Messaging.Services.Backoff;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -103,4 +104,9 @@ public interface IMessageBusBuilder
     /// This means any sensitive user data sent by this framework will be visible in logs, any exceptions thrown and others.
     /// </summary>
     IMessageBusBuilder EnableMessageContentLogging();
+
+    /// <summary>
+    /// Configures the backoff policy used by <see cref="BackoffHandler"/> and it's available options.
+    /// </summary>
+    IMessageBusBuilder ConfigureBackoffPolicy(Action<BackoffPolicyBuilder> configure);
 }

--- a/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/IMessageBusBuilder.cs
@@ -106,7 +106,7 @@ public interface IMessageBusBuilder
     IMessageBusBuilder EnableMessageContentLogging();
 
     /// <summary>
-    /// Configures the backoff policy used by <see cref="BackoffHandler"/> and it's available options.
+    /// Configures the backoff policy used by <see cref="BackoffHandler"/> and its available options.
     /// </summary>
     IMessageBusBuilder ConfigureBackoffPolicy(Action<BackoffPolicyBuilder> configure);
 }

--- a/src/AWS.Messaging/Configuration/IMessageConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/IMessageConfiguration.cs
@@ -1,7 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using AWS.Messaging.Configuration.Internal;
 using AWS.Messaging.Serialization;
+using AWS.Messaging.Services.Backoff;
+using AWS.Messaging.Services.Backoff.Policies;
+using AWS.Messaging.Services.Backoff.Policies.Options;
 
 namespace AWS.Messaging.Configuration;
 
@@ -74,4 +78,19 @@ public interface IMessageConfiguration
     /// This means any sensitive user data sent by this framework will be visible in logs, any exceptions thrown and others.
     /// </summary>
     bool LogMessageContent { get; set; }
+
+    /// <summary>
+    /// Sets the Backoff Policy to be used with <see cref="BackoffHandler"/>.
+    /// </summary>
+    BackoffPolicy BackoffPolicy { get; set; }
+
+    /// <summary>
+    /// Holds an instance of <see cref="IntervalBackoffOptions"/> to control the behavior of <see cref="IntervalBackoffPolicy"/>.
+    /// </summary>
+    IntervalBackoffOptions IntervalBackoffOptions { get; }
+
+    /// <summary>
+    /// Holds an instance of <see cref="CappedExponentialBackoffOptions"/> to control the behavior of <see cref="CappedExponentialBackoffPolicy"/>.
+    /// </summary>
+    CappedExponentialBackoffOptions CappedExponentialBackoffOptions { get; }
 }

--- a/src/AWS.Messaging/Configuration/Internal/ApplicationSettings.cs
+++ b/src/AWS.Messaging/Configuration/Internal/ApplicationSettings.cs
@@ -1,6 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using AWS.Messaging.Services.Backoff;
+using AWS.Messaging.Services.Backoff.Policies.Options;
+
 namespace AWS.Messaging.Configuration.Internal;
 
 /// <summary>
@@ -38,6 +41,21 @@ public class ApplicationSettings
     /// The list of configured SQS Pollers.
     /// </summary>
     public ICollection<SQSPoller> SQSPollers { get; set; } = default!;
+
+    /// <summary>
+    /// The backoff policy used by <see cref="BackoffHandler"/> in the SQS Poller.
+    /// </summary>
+    public BackoffPolicy? BackoffPolicy { get; set; } = default;
+
+    /// <summary>
+    /// Configuration for the interval backoff policy.
+    /// </summary>
+    public IntervalBackoffOptions? IntervalBackoffOptions { get; set; }
+
+    /// <summary>
+    /// Configuration for the capped exponential backoff policy.
+    /// </summary>
+    public CappedExponentialBackoffOptions? CappedExponentialBackoffOptions { get; set; }
 
     /// <summary>
     /// Controls the visibility of data messages in the logging framework, exception handling and other areas.

--- a/src/AWS.Messaging/Configuration/Internal/BackoffPolicy.cs
+++ b/src/AWS.Messaging/Configuration/Internal/BackoffPolicy.cs
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Messaging.Services.Backoff;
+using AWS.Messaging.Services.Backoff.Policies;
+
+namespace AWS.Messaging.Configuration.Internal;
+
+/// <summary>
+/// Represents the available backoff policies that can be paired with <see cref="BackoffHandler"/>.
+/// </summary>
+public enum BackoffPolicy
+{
+    /// <summary>
+    /// Represents the backoff policy <see cref="NoBackoffPolicy"/>.
+    /// </summary>
+    None,
+    /// <summary>
+    /// Represents the backoff policy <see cref="IntervalBackoffPolicy"/>.
+    /// </summary>
+    Interval,
+    /// <summary>
+    /// Represents the backoff policy <see cref="CappedExponentialBackoffPolicy"/>.
+    /// </summary>
+    CappedExponential
+}

--- a/src/AWS.Messaging/Configuration/MessageConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/MessageConfiguration.cs
@@ -1,7 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using AWS.Messaging.Configuration.Internal;
 using AWS.Messaging.Serialization;
+using AWS.Messaging.Services.Backoff.Policies.Options;
 
 namespace AWS.Messaging.Configuration;
 
@@ -54,4 +56,13 @@ public class MessageConfiguration : IMessageConfiguration
 
     /// <inheritdoc/>
     public bool LogMessageContent { get; set; }
+
+    /// <inheritdoc/>
+    public BackoffPolicy BackoffPolicy { get; set; } = BackoffPolicy.CappedExponential;
+
+    /// <inheritdoc/>
+    public IntervalBackoffOptions IntervalBackoffOptions { get; set; } = new();
+
+    /// <inheritdoc/>
+    public CappedExponentialBackoffOptions CappedExponentialBackoffOptions { get; set; } = new();
 }

--- a/src/AWS.Messaging/Configuration/SQSMessagePollerConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/SQSMessagePollerConfiguration.cs
@@ -9,7 +9,7 @@ namespace AWS.Messaging.Configuration;
 /// <summary>
 /// Internal configuration for polling messages from SQS
 /// </summary>
-internal class SQSMessagePollerConfiguration : IMessagePollerConfiguration
+public class SQSMessagePollerConfiguration : IMessagePollerConfiguration
 {
     /// <summary>
     /// Default value for <see cref="MaxNumberOfConcurrentMessages"/>
@@ -153,7 +153,7 @@ internal class SQSMessagePollerConfiguration : IMessagePollerConfiguration
             case KmsAccessDeniedException:      // The caller doesn't have the required KMS access.
             case KmsInvalidKeyUsageException:   // The key is incompatible with the operation, or the encryption/signing algorithm is incompatible.
             case KmsInvalidStateException:      // The state of the specified resource is not valid for this request.
-            case KmsNotFoundException:          // The specified entity or resource could not be found. 
+            case KmsNotFoundException:          // The specified entity or resource could not be found.
             case KmsOptInRequiredException:     // The specified key policy isn't syntactically or semantically correct.
                 return true;
 

--- a/src/AWS.Messaging/Exceptions.cs
+++ b/src/AWS.Messaging/Exceptions.cs
@@ -184,6 +184,17 @@ public class InvalidSQSMessagePollerOptionsException : AWSMessagingException
 }
 
 /// <summary>
+/// Thrown when the backoff policy options are configured with one or more invalid values.
+/// </summary>
+public class InvalidBackoffOptionsException : AWSMessagingException
+{
+    /// <summary>
+    /// Creates an instance of <see cref="InvalidBackoffOptionsException"/>.
+    /// </summary>
+    public InvalidBackoffOptionsException(string message, Exception? innerException = null) : base(message, innerException) { }
+}
+
+/// <summary>
 /// Thrown during message handling if unable to find an <see cref="IMessageHandler{T}.HandleAsync(MessageEnvelope{T}, CancellationToken)"/>
 /// method on the handler type for a given message
 /// </summary>

--- a/src/AWS.Messaging/Extensions/ServiceCollectionExtensions.cs
+++ b/src/AWS.Messaging/Extensions/ServiceCollectionExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.DependencyInjection;
 public static class ServiceCollectionExtensions
 {
     /// <summary>
-    /// Adds the <see cref="IMessageBusBuilder"/> to the dependency injection framework 
+    /// Adds the <see cref="IMessageBusBuilder"/> to the dependency injection framework
     /// to allow access to the framework components throughout the application.
     /// Allows the configuration of the messaging framework by exposing methods to add publishers and subscribers.
     /// </summary>
@@ -19,10 +19,10 @@ public static class ServiceCollectionExtensions
     /// <param name="builder">An action to define the message framework configuration using <see cref="MessageBusBuilder"/></param>
     public static IServiceCollection AddAWSMessageBus(this IServiceCollection services, Action<MessageBusBuilder> builder)
     {
-        var messageBusBuilder = new MessageBusBuilder();
+        var messageBusBuilder = new MessageBusBuilder(services);
 
         builder(messageBusBuilder);
-        messageBusBuilder.Build(services);
+        messageBusBuilder.Build();
 
         return services;
     }

--- a/src/AWS.Messaging/SQS/SQSMessagePoller.cs
+++ b/src/AWS.Messaging/SQS/SQSMessagePoller.cs
@@ -111,9 +111,8 @@ internal class SQSMessagePoller : IMessagePoller, ISQSMessageCommunication
                 MessageAttributeNames = new List<string> { "All" }
             };
 
-            List<Message>? receivedMessages = null;
-
-            await _backoffHandler.BackoffAsync(async () =>
+            List<Message>? receivedMessages =
+                await _backoffHandler.BackoffAsync<List<Message>?>(async () =>
                 {
                     _logger.LogTrace("Retrieving up to {NumberOfMessagesToRead} messages from {QueueUrl}",
                         receiveMessageRequest.MaxNumberOfMessages, receiveMessageRequest.QueueUrl);
@@ -123,7 +122,7 @@ internal class SQSMessagePoller : IMessagePoller, ISQSMessageCommunication
                     _logger.LogTrace("Retrieved {MessagesCount} messages from {QueueUrl} via request ID {RequestId}",
                         receiveMessageResponse.Messages.Count, receiveMessageRequest.QueueUrl, receiveMessageResponse.ResponseMetadata.RequestId);
 
-                    receivedMessages = receiveMessageResponse.Messages;
+                    return receiveMessageResponse.Messages;
                 },
                 _configuration,
                 token);

--- a/src/AWS.Messaging/Services/Backoff/BackoffHandler.cs
+++ b/src/AWS.Messaging/Services/Backoff/BackoffHandler.cs
@@ -69,7 +69,7 @@ internal class BackoffHandler : IBackoffHandler
             {
                 // Checking the backoff policy for how long to backoff before attempting to poll SQS for messages again.
                 var waitTime = _backoffPolicy.RetrieveBackoffTime(retries);
-                _logger.LogWarning("Backing off for {WaitTime}s before trying again...", waitTime);
+                _logger.LogWarning("Backing off polling from SQS for messages for {WaitTime}s before trying again...", waitTime);
 
                 await Task.Delay(TimeSpan.FromSeconds(waitTime), token);
 

--- a/src/AWS.Messaging/Services/Backoff/BackoffHandler.cs
+++ b/src/AWS.Messaging/Services/Backoff/BackoffHandler.cs
@@ -1,0 +1,84 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Runtime.ExceptionServices;
+using AWS.Messaging.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace AWS.Messaging.Services.Backoff;
+
+/// <summary>
+/// A backoff handler that is responsible for performing back-offs in the event that a given delegate throws an exception.
+/// The delegate will be retried after backing off for a certain period of time.
+/// The <see cref="BackoffHandler"/> is used with a <see cref="IBackoffPolicy"/> to determine whether a backoff should occur
+/// and how long to wait between back-offs.
+/// </summary>
+internal class BackoffHandler : IBackoffHandler
+{
+    private readonly IBackoffPolicy _backoffPolicy;
+    private readonly ILogger<BackoffHandler> _logger;
+
+    /// <summary>
+    /// Constructs an instance of <see cref="BackoffHandler"/>
+    /// </summary>
+    /// <param name="backoffPolicy">The backoff policy that determines whether a backoff should occur
+    /// and how long to wait between back-offs.</param>
+    /// <param name="logger">Logger for debugging information</param>
+    public BackoffHandler(IBackoffPolicy backoffPolicy, ILogger<BackoffHandler> logger)
+    {
+        _backoffPolicy = backoffPolicy;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Performs a back off in the event that a given delegate throws an exception.
+    /// The delegate will be retried after backing off for a certain period of time.
+    /// </summary>
+    /// <param name="task">The delegate for which to perform a backoff.</param>
+    /// <param name="configuration">Internal configuration for polling messages from SQS.</param>
+    /// <param name="token">The cancellation token used to cancel the request.</param>
+    public async Task BackoffAsync(Func<Task> task, SQSMessagePollerConfiguration configuration, CancellationToken token = default)
+    {
+        bool shouldRetry;
+        var retries = 0;
+        do
+        {
+            ExceptionDispatchInfo? capturedException = null;
+            shouldRetry = false;
+
+            try
+            {
+                await task.Invoke();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "We have encountered an issue while polling '{SubscriberEndpoint}'.", configuration.SubscriberEndpoint);
+                capturedException = ExceptionDispatchInfo.Capture(ex);
+            }
+
+            if (capturedException == null) continue;
+
+            // Checking the backoff policy whether a backoff should be attempted.
+            shouldRetry = _backoffPolicy.ShouldBackoff(capturedException.SourceException, configuration);
+
+            if (!shouldRetry)
+            {
+                capturedException.Throw();
+            }
+            else
+            {
+                // Checking the backoff policy for how long to backoff before attempting to poll SQS for messages again.
+                var waitTime = _backoffPolicy.RetrieveBackoffTime(retries);
+                _logger.LogWarning("Backing off for {WaitTime}ms before trying again...", waitTime);
+
+                await Task.Delay(TimeSpan.FromMilliseconds(waitTime), token);
+
+                retries++;
+                _logger.LogWarning("Attempting to poll SQS for messages once again...");
+            }
+
+        } while (
+            shouldRetry &&
+            !token.IsCancellationRequested);
+    }
+}

--- a/src/AWS.Messaging/Services/Backoff/BackoffHandler.cs
+++ b/src/AWS.Messaging/Services/Backoff/BackoffHandler.cs
@@ -52,7 +52,7 @@ internal class BackoffHandler : IBackoffHandler
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "We have encountered an issue while polling '{SubscriberEndpoint}'.", configuration.SubscriberEndpoint);
+                _logger.LogError(ex, "An unknown exception occurred while polling '{SubscriberEndpoint}'.", configuration.SubscriberEndpoint);
                 capturedException = ExceptionDispatchInfo.Capture(ex);
             }
 
@@ -69,12 +69,12 @@ internal class BackoffHandler : IBackoffHandler
             {
                 // Checking the backoff policy for how long to backoff before attempting to poll SQS for messages again.
                 var waitTime = _backoffPolicy.RetrieveBackoffTime(retries);
-                _logger.LogWarning("Backing off for {WaitTime}ms before trying again...", waitTime);
+                _logger.LogWarning("Backing off for {WaitTime}s before trying again...", waitTime);
 
-                await Task.Delay(TimeSpan.FromMilliseconds(waitTime), token);
+                await Task.Delay(TimeSpan.FromSeconds(waitTime), token);
 
                 retries++;
-                _logger.LogWarning("Attempting to poll SQS for messages once again...");
+                _logger.LogWarning("Attempt #{Retry} to poll SQS for messages...", retries);
             }
 
         } while (

--- a/src/AWS.Messaging/Services/Backoff/IBackoffHandler.cs
+++ b/src/AWS.Messaging/Services/Backoff/IBackoffHandler.cs
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Messaging.Configuration;
+
+namespace AWS.Messaging.Services.Backoff;
+
+/// <summary>
+/// Interface for a backoff handler that is responsible for performing back-offs in the event that a given delegate throws an exception.
+/// The delegate will be retried after backing off for a certain period of time.
+/// The <see cref="IBackoffHandler"/> could be used with a <see cref="IBackoffPolicy"/> to determine whether a backoff should occur
+/// and how long to wait between back-offs.
+/// </summary>
+public interface IBackoffHandler
+{
+    /// <summary>
+    /// Performs a back off in the event that a given delegate throws an exception.
+    /// The delegate will be retried after backing off for a certain period of time.
+    /// </summary>
+    /// <param name="task">The delegate for which to perform a backoff.</param>
+    /// <param name="configuration">Internal configuration for polling messages from SQS.</param>
+    /// <param name="token">The cancellation token used to cancel the request.</param>
+    Task BackoffAsync(Func<Task> task, SQSMessagePollerConfiguration configuration, CancellationToken token);
+}

--- a/src/AWS.Messaging/Services/Backoff/IBackoffHandler.cs
+++ b/src/AWS.Messaging/Services/Backoff/IBackoffHandler.cs
@@ -20,5 +20,5 @@ public interface IBackoffHandler
     /// <param name="task">The delegate for which to perform a backoff.</param>
     /// <param name="configuration">Internal configuration for polling messages from SQS.</param>
     /// <param name="token">The cancellation token used to cancel the request.</param>
-    Task BackoffAsync(Func<Task> task, SQSMessagePollerConfiguration configuration, CancellationToken token);
+    Task<T> BackoffAsync<T>(Func<Task<T>> task, SQSMessagePollerConfiguration configuration, CancellationToken token);
 }

--- a/src/AWS.Messaging/Services/Backoff/IBackoffPolicy.cs
+++ b/src/AWS.Messaging/Services/Backoff/IBackoffPolicy.cs
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Messaging.Configuration;
+
+namespace AWS.Messaging.Services.Backoff;
+
+/// <summary>
+/// Interface for a Backoff Policy which determines if a <see cref="IBackoffHandler"/>
+/// should perform a backoff and how long to wait before performing the next backoff.
+/// </summary>
+public interface IBackoffPolicy
+{
+    /// <summary>
+    /// Determines if a <see cref="IBackoffHandler"/> should perform a backoff.
+    /// </summary>
+    /// <param name="exception">The exception that triggered a backoff in the <see cref="IBackoffHandler"/>.</param>
+    /// <param name="configuration">Internal configuration for polling messages from SQS.</param>
+    /// <returns>A boolean that indicates whether the <see cref="IBackoffHandler"/> should backoff or not.</returns>
+    bool ShouldBackoff(Exception exception, SQSMessagePollerConfiguration configuration);
+
+    /// <summary>
+    /// Performs a calculation based on the number of retries to determine how long the <see cref="IBackoffHandler"/>
+    /// will wait before performing the next backoff.
+    /// </summary>
+    /// <param name="numberOfRetries">The number of times the <see cref="IBackoffHandler"/> has retried a request after performing a backoff.</param>
+    /// <returns>A number that indicates how long the <see cref="IBackoffHandler"/> should wait.</returns>
+    double RetrieveBackoffTime(int numberOfRetries);
+}

--- a/src/AWS.Messaging/Services/Backoff/IBackoffPolicy.cs
+++ b/src/AWS.Messaging/Services/Backoff/IBackoffPolicy.cs
@@ -24,6 +24,6 @@ public interface IBackoffPolicy
     /// will wait before performing the next backoff.
     /// </summary>
     /// <param name="numberOfRetries">The number of times the <see cref="IBackoffHandler"/> has retried a request after performing a backoff.</param>
-    /// <returns>A number that indicates how long the <see cref="IBackoffHandler"/> should wait.</returns>
-    double RetrieveBackoffTime(int numberOfRetries);
+    /// <returns>A <see cref="TimeSpan"/> that indicates how long the <see cref="IBackoffHandler"/> should wait.</returns>
+    TimeSpan RetrieveBackoffTime(int numberOfRetries);
 }

--- a/src/AWS.Messaging/Services/Backoff/Policies/CappedExponentialBackoffPolicy.cs
+++ b/src/AWS.Messaging/Services/Backoff/Policies/CappedExponentialBackoffPolicy.cs
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Messaging.Configuration;
+using AWS.Messaging.Services.Backoff.Policies.Options;
+
+namespace AWS.Messaging.Services.Backoff.Policies;
+
+/// <summary>
+/// A backoff policy that will wait an exponentially increasing time for every backoff
+/// until it reaches a user-defined cap. At that point, it will switch to an interval backoff
+/// with the fixed interval equal to the cap.
+/// </summary>
+internal class CappedExponentialBackoffPolicy : IBackoffPolicy
+{
+    private readonly CappedExponentialBackoffOptions _options;
+
+    /// <summary>
+    /// Constructs an instance of <see cref="CappedExponentialBackoffPolicy"/>
+    /// </summary>
+    /// <param name="options">Configuration for the capped exponential backoff policy.</param>
+    public CappedExponentialBackoffPolicy(CappedExponentialBackoffOptions options)
+    {
+        _options = options;
+    }
+
+    /// <summary>
+    /// Determines if <see cref="BackoffHandler"/> should perform a backoff based on the thrown exception.
+    /// If the exception is a fatal one, a backoff is not performed.
+    /// If the exception is not fatal, a backoff is performed.
+    /// </summary>
+    /// <param name="exception">The exception that triggered a backoff in <see cref="BackoffHandler"/>.</param>
+    /// <param name="configuration">Internal configuration for polling messages from SQS.</param>
+    /// <returns>true, if the exception is not fatal. false, if it is fatal.</returns>
+    public bool ShouldBackoff(Exception exception, SQSMessagePollerConfiguration configuration)
+    {
+        return !configuration.IsExceptionFatal(exception);
+    }
+
+    /// <summary>
+    /// Retrieves the backoff time which is exponentially increasing based on the number of retries already performed.
+    /// </summary>
+    /// <param name="numberOfRetries">The number of times the <see cref="BackoffHandler"/> has retried a request after performing a backoff.</param>
+    /// <returns>An exponentially increasing backoff time.</returns>
+    public double RetrieveBackoffTime(int numberOfRetries)
+    {
+        var backoffTime = Math.Pow(2, numberOfRetries);
+        return (backoffTime > _options.CapBackoffTime ? _options.CapBackoffTime : backoffTime);
+    }
+}

--- a/src/AWS.Messaging/Services/Backoff/Policies/CappedExponentialBackoffPolicy.cs
+++ b/src/AWS.Messaging/Services/Backoff/Policies/CappedExponentialBackoffPolicy.cs
@@ -38,10 +38,10 @@ internal class CappedExponentialBackoffPolicy : IBackoffPolicy
     }
 
     /// <summary>
-    /// Retrieves the backoff time which is exponentially increasing based on the number of retries already performed.
+    /// Retrieves the backoff time in seconds which is exponentially increasing based on the number of retries already performed.
     /// </summary>
     /// <param name="numberOfRetries">The number of times the <see cref="BackoffHandler"/> has retried a request after performing a backoff.</param>
-    /// <returns>An exponentially increasing backoff time.</returns>
+    /// <returns>An exponentially increasing backoff time in seconds.</returns>
     public double RetrieveBackoffTime(int numberOfRetries)
     {
         var backoffTime = Math.Pow(2, numberOfRetries);

--- a/src/AWS.Messaging/Services/Backoff/Policies/IntervalBackoffPolicy.cs
+++ b/src/AWS.Messaging/Services/Backoff/Policies/IntervalBackoffPolicy.cs
@@ -39,9 +39,9 @@ internal class IntervalBackoffPolicy : IBackoffPolicy
     /// Retrieves the backoff time in seconds which is a fixed interval, regardless of how many retries have already been performed.
     /// </summary>
     /// <param name="numberOfRetries">The number of times the <see cref="BackoffHandler"/> has retried a request after performing a backoff.</param>
-    /// <returns>A fixed interval representing the backoff time in seconds.</returns>
-    public double RetrieveBackoffTime(int numberOfRetries)
+    /// <returns>A fixed interval representing the backoff time as a <see cref="TimeSpan"/>.</returns>
+    public TimeSpan RetrieveBackoffTime(int numberOfRetries)
     {
-        return _options.FixedInterval;
+        return TimeSpan.FromSeconds(_options.FixedInterval);
     }
 }

--- a/src/AWS.Messaging/Services/Backoff/Policies/IntervalBackoffPolicy.cs
+++ b/src/AWS.Messaging/Services/Backoff/Policies/IntervalBackoffPolicy.cs
@@ -36,10 +36,10 @@ internal class IntervalBackoffPolicy : IBackoffPolicy
     }
 
     /// <summary>
-    /// Retrieves the backoff time which is a fixed interval, regardless of how many retries have already been performed.
+    /// Retrieves the backoff time in seconds which is a fixed interval, regardless of how many retries have already been performed.
     /// </summary>
     /// <param name="numberOfRetries">The number of times the <see cref="BackoffHandler"/> has retried a request after performing a backoff.</param>
-    /// <returns>A fixed interval representing the backoff time.</returns>
+    /// <returns>A fixed interval representing the backoff time in seconds.</returns>
     public double RetrieveBackoffTime(int numberOfRetries)
     {
         return _options.FixedInterval;

--- a/src/AWS.Messaging/Services/Backoff/Policies/IntervalBackoffPolicy.cs
+++ b/src/AWS.Messaging/Services/Backoff/Policies/IntervalBackoffPolicy.cs
@@ -37,11 +37,14 @@ internal class IntervalBackoffPolicy : IBackoffPolicy
 
     /// <summary>
     /// Retrieves the backoff time in seconds which is a fixed interval, regardless of how many retries have already been performed.
+    /// Jitter is applied to the fixed interval to add some amount of randomness to the backoff to spread the retries around in time.
     /// </summary>
     /// <param name="numberOfRetries">The number of times the <see cref="BackoffHandler"/> has retried a request after performing a backoff.</param>
-    /// <returns>A fixed interval representing the backoff time as a <see cref="TimeSpan"/>.</returns>
+    /// <returns>An interval representing the backoff time as a <see cref="TimeSpan"/>.</returns>
     public TimeSpan RetrieveBackoffTime(int numberOfRetries)
     {
-        return TimeSpan.FromSeconds(_options.FixedInterval);
+        double jitter = Random.Shared.NextDouble();
+        var backoffTime = Convert.ToInt32(jitter * _options.FixedInterval);
+        return TimeSpan.FromSeconds(backoffTime);
     }
 }

--- a/src/AWS.Messaging/Services/Backoff/Policies/IntervalBackoffPolicy.cs
+++ b/src/AWS.Messaging/Services/Backoff/Policies/IntervalBackoffPolicy.cs
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Messaging.Configuration;
+using AWS.Messaging.Services.Backoff.Policies.Options;
+
+namespace AWS.Messaging.Services.Backoff.Policies;
+
+/// <summary>
+/// A backoff policy that will wait for a fixed interval between back-offs.
+/// </summary>
+internal class IntervalBackoffPolicy : IBackoffPolicy
+{
+    private readonly IntervalBackoffOptions _options;
+
+    /// <summary>
+    /// Constructs an instance of <see cref="IntervalBackoffPolicy"/>
+    /// </summary>
+    /// <param name="options">Configuration for the interval backoff policy.</param>
+    public IntervalBackoffPolicy(IntervalBackoffOptions options)
+    {
+        _options = options;
+    }
+
+    /// <summary>
+    /// Determines if <see cref="BackoffHandler"/> should perform a backoff based on the thrown exception.
+    /// If the exception is a fatal one, a backoff is not performed.
+    /// If the exception is not fatal, a backoff is performed.
+    /// </summary>
+    /// <param name="exception">The exception that triggered a backoff in <see cref="BackoffHandler"/>.</param>
+    /// <param name="configuration">Internal configuration for polling messages from SQS.</param>
+    /// <returns>true, if the exception is not fatal. false, if it is fatal.</returns>
+    public bool ShouldBackoff(Exception exception, SQSMessagePollerConfiguration configuration)
+    {
+        return !configuration.IsExceptionFatal(exception);
+    }
+
+    /// <summary>
+    /// Retrieves the backoff time which is a fixed interval, regardless of how many retries have already been performed.
+    /// </summary>
+    /// <param name="numberOfRetries">The number of times the <see cref="BackoffHandler"/> has retried a request after performing a backoff.</param>
+    /// <returns>A fixed interval representing the backoff time.</returns>
+    public double RetrieveBackoffTime(int numberOfRetries)
+    {
+        return _options.FixedInterval;
+    }
+}

--- a/src/AWS.Messaging/Services/Backoff/Policies/NoBackoffPolicy.cs
+++ b/src/AWS.Messaging/Services/Backoff/Policies/NoBackoffPolicy.cs
@@ -21,5 +21,5 @@ internal class NoBackoffPolicy : IBackoffPolicy
     /// This is a no-op and will always return 0 as the backoff time is not needed.
     /// </summary>
     /// <returns>0</returns>
-    public double RetrieveBackoffTime(int numberOfRetries) => 0;
+    public TimeSpan RetrieveBackoffTime(int numberOfRetries) => TimeSpan.Zero;
 }

--- a/src/AWS.Messaging/Services/Backoff/Policies/NoBackoffPolicy.cs
+++ b/src/AWS.Messaging/Services/Backoff/Policies/NoBackoffPolicy.cs
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using AWS.Messaging.Configuration;
+
+namespace AWS.Messaging.Services.Backoff.Policies;
+
+/// <summary>
+/// A backoff policy that will not perform a backoff.
+/// This policy can essentially be used to disable the backoff logic of the <see cref="IBackoffHandler"/>.
+/// </summary>
+internal class NoBackoffPolicy : IBackoffPolicy
+{
+    /// <summary>
+    /// This is a no-op and will always return false indicating that a backoff should not occur.
+    /// </summary>
+    /// <returns>false</returns>
+    public bool ShouldBackoff(Exception exception, SQSMessagePollerConfiguration configuration) => false;
+
+    /// <summary>
+    /// This is a no-op and will always return 0 as the backoff time is not needed.
+    /// </summary>
+    /// <returns>0</returns>
+    public double RetrieveBackoffTime(int numberOfRetries) => 0;
+}

--- a/src/AWS.Messaging/Services/Backoff/Policies/Options/CappedExponentialBackoffOptions.cs
+++ b/src/AWS.Messaging/Services/Backoff/Policies/Options/CappedExponentialBackoffOptions.cs
@@ -12,9 +12,9 @@ public class CappedExponentialBackoffOptions
     /// The backoff time in seconds to cap the exponential backoff at.
     /// Once the cap is reached, an interval backoff will occur with
     /// <see cref="CapBackoffTime"/> as the fixed interval.
-    /// The default value is 1 hour.
+    /// The default value is 1 minute.
     /// </summary>
-    public int CapBackoffTime { get; set; } = 3600;
+    public int CapBackoffTime { get; set; } = 60;
 
     /// <summary>
     /// Validates that the options set for the <see cref="CappedExponentialBackoffPolicy"/>.

--- a/src/AWS.Messaging/Services/Backoff/Policies/Options/CappedExponentialBackoffOptions.cs
+++ b/src/AWS.Messaging/Services/Backoff/Policies/Options/CappedExponentialBackoffOptions.cs
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Services.Backoff.Policies.Options;
+
+/// <summary>
+/// Configuration for the capped exponential backoff policy.
+/// </summary>
+public class CappedExponentialBackoffOptions
+{
+    /// <summary>
+    /// The backoff time in milliseconds to cap the exponential backoff at.
+    /// The default value is 1 hour.
+    /// </summary>
+    public int CapBackoffTime { get; set; } = 3600000;
+
+    /// <summary>
+    /// Validates that the options set for the <see cref="CappedExponentialBackoffPolicy"/>.
+    /// </summary>
+    /// <exception cref="InvalidBackoffOptionsException">Thrown when one or more invalid options are found</exception>
+    internal void Validate()
+    {
+        var errorMessages = new List<string>();
+
+        if (CapBackoffTime < 0)
+        {
+            errorMessages.Add($"{nameof(CapBackoffTime)} must be greater than or equal to 0. Current value: {CapBackoffTime}.");
+        }
+
+        if (errorMessages.Any())
+        {
+            throw new InvalidBackoffOptionsException(string.Join(Environment.NewLine, errorMessages));
+        }
+    }
+}

--- a/src/AWS.Messaging/Services/Backoff/Policies/Options/CappedExponentialBackoffOptions.cs
+++ b/src/AWS.Messaging/Services/Backoff/Policies/Options/CappedExponentialBackoffOptions.cs
@@ -10,6 +10,8 @@ public class CappedExponentialBackoffOptions
 {
     /// <summary>
     /// The backoff time in seconds to cap the exponential backoff at.
+    /// Once the cap is reached, an interval backoff will occur with
+    /// <see cref="CapBackoffTime"/> as the fixed interval.
     /// The default value is 1 hour.
     /// </summary>
     public int CapBackoffTime { get; set; } = 3600;

--- a/src/AWS.Messaging/Services/Backoff/Policies/Options/CappedExponentialBackoffOptions.cs
+++ b/src/AWS.Messaging/Services/Backoff/Policies/Options/CappedExponentialBackoffOptions.cs
@@ -9,10 +9,10 @@ namespace AWS.Messaging.Services.Backoff.Policies.Options;
 public class CappedExponentialBackoffOptions
 {
     /// <summary>
-    /// The backoff time in milliseconds to cap the exponential backoff at.
+    /// The backoff time in seconds to cap the exponential backoff at.
     /// The default value is 1 hour.
     /// </summary>
-    public int CapBackoffTime { get; set; } = 3600000;
+    public int CapBackoffTime { get; set; } = 3600;
 
     /// <summary>
     /// Validates that the options set for the <see cref="CappedExponentialBackoffPolicy"/>.

--- a/src/AWS.Messaging/Services/Backoff/Policies/Options/IntervalBackoffOptions.cs
+++ b/src/AWS.Messaging/Services/Backoff/Policies/Options/IntervalBackoffOptions.cs
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Services.Backoff.Policies.Options;
+
+/// <summary>
+/// Configuration for the interval backoff policy.
+/// </summary>
+public class IntervalBackoffOptions
+{
+    /// <summary>
+    /// The fixed interval in milliseconds to wait between back-offs.
+    /// The default value is 1 second.
+    /// </summary>
+    public int FixedInterval { get; set; } = 1000;
+
+    /// <summary>
+    /// Validates that the options set for the <see cref="IntervalBackoffPolicy"/>.
+    /// </summary>
+    /// <exception cref="InvalidBackoffOptionsException">Thrown when one or more invalid options are found</exception>
+    internal void Validate()
+    {
+        var errorMessages = new List<string>();
+
+        if (FixedInterval < 0)
+        {
+            errorMessages.Add($"{nameof(FixedInterval)} must be greater than or equal to 0. Current value: {FixedInterval}.");
+        }
+
+        if (errorMessages.Any())
+        {
+            throw new InvalidBackoffOptionsException(string.Join(Environment.NewLine, errorMessages));
+        }
+    }
+}

--- a/src/AWS.Messaging/Services/Backoff/Policies/Options/IntervalBackoffOptions.cs
+++ b/src/AWS.Messaging/Services/Backoff/Policies/Options/IntervalBackoffOptions.cs
@@ -9,10 +9,10 @@ namespace AWS.Messaging.Services.Backoff.Policies.Options;
 public class IntervalBackoffOptions
 {
     /// <summary>
-    /// The fixed interval in milliseconds to wait between back-offs.
+    /// The fixed interval in seconds to wait between back-offs.
     /// The default value is 1 second.
     /// </summary>
-    public int FixedInterval { get; set; } = 1000;
+    public int FixedInterval { get; set; } = 1;
 
     /// <summary>
     /// Validates that the options set for the <see cref="IntervalBackoffPolicy"/>.

--- a/test/AWS.Messaging.UnitTests/AppSettingsConfigurationTests.cs
+++ b/test/AWS.Messaging.UnitTests/AppSettingsConfigurationTests.cs
@@ -355,7 +355,7 @@ public class AppSettingsConfigurationTests
                 ""AWS.Messaging"": {
                     ""BackoffPolicy"": ""Interval"",
                     ""IntervalBackoffOptions"": {
-                        ""FixedInterval"": 2000
+                        ""FixedInterval"": 2
                     }
                 }
             }";
@@ -364,7 +364,7 @@ public class AppSettingsConfigurationTests
 
         Assert.Equal(BackoffPolicy.Interval, messageConfiguration.BackoffPolicy);
         Assert.NotNull(messageConfiguration.IntervalBackoffOptions);
-        Assert.Equal(2000, messageConfiguration.IntervalBackoffOptions.FixedInterval);
+        Assert.Equal(2, messageConfiguration.IntervalBackoffOptions.FixedInterval);
     }
 
     [Fact]
@@ -375,7 +375,7 @@ public class AppSettingsConfigurationTests
                 ""AWS.Messaging"": {
                     ""BackoffPolicy"": ""CappedExponential"",
                     ""CappedExponentialBackoffOptions"": {
-                        ""CapBackoffTime"": 2000
+                        ""CapBackoffTime"": 2
                     }
                 }
             }";
@@ -384,7 +384,7 @@ public class AppSettingsConfigurationTests
 
         Assert.Equal(BackoffPolicy.CappedExponential, messageConfiguration.BackoffPolicy);
         Assert.NotNull(messageConfiguration.CappedExponentialBackoffOptions);
-        Assert.Equal(2000, messageConfiguration.CappedExponentialBackoffOptions.CapBackoffTime);
+        Assert.Equal(2, messageConfiguration.CappedExponentialBackoffOptions.CapBackoffTime);
     }
 
     private IMessageConfiguration SetupConfigurationAndServices(string json)

--- a/test/AWS.Messaging.UnitTests/Backoff/BackoffHandlerTests.cs
+++ b/test/AWS.Messaging.UnitTests/Backoff/BackoffHandlerTests.cs
@@ -1,0 +1,88 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AWS.Messaging.Configuration;
+using AWS.Messaging.Services.Backoff;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace AWS.Messaging.UnitTests.Backoff;
+
+public class BackoffHandlerTests
+{
+    private readonly Mock<IBackoffPolicy> _backoffPolicy = new();
+    private readonly Mock<ILogger<BackoffHandler>> _logger = new();
+
+    [Fact]
+    public async Task RetryAsync_NoException()
+    {
+        var source = new CancellationTokenSource();
+        var sqsMessagePollerConfiguration = new SQSMessagePollerConfiguration("queueURL");
+        var backoffHandler = new BackoffHandler(_backoffPolicy.Object, _logger.Object);
+
+        await backoffHandler.BackoffAsync(() => Task.CompletedTask,
+            sqsMessagePollerConfiguration,
+            source.Token);
+
+        _backoffPolicy.Verify(x => x.ShouldBackoff(It.IsAny<Exception>(), sqsMessagePollerConfiguration), Times.Never);
+        _backoffPolicy.Verify(x => x.RetrieveBackoffTime(It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RetryAsync_ShouldNotBackoff()
+    {
+        var source = new CancellationTokenSource();
+        var sqsMessagePollerConfiguration = new SQSMessagePollerConfiguration("queueURL");
+        var backoffHandler = new BackoffHandler(_backoffPolicy.Object, _logger.Object);
+        _backoffPolicy
+            .Setup(x =>
+                x.ShouldBackoff(It.IsAny<Exception>(), sqsMessagePollerConfiguration))
+            .Returns(false);
+
+        await Assert.ThrowsAsync<Exception>(async () =>
+        {
+            await backoffHandler.BackoffAsync(() => throw new Exception("Failed to process."),
+                sqsMessagePollerConfiguration,
+                source.Token);
+        });
+
+        _backoffPolicy.Verify(x => x.ShouldBackoff(It.IsAny<Exception>(), sqsMessagePollerConfiguration), Times.Once);
+        _backoffPolicy.Verify(X => X.RetrieveBackoffTime(It.IsAny<int>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData(500, 7)]
+    [InlineData(1000, 12)]
+    [InlineData(1500, 17)]
+    [InlineData(2000, 22)]
+    [InlineData(2500, 27)]
+    [InlineData(3000, 32)]
+    public async Task RetryAsync_IntervalBackoff(int cancelAfter, int retries)
+    {
+        var source = new CancellationTokenSource();
+        var sqsMessagePollerConfiguration = new SQSMessagePollerConfiguration("queueURL");
+        var backoffHandler = new BackoffHandler(_backoffPolicy.Object, _logger.Object);
+        _backoffPolicy
+            .Setup(x =>
+                x.ShouldBackoff(It.IsAny<Exception>(), sqsMessagePollerConfiguration))
+            .Returns(true);
+        _backoffPolicy
+            .Setup(x => x.RetrieveBackoffTime(It.IsAny<int>()))
+            .Returns(100);
+
+        source.CancelAfter(cancelAfter);
+        try
+        {
+            await backoffHandler.BackoffAsync(() => throw new Exception("Failed to process."),
+                sqsMessagePollerConfiguration,
+                source.Token);
+        }
+        catch (TaskCanceledException) { }
+
+        _backoffPolicy.Verify(X => X.RetrieveBackoffTime(It.IsAny<int>()), Times.AtMost(retries));
+    }
+}

--- a/test/AWS.Messaging.UnitTests/Backoff/BackoffHandlerTests.cs
+++ b/test/AWS.Messaging.UnitTests/Backoff/BackoffHandlerTests.cs
@@ -55,12 +55,11 @@ public class BackoffHandlerTests
     }
 
     [Theory]
-    [InlineData(500, 7)]
-    [InlineData(1000, 12)]
-    [InlineData(1500, 17)]
-    [InlineData(2000, 22)]
-    [InlineData(2500, 27)]
-    [InlineData(3000, 32)]
+    [InlineData(1000, 2)]
+    [InlineData(2000, 3)]
+    [InlineData(3000, 4)]
+    [InlineData(4000, 5)]
+    [InlineData(5000, 6)]
     public async Task RetryAsync_IntervalBackoff(int cancelAfter, int retries)
     {
         var source = new CancellationTokenSource();
@@ -72,7 +71,7 @@ public class BackoffHandlerTests
             .Returns(true);
         _backoffPolicy
             .Setup(x => x.RetrieveBackoffTime(It.IsAny<int>()))
-            .Returns(100);
+            .Returns(1);
 
         source.CancelAfter(cancelAfter);
         try

--- a/test/AWS.Messaging.UnitTests/Backoff/Policies/CappedExponentialBackoffPolicyTests.cs
+++ b/test/AWS.Messaging.UnitTests/Backoff/Policies/CappedExponentialBackoffPolicyTests.cs
@@ -1,0 +1,58 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using AWS.Messaging.Configuration;
+using AWS.Messaging.Services.Backoff.Policies;
+using AWS.Messaging.Services.Backoff.Policies.Options;
+using Xunit;
+
+namespace AWS.Messaging.UnitTests.Backoff.Policies;
+
+public class CappedExponentialBackoffPolicyTests
+{
+    [Theory]
+    [InlineData(typeof(QueueDoesNotExistException), false)]
+    [InlineData(typeof(UnsupportedOperationException), false)]
+    [InlineData(typeof(InvalidAddressException), false)]
+    [InlineData(typeof(InvalidSecurityException), false)]
+    [InlineData(typeof(KmsAccessDeniedException), false)]
+    [InlineData(typeof(KmsInvalidKeyUsageException), false)]
+    [InlineData(typeof(KmsInvalidStateException), false)]
+    [InlineData(typeof(AmazonSQSException), true)]
+    [InlineData(typeof(Exception), true)]
+    public void ShouldBackoffTest(Type exceptionType, bool shouldBackoff)
+    {
+        var exception = Activator.CreateInstance(exceptionType, "Exception message");
+        if (exception is null)
+            Assert.Fail();
+        var sqsMessagePollerConfiguration = new SQSMessagePollerConfiguration("queueURL");
+
+        var cappedExponentialBackoffOptions = new CappedExponentialBackoffOptions();
+        var cappedExponentialBackoffPolicy = new CappedExponentialBackoffPolicy(cappedExponentialBackoffOptions);
+
+        Assert.Equal(shouldBackoff, cappedExponentialBackoffPolicy.ShouldBackoff((Exception) exception, sqsMessagePollerConfiguration));
+    }
+
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(1, 2)]
+    [InlineData(2, 4)]
+    [InlineData(3, 8)]
+    [InlineData(4, 16)]
+    [InlineData(5, 32)]
+    [InlineData(6, 64)]
+    [InlineData(7, 128)]
+    [InlineData(8, 256)]
+    [InlineData(9, 512)]
+    [InlineData(10, 1024)]
+    public void RetrieveBackoffTimeTest(int retry, int backoffTime)
+    {
+        var cappedExponentialBackoffOptions = new CappedExponentialBackoffOptions();
+        var cappedExponentialBackoffPolicy = new CappedExponentialBackoffPolicy(cappedExponentialBackoffOptions);
+
+        Assert.Equal(backoffTime, cappedExponentialBackoffPolicy.RetrieveBackoffTime(retry));
+    }
+}

--- a/test/AWS.Messaging.UnitTests/Backoff/Policies/CappedExponentialBackoffPolicyTests.cs
+++ b/test/AWS.Messaging.UnitTests/Backoff/Policies/CappedExponentialBackoffPolicyTests.cs
@@ -43,16 +43,16 @@ public class CappedExponentialBackoffPolicyTests
     [InlineData(3, 8)]
     [InlineData(4, 16)]
     [InlineData(5, 32)]
-    [InlineData(6, 64)]
-    [InlineData(7, 128)]
-    [InlineData(8, 256)]
-    [InlineData(9, 512)]
-    [InlineData(10, 1024)]
+    [InlineData(6, 60)]
+    [InlineData(7, 60)]
+    [InlineData(8, 60)]
+    [InlineData(9, 60)]
+    [InlineData(10, 60)]
     public void RetrieveBackoffTimeTest(int retry, int backoffTime)
     {
         var cappedExponentialBackoffOptions = new CappedExponentialBackoffOptions();
         var cappedExponentialBackoffPolicy = new CappedExponentialBackoffPolicy(cappedExponentialBackoffOptions);
 
-        Assert.Equal(backoffTime, cappedExponentialBackoffPolicy.RetrieveBackoffTime(retry));
+        Assert.True(TimeSpan.FromSeconds(backoffTime) >= cappedExponentialBackoffPolicy.RetrieveBackoffTime(retry));
     }
 }

--- a/test/AWS.Messaging.UnitTests/Backoff/Policies/IntervalBackoffPolicyTests.cs
+++ b/test/AWS.Messaging.UnitTests/Backoff/Policies/IntervalBackoffPolicyTests.cs
@@ -44,6 +44,6 @@ public class IntervalBackoffPolicyTests
         var intervalBackoffOptions = new IntervalBackoffOptions();
         var intervalBackoffPolicy = new IntervalBackoffPolicy(intervalBackoffOptions);
 
-        Assert.Equal(intervalBackoffOptions.FixedInterval, intervalBackoffPolicy.RetrieveBackoffTime(It.IsAny<int>()));
+        Assert.Equal(TimeSpan.FromSeconds(intervalBackoffOptions.FixedInterval), intervalBackoffPolicy.RetrieveBackoffTime(It.IsAny<int>()));
     }
 }

--- a/test/AWS.Messaging.UnitTests/Backoff/Policies/IntervalBackoffPolicyTests.cs
+++ b/test/AWS.Messaging.UnitTests/Backoff/Policies/IntervalBackoffPolicyTests.cs
@@ -1,0 +1,49 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Reflection;
+using Amazon.SQS;
+using Amazon.SQS.Model;
+using AWS.Messaging.Configuration;
+using AWS.Messaging.Services.Backoff.Policies;
+using AWS.Messaging.Services.Backoff.Policies.Options;
+using Moq;
+using Xunit;
+
+namespace AWS.Messaging.UnitTests.Backoff.Policies;
+
+public class IntervalBackoffPolicyTests
+{
+    [Theory]
+    [InlineData(typeof(QueueDoesNotExistException), false)]
+    [InlineData(typeof(UnsupportedOperationException), false)]
+    [InlineData(typeof(InvalidAddressException), false)]
+    [InlineData(typeof(InvalidSecurityException), false)]
+    [InlineData(typeof(KmsAccessDeniedException), false)]
+    [InlineData(typeof(KmsInvalidKeyUsageException), false)]
+    [InlineData(typeof(KmsInvalidStateException), false)]
+    [InlineData(typeof(AmazonSQSException), true)]
+    [InlineData(typeof(Exception), true)]
+    public void ShouldBackoffTest(Type exceptionType, bool shouldBackoff)
+    {
+        var exception = Activator.CreateInstance(exceptionType, "Exception message");
+        if (exception is null)
+            Assert.Fail();
+        var sqsMessagePollerConfiguration = new SQSMessagePollerConfiguration("queueURL");
+
+        var intervalBackoffOptions = new IntervalBackoffOptions();
+        var intervalBackoffPolicy = new IntervalBackoffPolicy(intervalBackoffOptions);
+
+        Assert.Equal(shouldBackoff, intervalBackoffPolicy.ShouldBackoff((Exception) exception, sqsMessagePollerConfiguration));
+    }
+
+    [Fact]
+    public void RetrieveBackoffTimeTest()
+    {
+        var intervalBackoffOptions = new IntervalBackoffOptions();
+        var intervalBackoffPolicy = new IntervalBackoffPolicy(intervalBackoffOptions);
+
+        Assert.Equal(intervalBackoffOptions.FixedInterval, intervalBackoffPolicy.RetrieveBackoffTime(It.IsAny<int>()));
+    }
+}

--- a/test/AWS.Messaging.UnitTests/Backoff/Policies/IntervalBackoffPolicyTests.cs
+++ b/test/AWS.Messaging.UnitTests/Backoff/Policies/IntervalBackoffPolicyTests.cs
@@ -44,6 +44,6 @@ public class IntervalBackoffPolicyTests
         var intervalBackoffOptions = new IntervalBackoffOptions();
         var intervalBackoffPolicy = new IntervalBackoffPolicy(intervalBackoffOptions);
 
-        Assert.Equal(TimeSpan.FromSeconds(intervalBackoffOptions.FixedInterval), intervalBackoffPolicy.RetrieveBackoffTime(It.IsAny<int>()));
+        Assert.True(TimeSpan.FromSeconds(intervalBackoffOptions.FixedInterval) >= intervalBackoffPolicy.RetrieveBackoffTime(It.IsAny<int>()));
     }
 }

--- a/test/AWS.Messaging.UnitTests/Backoff/Policies/NoBackoffPolicyTests.cs
+++ b/test/AWS.Messaging.UnitTests/Backoff/Policies/NoBackoffPolicyTests.cs
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using AWS.Messaging.Configuration;
+using AWS.Messaging.Services.Backoff.Policies;
+using Moq;
+using Xunit;
+
+namespace AWS.Messaging.UnitTests.Backoff.Policies;
+
+public class NoBackoffPolicyTests
+{
+    [Fact]
+    public void ShouldBackoffTest()
+    {
+        var noBackoffPolicy = new NoBackoffPolicy();
+
+        Assert.False(noBackoffPolicy.ShouldBackoff(It.IsAny<Exception>(), It.IsAny<SQSMessagePollerConfiguration>()));
+    }
+
+    [Fact]
+    public void RetrieveBackoffTimeTest()
+    {
+        var noBackoffPolicy = new NoBackoffPolicy();
+
+        Assert.Equal(0, noBackoffPolicy.RetrieveBackoffTime(It.IsAny<int>()));
+    }
+}

--- a/test/AWS.Messaging.UnitTests/Backoff/Policies/NoBackoffPolicyTests.cs
+++ b/test/AWS.Messaging.UnitTests/Backoff/Policies/NoBackoffPolicyTests.cs
@@ -24,6 +24,6 @@ public class NoBackoffPolicyTests
     {
         var noBackoffPolicy = new NoBackoffPolicy();
 
-        Assert.Equal(0, noBackoffPolicy.RetrieveBackoffTime(It.IsAny<int>()));
+        Assert.Equal(TimeSpan.Zero, noBackoffPolicy.RetrieveBackoffTime(It.IsAny<int>()));
     }
 }

--- a/test/AWS.Messaging.UnitTests/MessageBusBuilderTests.cs
+++ b/test/AWS.Messaging.UnitTests/MessageBusBuilderTests.cs
@@ -143,16 +143,16 @@ public class MessageBusBuilderTests
 
         Assert.IsType<IntervalBackoffPolicy>(backoffPolicy);
 
-        Assert.Equal(1000, backoffPolicy.RetrieveBackoffTime(retry));
+        Assert.Equal(1, backoffPolicy.RetrieveBackoffTime(retry));
     }
 
     [Theory]
     [InlineData(0)]
-    [InlineData(500)]
-    [InlineData(1000)]
-    [InlineData(1500)]
-    [InlineData(2000)]
-    [InlineData(2500)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(5)]
     public void MessageBus_ConfigureBackoffPolicy_IntervalBackoffPolicy_WithOptions(int interval)
     {
         _serviceCollection.AddAWSMessageBus(builder =>
@@ -206,10 +206,10 @@ public class MessageBusBuilderTests
     }
 
     [Theory]
-    [InlineData(5, 30)]
-    [InlineData(6, 60)]
-    [InlineData(7, 100)]
-    [InlineData(8, 200)]
+    [InlineData(5, 3)]
+    [InlineData(6, 6)]
+    [InlineData(7, 10)]
+    [InlineData(8, 20)]
     public void MessageBus_ConfigureBackoffPolicy_CappedExponentialBackoffPolicy_WithOptions(int retry, int cap)
     {
         _serviceCollection.AddAWSMessageBus(builder =>

--- a/test/AWS.Messaging.UnitTests/MessageBusBuilderTests.cs
+++ b/test/AWS.Messaging.UnitTests/MessageBusBuilderTests.cs
@@ -143,7 +143,7 @@ public class MessageBusBuilderTests
 
         Assert.IsType<IntervalBackoffPolicy>(backoffPolicy);
 
-        Assert.Equal(TimeSpan.FromSeconds(1), backoffPolicy.RetrieveBackoffTime(retry));
+        Assert.True(TimeSpan.FromSeconds(1) >= backoffPolicy.RetrieveBackoffTime(retry));
     }
 
     [Theory]
@@ -178,7 +178,7 @@ public class MessageBusBuilderTests
 
         Assert.IsType<IntervalBackoffPolicy>(backoffPolicy);
 
-        Assert.Equal(TimeSpan.FromSeconds(interval), backoffPolicy.RetrieveBackoffTime(It.IsAny<int>()));
+        Assert.True(TimeSpan.FromSeconds(interval) >= backoffPolicy.RetrieveBackoffTime(It.IsAny<int>()));
     }
 
     [Fact]

--- a/test/AWS.Messaging.UnitTests/MessageBusBuilderTests.cs
+++ b/test/AWS.Messaging.UnitTests/MessageBusBuilderTests.cs
@@ -143,7 +143,7 @@ public class MessageBusBuilderTests
 
         Assert.IsType<IntervalBackoffPolicy>(backoffPolicy);
 
-        Assert.Equal(1, backoffPolicy.RetrieveBackoffTime(retry));
+        Assert.Equal(TimeSpan.FromSeconds(1), backoffPolicy.RetrieveBackoffTime(retry));
     }
 
     [Theory]
@@ -178,7 +178,7 @@ public class MessageBusBuilderTests
 
         Assert.IsType<IntervalBackoffPolicy>(backoffPolicy);
 
-        Assert.Equal(interval, backoffPolicy.RetrieveBackoffTime(It.IsAny<int>()));
+        Assert.Equal(TimeSpan.FromSeconds(interval), backoffPolicy.RetrieveBackoffTime(It.IsAny<int>()));
     }
 
     [Fact]
@@ -235,7 +235,7 @@ public class MessageBusBuilderTests
 
         Assert.IsType<CappedExponentialBackoffPolicy>(backoffPolicy);
 
-        Assert.Equal(cap, backoffPolicy.RetrieveBackoffTime(retry));
+        Assert.True(TimeSpan.FromSeconds(cap) >= backoffPolicy.RetrieveBackoffTime(retry));
     }
 
     [Fact]

--- a/test/AWS.Messaging.UnitTests/MessageBusBuilderTests.cs
+++ b/test/AWS.Messaging.UnitTests/MessageBusBuilderTests.cs
@@ -16,6 +16,8 @@ using AWS.Messaging.Publishers.SNS;
 using AWS.Messaging.Publishers.SQS;
 using AWS.Messaging.Serialization;
 using AWS.Messaging.Services;
+using AWS.Messaging.Services.Backoff;
+using AWS.Messaging.Services.Backoff.Policies;
 using AWS.Messaging.UnitTests.MessageHandlers;
 using AWS.Messaging.UnitTests.Models;
 using Microsoft.Extensions.DependencyInjection;
@@ -53,6 +55,187 @@ public class MessageBusBuilderTests
         Assert.NotNull(messagePublisher);
 
         CheckRequiredServices(serviceProvider);
+    }
+
+    [Fact]
+    public void MessageBus_ConfigureBackoffPolicy_Default()
+    {
+        _serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddSQSPoller("queueUrl");
+        });
+
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+
+        var backoffHandler = serviceProvider.GetService<IBackoffHandler>();
+        Assert.NotNull(backoffHandler);
+
+        var backoffPolicy = serviceProvider.GetService<IBackoffPolicy>();
+        Assert.NotNull(backoffPolicy);
+
+        Assert.IsType<CappedExponentialBackoffPolicy>(backoffPolicy);
+    }
+
+    [Fact]
+    public void MessageBus_ConfigureBackoffPolicy_NoBackoffHandler()
+    {
+        _serviceCollection.AddAWSMessageBus(builder => { });
+
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+
+        var backoffHandler = serviceProvider.GetService<IBackoffHandler>();
+        Assert.Null(backoffHandler);
+
+        var backoffPolicy = serviceProvider.GetService<IBackoffPolicy>();
+        Assert.Null(backoffPolicy);
+    }
+
+    [Fact]
+    public void MessageBus_ConfigureBackoffPolicy_NoBackoffPolicy()
+    {
+        _serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddSQSPoller("queueUrl");
+
+            builder.ConfigureBackoffPolicy(options =>
+            {
+                options.UseNoBackoff();
+            });
+        });
+
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+
+        var backoffHandler = serviceProvider.GetService<IBackoffHandler>();
+        Assert.NotNull(backoffHandler);
+
+        var backoffPolicy = serviceProvider.GetService<IBackoffPolicy>();
+        Assert.NotNull(backoffPolicy);
+
+        Assert.IsType<NoBackoffPolicy>(backoffPolicy);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(5)]
+    public void MessageBus_ConfigureBackoffPolicy_IntervalBackoffPolicy(int retry)
+    {
+        _serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddSQSPoller("queueUrl");
+
+            builder.ConfigureBackoffPolicy(options =>
+            {
+                options.UseIntervalBackoff();
+            });
+        });
+
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+
+        var backoffHandler = serviceProvider.GetService<IBackoffHandler>();
+        Assert.NotNull(backoffHandler);
+
+        var backoffPolicy = serviceProvider.GetService<IBackoffPolicy>();
+        Assert.NotNull(backoffPolicy);
+
+        Assert.IsType<IntervalBackoffPolicy>(backoffPolicy);
+
+        Assert.Equal(1000, backoffPolicy.RetrieveBackoffTime(retry));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(500)]
+    [InlineData(1000)]
+    [InlineData(1500)]
+    [InlineData(2000)]
+    [InlineData(2500)]
+    public void MessageBus_ConfigureBackoffPolicy_IntervalBackoffPolicy_WithOptions(int interval)
+    {
+        _serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddSQSPoller("queueUrl");
+
+            builder.ConfigureBackoffPolicy(options =>
+            {
+                options.UseIntervalBackoff(x =>
+                {
+                    x.FixedInterval = interval;
+                });
+            });
+        });
+
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+
+        var backoffHandler = serviceProvider.GetService<IBackoffHandler>();
+        Assert.NotNull(backoffHandler);
+
+        var backoffPolicy = serviceProvider.GetService<IBackoffPolicy>();
+        Assert.NotNull(backoffPolicy);
+
+        Assert.IsType<IntervalBackoffPolicy>(backoffPolicy);
+
+        Assert.Equal(interval, backoffPolicy.RetrieveBackoffTime(It.IsAny<int>()));
+    }
+
+    [Fact]
+    public void MessageBus_ConfigureBackoffPolicy_CappedExponentialBackoffPolicy()
+    {
+        _serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddSQSPoller("queueUrl");
+
+            builder.ConfigureBackoffPolicy(options =>
+            {
+                options.UseCappedExponentialBackoff();
+            });
+        });
+
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+
+        var backoffHandler = serviceProvider.GetService<IBackoffHandler>();
+        Assert.NotNull(backoffHandler);
+
+        var backoffPolicy = serviceProvider.GetService<IBackoffPolicy>();
+        Assert.NotNull(backoffPolicy);
+
+        Assert.IsType<CappedExponentialBackoffPolicy>(backoffPolicy);
+    }
+
+    [Theory]
+    [InlineData(5, 30)]
+    [InlineData(6, 60)]
+    [InlineData(7, 100)]
+    [InlineData(8, 200)]
+    public void MessageBus_ConfigureBackoffPolicy_CappedExponentialBackoffPolicy_WithOptions(int retry, int cap)
+    {
+        _serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddSQSPoller("queueUrl");
+
+            builder.ConfigureBackoffPolicy(options =>
+            {
+                options.UseCappedExponentialBackoff(x =>
+                {
+                    x.CapBackoffTime = cap;
+                });
+            });
+        });
+
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+
+        var backoffHandler = serviceProvider.GetService<IBackoffHandler>();
+        Assert.NotNull(backoffHandler);
+
+        var backoffPolicy = serviceProvider.GetService<IBackoffPolicy>();
+        Assert.NotNull(backoffPolicy);
+
+        Assert.IsType<CappedExponentialBackoffPolicy>(backoffPolicy);
+
+        Assert.Equal(cap, backoffPolicy.RetrieveBackoffTime(retry));
     }
 
     [Fact]
@@ -236,7 +419,7 @@ public class MessageBusBuilderTests
     }
 
     /// <summary>
-    /// Asserts that adding a SQS Poller will add the required 
+    /// Asserts that adding a SQS Poller will add the required
     /// factories and services to the service provider
     /// </summary>
     [Fact]
@@ -376,7 +559,7 @@ public class MessageBusBuilderTests
     /// </summary>
     public static IEnumerable<object[]> GetInvalidSQSMessagePollerOptionsCases()
     {
-        // MaxNumberOfConcurrentMessages must be postive 
+        // MaxNumberOfConcurrentMessages must be postive
         yield return new object[] { new Action<SQSMessagePollerOptions>((options) => options.MaxNumberOfConcurrentMessages = -1) };
         yield return new object[] { new Action<SQSMessagePollerOptions>((options) => options.MaxNumberOfConcurrentMessages = 0) };
 
@@ -388,7 +571,7 @@ public class MessageBusBuilderTests
         yield return new object[] { new Action<SQSMessagePollerOptions>((options) => options.WaitTimeSeconds = -1) };
         yield return new object[] { new Action<SQSMessagePollerOptions>((options) => options.WaitTimeSeconds = 21) };
 
-        // VisibilityTimeoutExtensionThreshold must be postive 
+        // VisibilityTimeoutExtensionThreshold must be postive
         yield return new object[] { new Action<SQSMessagePollerOptions>((options) => options.VisibilityTimeoutExtensionThreshold = -1) };
         yield return new object[] { new Action<SQSMessagePollerOptions>((options) => options.VisibilityTimeoutExtensionThreshold = 0) };
 


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7390

*Description of changes:*
* Create interfaces for IBackoffHandler and IBackoffPolicy
* Add message bus configuration points for specifying the backoff policy, which for now is no backoff, interval backoff or capped exponential backoff
* Implement the 3 backoff policies: No backoff, Interval backoff and Capped Exponential backoff
* Implement the default backoff handler
* Add a sample app that replaces our BackoffHandler with Polly
* Add tests and update docs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
