### PR TITLE
fix: fix the API reference not rendering

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -21,7 +21,6 @@
         ],
         "exclude": [
           "_site/**",
-          "docs/**",
           "filter.yml"
         ]
       }


### PR DESCRIPTION
*Description of changes:*
After the PR #102, GitHub Pages and the API reference stopped being rendered properly. This PR fixes the issue which was not reproducible locally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
