### PR TITLE
fix: Correctly deserialize outer envelope when processing messages relayed through EventBridge

### DIFF
--- a/src/AWS.Messaging/Serialization/EnvelopeSerializer.cs
+++ b/src/AWS.Messaging/Serialization/EnvelopeSerializer.cs
@@ -316,7 +316,15 @@ internal class EnvelopeSerializer : IEnvelopeSerializer
     {
         if (node.TryGetProperty(propertyName, out var propertyValue))
         {
-            return propertyValue.ToString();
+            return propertyValue.ValueKind switch
+            {
+                JsonValueKind.Object => propertyValue.GetRawText(),
+                JsonValueKind.String => propertyValue.GetString(),
+                JsonValueKind.Number => propertyValue.ToString(),
+                JsonValueKind.True => propertyValue.ToString(),
+                JsonValueKind.False => propertyValue.ToString(),
+                _ => throw new InvalidDataException($"{propertyValue.ValueKind} cannot be converted to a string value"),
+            };
         }
         return null;
     }

--- a/src/AWS.Messaging/Serialization/EnvelopeSerializer.cs
+++ b/src/AWS.Messaging/Serialization/EnvelopeSerializer.cs
@@ -244,13 +244,13 @@ internal class EnvelopeSerializer : IEnvelopeSerializer
                 SetSNSMetadata(envelopeConfiguration, root);
             }
             // Check if the SQS message body contains an outer envelope injected by EventBridge.
-            else if (root.TryGetProperty("detail", out var innerEnvelope)
+            else if (root.TryGetProperty("detail", out var _)
                 && root.TryGetProperty("id", out var _)
                 && root.TryGetProperty("version", out var _)
                 && root.TryGetProperty("region", out var _))
             {
                 // Retrieve the inner message envelope.
-                envelopeConfiguration.MessageEnvelopeBody = innerEnvelope.GetString();
+                envelopeConfiguration.MessageEnvelopeBody = GetJsonPropertyAsString(root, "detail");
                 if (string.IsNullOrEmpty(envelopeConfiguration.MessageEnvelopeBody))
                 {
                     _logger.LogError("Failed to create a message envelope configuration because the EventBridge message envelope does not contain a valid 'detail' property.");
@@ -316,7 +316,7 @@ internal class EnvelopeSerializer : IEnvelopeSerializer
     {
         if (node.TryGetProperty(propertyName, out var propertyValue))
         {
-            return propertyValue.GetString();
+            return propertyValue.ToString();
         }
         return null;
     }

--- a/test/AWS.Messaging.IntegrationTests/EventBridgeEndToEndTests.cs
+++ b/test/AWS.Messaging.IntegrationTests/EventBridgeEndToEndTests.cs
@@ -1,0 +1,189 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.EventBridge.Model;
+using Amazon.EventBridge;
+using Amazon.SecurityToken.Model;
+using Amazon.SecurityToken;
+using Amazon.SQS.Model;
+using Amazon.SQS;
+using AWS.Messaging.IntegrationTests.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using AWS.Messaging.IntegrationTests.Handlers;
+using AWS.Messaging.Services;
+using Microsoft.Extensions.Hosting;
+using System.Threading;
+
+namespace AWS.Messaging.IntegrationTests;
+
+public class EventBridgeEndToEndTests : IAsyncLifetime
+{
+    private readonly IAmazonEventBridge _eventBridgeClient;
+    private readonly IAmazonSQS _sqsClient;
+    private readonly IAmazonSecurityTokenService _stsClient;
+    private ServiceProvider _serviceProvider;
+    private string _eventBusArn;
+    private string _resourceName;
+    private string _sqsQueueUrl;
+
+    public EventBridgeEndToEndTests()
+    {
+        _sqsClient = new AmazonSQSClient();
+        _eventBridgeClient = new AmazonEventBridgeClient();
+        _stsClient = new AmazonSecurityTokenServiceClient();
+        _serviceProvider = default!;
+        _eventBusArn = string.Empty;
+        _resourceName = string.Empty;
+        _sqsQueueUrl = string.Empty;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _resourceName = $"MPFTest-{Guid.NewGuid().ToString().Split('-').Last()}";
+        var createQueueResponse = await _sqsClient.CreateQueueAsync(_resourceName);
+        _sqsQueueUrl = createQueueResponse.QueueUrl;
+        var getQueueAttributesResponse = await _sqsClient.GetQueueAttributesAsync(_sqsQueueUrl, new List<string> { "QueueArn" });
+        var sqsQueueArn = getQueueAttributesResponse.QueueARN;
+        await _sqsClient.SetQueueAttributesAsync(new SetQueueAttributesRequest
+        {
+            QueueUrl = _sqsQueueUrl,
+            Attributes = new Dictionary<string, string>
+            {
+                { "Policy",
+                    @$"{{
+                        ""Version"": ""2008-10-17"",
+                        ""Statement"": [
+                            {{
+                                ""Effect"": ""Allow"",
+                                ""Principal"": {{
+                                    ""Service"": ""events.amazonaws.com""
+                                }},
+                                ""Action"": ""SQS:SendMessage"",
+                                ""Resource"": ""{sqsQueueArn}""
+                            }}
+                        ]
+                    }}"
+                }
+            }
+        });
+
+        var createEventBusResponse = await _eventBridgeClient.CreateEventBusAsync(
+            new CreateEventBusRequest
+            {
+                Name = _resourceName
+            });
+        _eventBusArn = createEventBusResponse.EventBusArn;
+
+        var getCallerIdentityResponse = await _stsClient.GetCallerIdentityAsync(new GetCallerIdentityRequest());
+        await _eventBridgeClient.PutRuleAsync(new PutRuleRequest
+        {
+            Name = _resourceName,
+            EventBusName = _resourceName,
+            EventPattern =
+            @$"{{
+              ""account"": [""{getCallerIdentityResponse.Account}""],
+              ""source"": [""/aws/messaging""]
+            }}"
+        });
+
+        await _eventBridgeClient.PutTargetsAsync(new PutTargetsRequest
+        {
+            EventBusName = _resourceName,
+            Targets = new List<Target>
+            {
+                new Target
+                {
+                    Arn = sqsQueueArn,
+                    Id = _resourceName
+                }
+            },
+            Rule = _resourceName
+        });
+
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddLogging();
+        serviceCollection.AddSingleton<TempStorage<ChatMessage>>();
+        serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddEventBridgePublisher<ChatMessage>(_eventBusArn);
+            builder.AddMessageSource("/aws/messaging");
+            builder.AddSQSPoller(_sqsQueueUrl, options =>
+            {
+                options.VisibilityTimeoutExtensionThreshold = 3;
+            });
+            builder.AddMessageHandler<ChatMessageHandler, ChatMessage>();
+        });
+        _serviceProvider = serviceCollection.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task PublishAndProcessMessage()
+    {
+        var publishStartTime = DateTime.UtcNow;
+        var publisher = _serviceProvider.GetRequiredService<IMessagePublisher>();
+        await publisher.PublishAsync(new ChatMessage
+        {
+            MessageDescription = "Test1"
+        });
+        var publishEndTime = DateTime.UtcNow;
+
+        var pump = _serviceProvider.GetRequiredService<IHostedService>() as MessagePumpService;
+        Assert.NotNull(pump);
+        var source = new CancellationTokenSource();
+
+        await pump.StartAsync(source.Token);
+
+        var tempStorage = _serviceProvider.GetRequiredService<TempStorage<ChatMessage>>();
+        source.CancelAfter(60000);
+        while (!source.IsCancellationRequested) { }
+
+        var messageEnvelope = Assert.Single(tempStorage.Messages);
+        Assert.False(string.IsNullOrEmpty(messageEnvelope.Id));
+        Assert.Equal("/aws/messaging", messageEnvelope.Source.ToString());
+        Assert.True(messageEnvelope.TimeStamp > publishStartTime);
+        Assert.True(messageEnvelope.TimeStamp < publishEndTime);
+        Assert.Equal("Test1", messageEnvelope.Message.MessageDescription);
+    }
+
+    public async Task DisposeAsync()
+    {
+        try
+        {
+            await _eventBridgeClient.RemoveTargetsAsync(new RemoveTargetsRequest
+            {
+                EventBusName = _resourceName,
+                Force = true,
+                Ids = new List<string> { _resourceName },
+                Rule = _resourceName
+            });
+        }
+        catch { }
+        try
+        {
+            await _eventBridgeClient.DeleteRuleAsync(new DeleteRuleRequest
+            {
+                EventBusName = _resourceName,
+                Name = _resourceName
+            });
+        }
+        catch { }
+        try
+        {
+            await _eventBridgeClient.DeleteEventBusAsync(new DeleteEventBusRequest
+            {
+                Name = _resourceName
+            });
+        }
+        catch { }
+        try
+        {
+            await _sqsClient.DeleteQueueAsync(_sqsQueueUrl);
+        }
+        catch { }
+    }
+}

--- a/test/AWS.Messaging.IntegrationTests/SNSEndToEndTests.cs
+++ b/test/AWS.Messaging.IntegrationTests/SNSEndToEndTests.cs
@@ -1,0 +1,106 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Amazon.SQS;
+using Microsoft.Extensions.DependencyInjection;
+using AWS.Messaging.IntegrationTests.Models;
+using Amazon.SimpleNotificationService;
+using Amazon.SimpleNotificationService.Model;
+using AWS.Messaging.IntegrationTests.Handlers;
+using AWS.Messaging.Services;
+using Microsoft.Extensions.Hosting;
+using System.Threading;
+
+namespace AWS.Messaging.IntegrationTests;
+
+public class SNSEndToEndTests : IAsyncLifetime
+{
+    private readonly IAmazonSimpleNotificationService _snsClient;
+    private readonly IAmazonSQS _sqsClient;
+    private ServiceProvider _serviceProvider;
+    private string _snsTopicArn;
+    private string _sqsQueueUrl;
+
+    public SNSEndToEndTests()
+    {
+        _sqsClient = new AmazonSQSClient();
+        _snsClient = new AmazonSimpleNotificationServiceClient();
+        _serviceProvider = default!;
+        _snsTopicArn = string.Empty;
+        _sqsQueueUrl = string.Empty;
+    }
+
+    public async Task InitializeAsync()
+    {
+        var resourceName = $"MPFTest-{Guid.NewGuid().ToString().Split('-').Last()}";
+        var createQueueResponse = await _sqsClient.CreateQueueAsync(resourceName);
+        _sqsQueueUrl = createQueueResponse.QueueUrl;
+
+        var createTopicResponse = await _snsClient.CreateTopicAsync(resourceName);
+        _snsTopicArn = createTopicResponse.TopicArn;
+
+        await _snsClient.SubscribeQueueAsync(_snsTopicArn, _sqsClient, _sqsQueueUrl);
+
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddLogging();
+        serviceCollection.AddSingleton<TempStorage<ChatMessage>>();
+        serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddSNSPublisher<ChatMessage>(_snsTopicArn);
+            builder.AddMessageSource("/aws/messaging");
+            builder.AddSQSPoller(_sqsQueueUrl, options =>
+            {
+                options.VisibilityTimeoutExtensionThreshold = 3;
+            });
+            builder.AddMessageHandler<ChatMessageHandler, ChatMessage>();
+        });
+        _serviceProvider = serviceCollection.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task PublishAndProcessMessage()
+    {
+        var publishStartTime = DateTime.UtcNow;
+        var publisher = _serviceProvider.GetRequiredService<IMessagePublisher>();
+        await publisher.PublishAsync(new ChatMessage
+        {
+            MessageDescription = "Test1"
+        });
+        var publishEndTime = DateTime.UtcNow;
+
+        var pump = _serviceProvider.GetRequiredService<IHostedService>() as MessagePumpService;
+        Assert.NotNull(pump);
+        var source = new CancellationTokenSource();
+
+        await pump.StartAsync(source.Token);
+
+        var tempStorage = _serviceProvider.GetRequiredService<TempStorage<ChatMessage>>();
+        source.CancelAfter(60000);
+        while (!source.IsCancellationRequested) { }
+
+        var messageEnvelope = Assert.Single(tempStorage.Messages);
+        Assert.False(string.IsNullOrEmpty(messageEnvelope.Id));
+        Assert.Equal("/aws/messaging", messageEnvelope.Source.ToString());
+        Assert.True(messageEnvelope.TimeStamp > publishStartTime);
+        Assert.True(messageEnvelope.TimeStamp < publishEndTime);
+        Assert.Equal("Test1", messageEnvelope.Message.MessageDescription);
+    }
+
+    public async Task DisposeAsync()
+    {
+        try
+        {
+            await _snsClient.DeleteTopicAsync(new DeleteTopicRequest { TopicArn = _snsTopicArn });
+        }
+        catch { }
+        try
+        {
+            await _sqsClient.DeleteQueueAsync(_sqsQueueUrl);
+        }
+        catch { }
+    }
+}

--- a/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
@@ -268,19 +268,19 @@ public class EnvelopeSerializerTests
         var serviceProvider = _serviceCollection.BuildServiceProvider();
         var envelopeSerializer = serviceProvider.GetRequiredService<IEnvelopeSerializer>();
 
-        var innerMessageEnvelope = new MessageEnvelope<AddressInfo>
+        var innerMessageEnvelope = new MessageEnvelope<string>
         {
             Id = "66659d05-e4ff-462f-81c4-09e560e66a5c",
             Source = new Uri("/aws/messaging", UriKind.Relative),
             Version = "1.0",
             MessageTypeIdentifier = "addressInfo",
             TimeStamp = _testdate,
-            Message = new AddressInfo
+            Message = JsonSerializer.Serialize(new AddressInfo
             {
                 Street = "Prince St",
                 Unit = 123,
                 ZipCode = "00001"
-            }
+            })
         };
 
         var outerMessageEnvelope = new Dictionary<string, object>
@@ -293,7 +293,7 @@ public class EnvelopeSerializerTests
             { "account", "123456789123" },
             { "region", "us-west-2" },
             { "resources", new List<string>{ "arn1", "arn2" } },
-            { "detail", await envelopeSerializer.SerializeAsync(innerMessageEnvelope) },
+            { "detail", innerMessageEnvelope }, // The "detail" property is set as a JSON object and not a string.
         };
 
         var sqsMessage = new Message


### PR DESCRIPTION
*Issue*
* https://github.com/awslabs/aws-dotnet-messaging/issues/97
* DOTNET-7432

*Description of changes:* 
This is a sample SQS message when messages are forwarded by EventBridge
```
{
  "version": "0",
  "id": "961ac8a3-a4ee-0e17-d8d9-36c81ae29955",
  "detail-type": "AWS.Messaging.IntegrationTests.Models.ChatMessage",
  "source": "/aws/messaging",
  "account": "000000000",
  "time": "2024-03-25T20:39:11Z",
  "region": "us-west-2",
  "resources": [],
  "detail": {
    "id": "526d5466-5f51-42ce-a64b-8a220a7f1b71",
    "source": "/aws/messaging",
    "specversion": "1.0",
    "type": "AWS.Messaging.IntegrationTests.Models.ChatMessage",
    "time": "2024-03-25T20:39:10.8491344+00:00",
    "data": "{\"MessageDescription\":\"Test1\"}"
  }
}
```

The `detail` property is sent as a JSON object and not as a string. Invoking [JsonElement.GetString](https://learn.microsoft.com/en-us/dotnet/api/system.text.json.jsonelement.getstring?view=net-8.0) on this node throws an `InvalidOperationException`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
