### PR TITLE
ci: add support for automated versioning and changelog creation

### DIFF
--- a/.autover/autover.json
+++ b/.autover/autover.json
@@ -1,0 +1,19 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Messaging",
+      "Path": "src/AWS.Messaging/AWS.Messaging.csproj"
+    },
+    {
+      "Name": "AWS.Messaging.Lambda",
+      "Path": "src/AWS.Messaging.Lambda/AWS.Messaging.Lambda.csproj"
+    },
+    {
+      "Name": "AWS.Messaging.Telemetry.OpenTelemetry",
+      "Path": "src/AWS.Messaging.Telemetry.OpenTelemetry/AWS.Messaging.Telemetry.OpenTelemetry.csproj"
+    }
+  ],
+  "UseCommitsForChangelog": false,
+  "DefaultIncrementType": "Patch",
+  "ChangeFilesDetermineIncrementType": true
+}

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,71 @@
+# This GitHub Workflow will create a new release branch that contains the updated C# project versions and changelog.
+# The workflow will also create a PR that targets `dev` from the release branch.
+name: Create Release PR
+
+# This workflow is manually triggered when in preparation for a release. The workflow should be dispatched from the `dev` branch.
+on:
+  workflow_dispatch:
+
+jobs:
+  release-pr:
+    name: Release PR
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout a full clone of the repo
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+      # Install .NET8 which is needed for AutoVer
+      - name: Setup .NET 8.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      # Install AutoVer to automate versioning and changelog creation
+      - name: Install AutoVer
+        run: dotnet tool install --global AutoVer --version 0.0.19
+      # Set up a git user to be able to run git commands later on
+      - name: Setup Git User
+        run: |
+          git config --global user.email "github-aws-sdk-dotnet-automation@amazon.com"
+          git config --global user.name "aws-sdk-dotnet-automation"
+      # Create the release branch which will contain the version changes and updated changelog
+      - name: Create Release Branch
+        id: create-release-branch
+        run: |
+          branch=releases/next-release
+          git checkout -b $branch
+          echo "BRANCH=$branch" >> $GITHUB_OUTPUT
+      # Update the version of projects based on the change files
+      - name: Increment Version
+        run: autover version
+      # Update the changelog based on the change files
+      - name: Update Changelog
+        run: autover changelog
+      # Push the release branch up as well as the created tag
+      - name: Push Changes
+        run: |
+          branch=${{ steps.create-release-branch.outputs.BRANCH }}
+          git push origin $branch
+          git push origin $branch --tags
+      # Get the release name that will be used to create a PR
+      - name: Read Release Name
+        id: read-release-name
+        run: |
+          version=$(autover changelog --release-name)
+          echo "VERSION=$version" >> $GITHUB_OUTPUT
+      # Get the changelog that will be used to create a PR
+      - name: Read Changelog
+        id: read-changelog
+        run: |
+          changelog=$(autover changelog --output-to-console)
+          echo "CHANGELOG<<EOF"$'\n'"$changelog"$'\n'EOF >> "$GITHUB_OUTPUT"
+      # Create the Release PR and label it
+      - name: Create Pull Request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pr_url="$(gh pr create --title "${{ steps.read-release-name.outputs.VERSION }}" --body "${{ steps.read-changelog.outputs.CHANGELOG }}" --base dev --head ${{ steps.create-release-branch.outputs.BRANCH }})"
+          gh label create "Release PR" --description "A Release PR that includes versioning and changelog changes" -c "#FF0000" -f
+          gh pr edit $pr_url --add-label "Release PR"

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -5,12 +5,20 @@ name: Create Release PR
 # This workflow is manually triggered when in preparation for a release. The workflow should be dispatched from the `dev` branch.
 on:
   workflow_dispatch:
+    inputs:
+      OVERRIDE_VERSION:
+        description: "Override Version"
+        type: string
+        required: false
 
 jobs:
   release-pr:
     name: Release PR
     runs-on: ubuntu-latest
 
+    env:
+      INPUT_OVERRIDE_VERSION: ${{ github.event.inputs.OVERRIDE_VERSION }}
+      
     steps:
       # Checkout a full clone of the repo
       - name: Checkout
@@ -24,7 +32,7 @@ jobs:
           dotnet-version: 8.0.x
       # Install AutoVer to automate versioning and changelog creation
       - name: Install AutoVer
-        run: dotnet tool install --global AutoVer --version 0.0.19
+        run: dotnet tool install --global AutoVer --version 0.0.20
       # Set up a git user to be able to run git commands later on
       - name: Setup Git User
         run: |
@@ -40,6 +48,11 @@ jobs:
       # Update the version of projects based on the change files
       - name: Increment Version
         run: autover version
+        if: env.INPUT_OVERRIDE_VERSION == ''
+      # Update the version of projects based on the override version
+      - name: Increment Version
+        run: autover version --use-version "$INPUT_OVERRIDE_VERSION"
+        if: env.INPUT_OVERRIDE_VERSION != ''
       # Update the changelog based on the change files
       - name: Update Changelog
         run: autover changelog

--- a/.github/workflows/sync-main-dev.yml
+++ b/.github/workflows/sync-main-dev.yml
@@ -1,0 +1,122 @@
+# This GitHub Workflow is designed to run automatically after the Release PR, which was created by the `Create Release PR` workflow, is closed.
+# This workflow has 2 jobs. One will run if the `Release PR` is successfully merged, indicating that a release should go out.
+# The other will run if the `Release PR` was closed and a release is not intended to go out.
+name: Sync 'dev' and 'main'
+
+# The workflow will automatically be triggered when any PR is closed.
+on:
+  pull_request:
+    types: [closed]
+
+permissions: 
+  contents: write
+
+jobs:
+  # This job will check if the PR was successfully merged, it's source branch is `releases/next-release` and target branch is `dev`. 
+  # This indicates that the merged PR was the `Release PR`. 
+  # This job will synchronize `dev` and `main`, create a GitHub Release and delete the `releases/next-release` branch.
+  sync-dev-and-main:
+    name: Sync dev and main
+    if: |
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.ref == 'releases/next-release' &&
+      github.event.pull_request.base.ref == 'dev'
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout a full clone of the repo
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 0
+      # Install .NET8 which is needed for AutoVer
+      - name: Setup .NET 8.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      # Install AutoVer which is needed to retrieve information about the current release.
+      - name: Install AutoVer
+        run: dotnet tool install --global AutoVer --version 0.0.19
+      # Set up a git user to be able to run git commands later on
+      - name: Setup Git User
+        run: |
+          git config --global user.email "github-aws-sdk-dotnet-automation@amazon.com"
+          git config --global user.name "aws-sdk-dotnet-automation"
+      # Retrieve the release name which is needed for the GitHub Release
+      - name: Read Release Name
+        id: read-release-name
+        run: |
+          version=$(autover changelog --release-name)
+          echo "VERSION=$version" >> $GITHUB_OUTPUT
+      # Retrieve the tag name which is needed for the GitHub Release
+      - name: Read Tag Name
+        id: read-tag-name
+        run: |
+          tag=$(autover changelog --tag-name)
+          echo "TAG=$tag" >> $GITHUB_OUTPUT
+      # Retrieve the changelog which is needed for the GitHub Release
+      - name: Read Changelog
+        id: read-changelog
+        run: |
+          changelog=$(autover changelog --output-to-console)
+          echo "CHANGELOG<<EOF"$'\n'"$changelog"$'\n'EOF >> "$GITHUB_OUTPUT"
+      # Merge dev into main in order to synchronize the 2 branches
+      - name: Merge dev to main
+        run: |
+          git fetch origin
+          git checkout main
+          git merge dev
+          git push origin main
+      # Create the GitHub Release
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.read-tag-name.outputs.TAG }}" --title "${{ steps.read-release-name.outputs.VERSION }}" --notes "${{ steps.read-changelog.outputs.CHANGELOG }}"
+      # Delete the `releases/next-release` branch
+      - name: Clean up
+        run: |
+          git fetch origin
+          git push origin --delete releases/next-release
+  # This job will check if the PR was closed, it's source branch is `releases/next-release` and target branch is `dev`. 
+  # This indicates that the closed PR was the `Release PR`.
+  # This job will delete the tag created by AutoVer and the release branch.
+  clean-up-closed-release:
+    name: Clean up closed release
+    if: |
+      github.event.pull_request.merged == false &&
+      github.event.pull_request.head.ref == 'releases/next-release' &&
+      github.event.pull_request.base.ref == 'dev'
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout a full clone of the repo
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: releases/next-release
+          fetch-depth: 0
+      # Install .NET8 which is needed for AutoVer
+      - name: Setup .NET 8.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      # Install AutoVer which is needed to retrieve information about the current release.
+      - name: Install AutoVer
+        run: dotnet tool install --global AutoVer --version 0.0.19
+      # Set up a git user to be able to run git commands later on
+      - name: Setup Git User
+        run: |
+          git config --global user.email "github-aws-sdk-dotnet-automation@amazon.com"
+          git config --global user.name "aws-sdk-dotnet-automation"
+      # Retrieve the tag name to be deleted
+      - name: Read Tag Name
+        id: read-tag-name
+        run: |
+          tag=$(autover changelog --tag-name)
+          echo "TAG=$tag" >> $GITHUB_OUTPUT
+      # Delete the tag created by AutoVer and the release branch
+      - name: Clean up
+        run: |
+          git fetch origin
+          git push --delete origin ${{ steps.read-tag-name.outputs.TAG }}
+          git push origin --delete releases/next-release

--- a/.github/workflows/sync-main-dev.yml
+++ b/.github/workflows/sync-main-dev.yml
@@ -36,7 +36,7 @@ jobs:
           dotnet-version: 8.0.x
       # Install AutoVer which is needed to retrieve information about the current release.
       - name: Install AutoVer
-        run: dotnet tool install --global AutoVer --version 0.0.19
+        run: dotnet tool install --global AutoVer --version 0.0.20
       # Set up a git user to be able to run git commands later on
       - name: Setup Git User
         run: |
@@ -102,7 +102,7 @@ jobs:
           dotnet-version: 8.0.x
       # Install AutoVer which is needed to retrieve information about the current release.
       - name: Install AutoVer
-        run: dotnet tool install --global AutoVer --version 0.0.19
+        run: dotnet tool install --global AutoVer --version 0.0.20
       # Set up a git user to be able to run git commands later on
       - name: Setup Git User
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Changelog
-
 ### Release 2024-03-20
 * **AWS.Messaging (0.3.0-beta)**
   * Added back-off logic to the SQS Poller that can perform Exponential, Interval or disable back-offs entirely. The SQS Poller will now back-off before attempting to reach SQS in case of an exception.

--- a/src/AWS.Messaging.Lambda/AWS.Messaging.Lambda.csproj
+++ b/src/AWS.Messaging.Lambda/AWS.Messaging.Lambda.csproj
@@ -26,7 +26,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.2.0" />
     <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AWS.Messaging.Telemetry.OpenTelemetry/AWS.Messaging.Telemetry.OpenTelemetry.csproj
+++ b/src/AWS.Messaging.Telemetry.OpenTelemetry/AWS.Messaging.Telemetry.OpenTelemetry.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="1.6.0" />
     <PackageReference Include="OpenTelemetry.Api" Version="1.6.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AWS.Messaging/AWS.Messaging.csproj
+++ b/src/AWS.Messaging/AWS.Messaging.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.*" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.*" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
*Description of changes:*
This PR adds support for AutoVer which automates versioning based on `change file` which contributors add to their PRs/Branches to indicate the type of change they are performing as well as the changelog message.
The change file looks like:
```
{
  "Projects": [
    {
      "Name": "AWS.Messaging",
      "Type": "Patch",
      "ChangelogMessages": [
        "The changelog message"
      ]
    }
  ]
}
```

As part of the normal SDLC on this repo, when we are ready to release a set of changes, we can kick off the `Create Release PR` workflow against the `dev` branch. This workflow will go through the `change file` and determine the proper version for the projects that need to be versioned. It will also create the changelog based on the messages in the `change files`. These file changes will be added to a new `releases/next-release` branch for which the workflow will create a PR against to be merged to `dev`. We will have a chance to review the release PR as a sanity check. Once we are satisfied with the versions and changelog, we can merge that PR into dev.
This will trigger the workflow `Sync dev and main` which will check if the Release PR was successfully merged or it was closed. If the PR was successfully merged, it will sync dev and main, create a GitHub release and delete the `releases/next-release` branch. If the PR was closed, it will clean up the tag and branch created by AutoVer.

AutoVer is configured using the file `.autover/autover.json`. In that file, I have specified the projects that we want to version and I have indicated the we will use `change files` to determine the version and changelogs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
