### PR TITLE
Feature/improve exception text

### DIFF
--- a/src/AWS.Messaging/Exceptions.cs
+++ b/src/AWS.Messaging/Exceptions.cs
@@ -118,6 +118,17 @@ public class FailedToSerializeApplicationMessageException : AWSMessagingExceptio
 }
 
 /// <summary>
+/// Thrown if an exception occurs while publishing the message to SNS, SQS or EventBridge.
+/// </summary>
+public class FailedToPublishException : AWSMessagingException
+{
+    /// <summary>
+    /// Creates an instance of <see cref="FailedToPublishException"/>.
+    /// </summary>
+    public FailedToPublishException(string message, Exception? innerException = null) : base(message, innerException) { }
+}
+
+/// <summary>
 /// Thrown if the message being sent is invalid.
 /// </summary>
 public class InvalidMessageException : AWSMessagingException
@@ -260,3 +271,23 @@ public class InvalidFifoPublishingRequestException : AWSMessagingException
     /// </summary>
     public InvalidFifoPublishingRequestException(string message, Exception? innerException = null) : base(message, innerException) { }
 }
+
+/// <summary>
+/// Thrown if the EventBridgePublishResponse contains a message with an errorcode
+/// </summary>
+public class EventBridgePutEventsException : Exception
+{
+    /// <summary>
+    /// The error code from the EventBridge SDK
+    /// </summary>
+    public string ErrorCode { get; }
+
+    /// <summary>
+    /// Creates an instance of <see cref="EventBridgePutEventsException"/>.
+    /// </summary>
+    public EventBridgePutEventsException(string message, string errorCode) : base(message)
+    {
+        ErrorCode = errorCode;
+    }
+}
+

--- a/src/AWS.Messaging/IMessagePublisher.cs
+++ b/src/AWS.Messaging/IMessagePublisher.cs
@@ -29,5 +29,6 @@ public interface IMessagePublisher
     /// This method is accessible by injecting <see cref="IMessagePublisher"/> into the application code
     /// using the dependency injection framework.
     /// </summary>
+    /// <exception cref="FailedToPublishException">If the message failed to publish. The inner exception contains more details if failures arise from the SDK.</exception>
     Task<IPublishResponse> PublishAsync<T>(T message, CancellationToken token = default);
 }

--- a/src/AWS.Messaging/IMessagePublisher.cs
+++ b/src/AWS.Messaging/IMessagePublisher.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using AWS.Messaging.Configuration;
+using AWS.Messaging.Publishers;
 using AWS.Messaging.Publishers.SQS;
 
 namespace AWS.Messaging;
@@ -13,7 +14,7 @@ namespace AWS.Messaging;
 /// Using dependency injection, this interface is available to inject anywhere in the code.
 /// </summary>
 /// <remarks>
-/// This is the generic publisher, which can publish multiple message types to any of the 
+/// This is the generic publisher, which can publish multiple message types to any of the
 /// supported AWS services. To set service-specific options when publishing, use the service-specific
 /// publisher interface (such as <see cref="ISQSPublisher"/> for SQS) instead.
 /// </remarks>
@@ -28,5 +29,5 @@ public interface IMessagePublisher
     /// This method is accessible by injecting <see cref="IMessagePublisher"/> into the application code
     /// using the dependency injection framework.
     /// </summary>
-    Task PublishAsync<T>(T message, CancellationToken token = default);
+    Task<IPublishResponse> PublishAsync<T>(T message, CancellationToken token = default);
 }

--- a/src/AWS.Messaging/Publishers/EventBridge/EventBridgePublishResponse.cs
+++ b/src/AWS.Messaging/Publishers/EventBridge/EventBridgePublishResponse.cs
@@ -1,0 +1,129 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Publishers.EventBridge;
+/// <summary>
+/// Represents the results of an event published to an event bus.
+///
+///
+/// <para>
+/// If the publishing was successful, the entry has the event ID in it. Otherwise, you
+/// can use the error code and error message to identify the problem with the entry.
+/// </para>
+///
+/// <para>
+/// For information about the errors that are common to all actions, see <a href="https://docs.aws.amazon.com/eventbridge/latest/APIReference/CommonErrors.html">Common
+/// Errors</a>.
+/// </para>
+/// </summary>
+public class EventBridgePublishResponse : IPublishResponse
+{
+    /// <summary>
+        /// Gets and sets the property ErrorCode.
+        /// <para>
+        /// The error code that indicates why the event submission failed.
+        /// </para>
+        ///
+        /// <para>
+        /// Retryable errors include:
+        /// </para>
+        ///  <ul> <li>
+        /// <para>
+        ///  <code> <a href="https://docs.aws.amazon.com/eventbridge/latest/APIReference/CommonErrors.html">InternalFailure</a>
+        /// </code>
+        /// </para>
+        ///
+        /// <para>
+        /// The request processing has failed because of an unknown error, exception or failure.
+        /// </para>
+        ///  </li> <li>
+        /// <para>
+        ///  <code> <a href="https://docs.aws.amazon.com/eventbridge/latest/APIReference/CommonErrors.html">ThrottlingException</a>
+        /// </code>
+        /// </para>
+        ///
+        /// <para>
+        /// The request was denied due to request throttling.
+        /// </para>
+        ///  </li> </ul>
+        /// <para>
+        /// Non-retryable errors include:
+        /// </para>
+        ///  <ul> <li>
+        /// <para>
+        ///  <code> <a href="https://docs.aws.amazon.com/eventbridge/latest/APIReference/CommonErrors.html">AccessDeniedException</a>
+        /// </code>
+        /// </para>
+        ///
+        /// <para>
+        /// You do not have sufficient access to perform this action.
+        /// </para>
+        ///  </li> <li>
+        /// <para>
+        ///  <code>InvalidAccountIdException</code>
+        /// </para>
+        ///
+        /// <para>
+        /// The account ID provided is not valid.
+        /// </para>
+        ///  </li> <li>
+        /// <para>
+        ///  <code>InvalidArgument</code>
+        /// </para>
+        ///
+        /// <para>
+        /// A specified parameter is not valid.
+        /// </para>
+        ///  </li> <li>
+        /// <para>
+        ///  <code>MalformedDetail</code>
+        /// </para>
+        ///
+        /// <para>
+        /// The JSON provided is not valid.
+        /// </para>
+        ///  </li> <li>
+        /// <para>
+        ///  <code>RedactionFailure</code>
+        /// </para>
+        ///
+        /// <para>
+        /// Redacting the CloudTrail event failed.
+        /// </para>
+        ///  </li> <li>
+        /// <para>
+        ///  <code>NotAuthorizedForSourceException</code>
+        /// </para>
+        ///
+        /// <para>
+        /// You do not have permissions to publish events with this source onto this event bus.
+        /// </para>
+        ///  </li> <li>
+        /// <para>
+        ///  <code>NotAuthorizedForDetailTypeException</code>
+        /// </para>
+        ///
+        /// <para>
+        /// You do not have permissions to publish events with this detail type onto this event
+        /// bus.
+        /// </para>
+        ///  </li> </ul>
+        /// </summary>
+    public string? ErrorCode { get; set; }
+
+    /// <summary>
+    /// Gets and sets the property ErrorMessage.
+    /// <para>
+    /// The error message that explains why the event submission failed.
+    /// </para>
+    /// </summary>
+    public string? ErrorMessage { get; set; }
+
+    /// <summary>
+    /// Gets and sets the property EventId.
+    /// <para>
+    /// The ID of the event.
+    /// </para>
+    /// </summary>
+    public string? EventId { get; set; }
+}

--- a/src/AWS.Messaging/Publishers/EventBridge/EventBridgePublishResponse.cs
+++ b/src/AWS.Messaging/Publishers/EventBridge/EventBridgePublishResponse.cs
@@ -125,5 +125,5 @@ public class EventBridgePublishResponse : IPublishResponse
     /// The ID of the event.
     /// </para>
     /// </summary>
-    public string? EventId { get; set; }
+    public string? MessageId { get; set; }
 }

--- a/src/AWS.Messaging/Publishers/EventBridge/EventBridgePublisher.cs
+++ b/src/AWS.Messaging/Publishers/EventBridge/EventBridgePublisher.cs
@@ -43,6 +43,7 @@ internal class EventBridgePublisher : IMessagePublisher, IEventBridgePublisher
     /// <summary>
     /// <inheritdoc/>
     /// </summary>
+    /// <exception cref="FailedToPublishException">If the message failed to publish.</exception>
     /// <exception cref="InvalidMessageException">If the message is null or invalid.</exception>
     /// <exception cref="MissingMessageTypeConfigurationException">If cannot find the publisher configuration for the message type.</exception>
     public async Task<IPublishResponse> PublishAsync<T>(T message, CancellationToken token = default)
@@ -56,6 +57,7 @@ internal class EventBridgePublisher : IMessagePublisher, IEventBridgePublisher
     /// <param name="message">The application message that will be serialized and sent to an event bus</param>
     /// <param name="eventBridgeOptions">Contains additional parameters that can be set while sending a message to EventBridge</param>
     /// <param name="token">The cancellation token used to cancel the request.</param>
+    /// <exception cref="FailedToPublishException">If the message failed to publish.</exception>
     /// <exception cref="InvalidMessageException">If the message is null or invalid.</exception>
     /// <exception cref="MissingMessageTypeConfigurationException">If cannot find the publisher configuration for the message type.</exception>
     public async Task<EventBridgePublishResponse> PublishAsync<T>(T message, EventBridgeOptions? eventBridgeOptions, CancellationToken token = default)
@@ -80,7 +82,7 @@ internal class EventBridgePublisher : IMessagePublisher, IEventBridgePublisher
                 if (string.IsNullOrEmpty(eventBusName))
                 {
                     _logger.LogError("Unable to determine a destination event bus for message of type '{MessageType}'.", typeof(T));
-                    throw new InvalidPublisherEndpointException($"Unable to determine a destination queue for message of type '{typeof(T)}'.");
+                    throw new InvalidPublisherEndpointException($"Unable to determine a destination event bus for message of type '{typeof(T)}'.");
                 }
 
                 trace.AddMetadata(TelemetryKeys.EventBusName, eventBusName);
@@ -115,24 +117,25 @@ internal class EventBridgePublisher : IMessagePublisher, IEventBridgePublisher
                 var firstEntry = putEventsResponse.Entries.First(); // only 1 message is published, so we only expect 1 result
                 var publishResponse = new EventBridgePublishResponse()
                 {
-                    EventId = firstEntry.EventId,
+                    MessageId = firstEntry.EventId,
                     ErrorMessage = firstEntry.ErrorMessage,
                     ErrorCode = firstEntry.ErrorCode
                 };
+
                 if (string.IsNullOrWhiteSpace(firstEntry.ErrorCode))
                 {
-                    _logger.LogDebug("The message of type '{MessageType}' has been pushed successfully to EventBridge as event-id '{EventId}'.", typeof(T), publishResponse.EventId);
-                }
-                else
-                {
-                    _logger.LogDebug("The message of type '{MessageType}' has been pushed to EventBridge but failed with '{ErrorCode}'.", typeof(T), publishResponse.ErrorCode);
-                }
+                    _logger.LogDebug("The message of type '{MessageType}' has been pushed successfully to EventBridge as event-id '{EventId}'.", typeof(T), publishResponse.MessageId);
 
-                return publishResponse;
+                    return publishResponse;
+                }
+                _logger.LogDebug("The message of type '{MessageType}' has been pushed to EventBridge but failed with '{ErrorCode}'.", typeof(T), publishResponse.ErrorCode);
+                throw new EventBridgePutEventsException(firstEntry.ErrorMessage, firstEntry.ErrorCode);
             }
             catch (Exception ex)
             {
                 trace.AddException(ex);
+                if (ex is not AWSMessagingException)
+                    throw new FailedToPublishException("Message failed to publish.", ex);
                 throw;
             }
         }

--- a/src/AWS.Messaging/Publishers/EventBridge/IEventBridgePublisher.cs
+++ b/src/AWS.Messaging/Publishers/EventBridge/IEventBridgePublisher.cs
@@ -18,6 +18,6 @@ namespace AWS.Messaging.Publishers.EventBridge
         /// <param name="message">The application message that will be serialized and sent to an SNS topic</param>
         /// <param name="eventBridgeOptions">Contains additional parameters that can be set while sending a message to EventBridge</param>
         /// <param name="token">The cancellation token used to cancel the request.</param>
-        Task PublishAsync<T>(T message, EventBridgeOptions? eventBridgeOptions, CancellationToken token = default);
+        Task<EventBridgePublishResponse> PublishAsync<T>(T message, EventBridgeOptions? eventBridgeOptions, CancellationToken token = default);
     }
 }

--- a/src/AWS.Messaging/Publishers/IPublishResponse.cs
+++ b/src/AWS.Messaging/Publishers/IPublishResponse.cs
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Publishers;
+
+/// <summary>
+/// Represents the results of a published event
+/// </summary>
+public interface IPublishResponse
+{
+    /// <summary>
+    /// Gets and sets the property ErrorMessage.
+    /// <para>
+    /// The error message that explains why the event publish failed.
+    /// </para>
+    /// </summary>
+    public string? ErrorMessage { get; set; }
+
+    /// <summary>
+    /// Gets and sets the property EventId.
+    /// <para>
+    /// The ID of the event.
+    /// </para>
+    /// </summary>
+    public string? EventId { get; set; }
+}

--- a/src/AWS.Messaging/Publishers/IPublishResponse.cs
+++ b/src/AWS.Messaging/Publishers/IPublishResponse.cs
@@ -4,23 +4,15 @@
 namespace AWS.Messaging.Publishers;
 
 /// <summary>
-/// Represents the results of a published event
+/// Represents the results of a published message
 /// </summary>
 public interface IPublishResponse
 {
     /// <summary>
-    /// Gets and sets the property ErrorMessage.
+    /// Gets and sets the property MessageId.
     /// <para>
-    /// The error message that explains why the event publish failed.
+    /// The ID of the message.
     /// </para>
     /// </summary>
-    public string? ErrorMessage { get; set; }
-
-    /// <summary>
-    /// Gets and sets the property EventId.
-    /// <para>
-    /// The ID of the event.
-    /// </para>
-    /// </summary>
-    public string? EventId { get; set; }
+    public string? MessageId { get; set; }
 }

--- a/src/AWS.Messaging/Publishers/MessageRoutingPublisher.cs
+++ b/src/AWS.Messaging/Publishers/MessageRoutingPublisher.cs
@@ -68,7 +68,7 @@ internal class MessageRoutingPublisher : IMessagePublisher
     /// </summary>
     /// <param name="message">The message to be sent.</param>
     /// <param name="token">The cancellation token used to cancel the request.</param>
-    public async Task PublishAsync<T>(T message, CancellationToken token = default)
+    public async Task<IPublishResponse> PublishAsync<T>(T message, CancellationToken token = default)
     {
         using (var trace = _telemetryFactory.Trace("Routing message to AWS service"))
         {
@@ -90,12 +90,12 @@ internal class MessageRoutingPublisher : IMessagePublisher
                     if (typeof(ICommandPublisher).IsAssignableFrom(publisherType))
                     {
                         var publisher = _commandPublisherInstances.GetOrAdd(publisherType, _ => (ICommandPublisher) ActivatorUtilities.CreateInstance(_serviceProvider, publisherType));
-                        await publisher.SendAsync(message, token);
+                        return await publisher.SendAsync(message, token);
                     }
                     else if (typeof(IEventPublisher).IsAssignableFrom(publisherType))
                     {
                         var publisher = _eventPublisherInstances.GetOrAdd(publisherType, _ => (IEventPublisher) ActivatorUtilities.CreateInstance(_serviceProvider, publisherType));
-                        await publisher.PublishAsync(message, token);
+                        return await publisher.PublishAsync(message, token);
                     }
                     else
                     {

--- a/src/AWS.Messaging/Publishers/SNS/ISNSPublisher.cs
+++ b/src/AWS.Messaging/Publishers/SNS/ISNSPublisher.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using Amazon.SimpleNotificationService.Model;
 using AWS.Messaging.Services;
 
 namespace AWS.Messaging.Publishers.SNS
@@ -18,6 +19,6 @@ namespace AWS.Messaging.Publishers.SNS
         /// <param name="message">The application message that will be serialized and sent to an SNS topic</param>
         /// <param name="snsOptions">Contains additional parameters that can be set while sending a message to an SNS topic</param>
         /// <param name="token">The cancellation token used to cancel the request.</param>
-        Task PublishAsync<T>(T message, SNSOptions? snsOptions, CancellationToken token = default);
+        Task<SNSPublishResponse> PublishAsync<T>(T message, SNSOptions? snsOptions, CancellationToken token = default);
     }
 }

--- a/src/AWS.Messaging/Publishers/SNS/SNSPublishResponse.cs
+++ b/src/AWS.Messaging/Publishers/SNS/SNSPublishResponse.cs
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Publishers.SNS;
+
+/// <summary>
+/// Response for Publish action.
+/// </summary>
+public class SNSPublishResponse : IPublishResponse
+{
+    /// <summary>
+    /// The error message as provided by SNS, if any
+    /// </summary>
+    public string? ErrorMessage { get; set; }
+
+    /// <summary>
+    /// Gets and sets the property MessageId.
+    /// <para>
+    /// Unique identifier assigned to the published message.
+    /// </para>
+    ///
+    /// <para>
+    /// Length Constraint: Maximum 100 characters
+    /// </para>
+    /// </summary>
+    public string? EventId { get; set; }
+}

--- a/src/AWS.Messaging/Publishers/SNS/SNSPublishResponse.cs
+++ b/src/AWS.Messaging/Publishers/SNS/SNSPublishResponse.cs
@@ -23,5 +23,5 @@ public class SNSPublishResponse : IPublishResponse
     /// Length Constraint: Maximum 100 characters
     /// </para>
     /// </summary>
-    public string? EventId { get; set; }
+    public string? MessageId { get; set; }
 }

--- a/src/AWS.Messaging/Publishers/SQS/ISQSPublisher.cs
+++ b/src/AWS.Messaging/Publishers/SQS/ISQSPublisher.cs
@@ -18,6 +18,6 @@ namespace AWS.Messaging.Publishers.SQS
         /// <param name="message">The application message that will be serialized and sent to an SQS queue</param>
         /// <param name="sqsOptions">Contains additional parameters that can be set while sending a message to an SQS queue</param>
         /// <param name="token">The cancellation token used to cancel the request.</param>
-        Task SendAsync<T>(T message, SQSOptions? sqsOptions, CancellationToken token = default);
+        Task<SQSSendResponse> SendAsync<T>(T message, SQSOptions? sqsOptions, CancellationToken token = default);
     }
 }

--- a/src/AWS.Messaging/Publishers/SQS/SQSPublisher.cs
+++ b/src/AWS.Messaging/Publishers/SQS/SQSPublisher.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Net;
 using Amazon.SQS;
 using Amazon.SQS.Model;
 using AWS.Messaging.Configuration;
@@ -48,9 +49,9 @@ internal class SQSPublisher : ISQSPublisher
     /// <param name="token">The cancellation token used to cancel the request.</param>
     /// <exception cref="InvalidMessageException">If the message is null or invalid.</exception>
     /// <exception cref="MissingMessageTypeConfigurationException">If cannot find the publisher configuration for the message type.</exception>
-    public async Task SendAsync<T>(T message, CancellationToken token = default)
+    public async Task<IPublishResponse> SendAsync<T>(T message, CancellationToken token = default)
     {
-        await SendAsync(message, null, token);
+        return await SendAsync(message, null, token);
     }
 
     /// <summary>
@@ -61,7 +62,7 @@ internal class SQSPublisher : ISQSPublisher
     /// <param name="token">The cancellation token used to cancel the request.</param>
     /// <exception cref="InvalidMessageException">If the message is null or invalid.</exception>
     /// <exception cref="MissingMessageTypeConfigurationException">If cannot find the publisher configuration for the message type.</exception>
-    public async Task SendAsync<T>(T message, SQSOptions? sqsOptions, CancellationToken token = default)
+    public async Task<SQSSendResponse> SendAsync<T>(T message, SQSOptions? sqsOptions, CancellationToken token = default)
     {
         using (var trace = _telemetryFactory.Trace("Publish to AWS SQS"))
         {
@@ -100,13 +101,18 @@ internal class SQSPublisher : ISQSPublisher
                         // If we haven't resolved the client yet for this publisher, do so now
                         _sqsClient = _awsClientProvider.GetServiceClient<IAmazonSQS>();
                     }
+
                     client = _sqsClient;
                 }
 
                 _logger.LogDebug("Sending the message of type '{MessageType}' to SQS. Publisher Endpoint: {Endpoint}", typeof(T), queueUrl);
                 var sendMessageRequest = CreateSendMessageRequest(queueUrl, messageBody, sqsOptions);
-                await client.SendMessageAsync(sendMessageRequest, token);
+                var response = await client.SendMessageAsync(sendMessageRequest, token);
                 _logger.LogDebug("The message of type '{MessageType}' has been pushed to SQS.", typeof(T));
+                return new SQSSendResponse
+                {
+                    EventId = response.MessageId
+                };
             }
             catch (Exception ex)
             {
@@ -163,6 +169,7 @@ internal class SQSPublisher : ISQSPublisher
             _logger.LogError("Cannot find a configuration for the message of type '{MessageType}'.", messageType.FullName);
             throw new MissingMessageTypeConfigurationException($"The framework is not configured to accept messages of type '{messageType.FullName}'.");
         }
+
         if (mapping.PublishTargetType != PublisherTargetType.SQS_PUBLISHER)
         {
             _logger.LogError("Messages of type '{MessageType}' are not configured for publishing to SQS.", messageType.FullName);

--- a/src/AWS.Messaging/Publishers/SQS/SQSSendResponse.cs
+++ b/src/AWS.Messaging/Publishers/SQS/SQSSendResponse.cs
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Publishers.SQS;
+
+/// <summary>
+///
+/// </summary>
+public class SQSSendResponse : IPublishResponse
+{
+    /// <summary>
+    ///
+    /// </summary>
+    public string? ErrorMessage { get; set; }
+
+    /// <summary>
+    /// Gets and sets the property MessageId.
+    /// <para>
+    /// An attribute containing the <code>MessageId</code> of the message sent to the queue.
+    /// For more information, see <a href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-queue-message-identifiers.html">Queue
+    /// and Message Identifiers</a> in the <i>Amazon SQS Developer Guide</i>.
+    /// </para>
+    /// </summary>
+    public string? EventId { get; set; }
+}

--- a/src/AWS.Messaging/Publishers/SQS/SQSSendResponse.cs
+++ b/src/AWS.Messaging/Publishers/SQS/SQSSendResponse.cs
@@ -21,5 +21,5 @@ public class SQSSendResponse : IPublishResponse
     /// and Message Identifiers</a> in the <i>Amazon SQS Developer Guide</i>.
     /// </para>
     /// </summary>
-    public string? EventId { get; set; }
+    public string? MessageId { get; set; }
 }

--- a/src/AWS.Messaging/Services/ICommandPublisher.cs
+++ b/src/AWS.Messaging/Services/ICommandPublisher.cs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
 // SPDX-License-Identifier: Apache-2.0
 
+using AWS.Messaging.Publishers;
+
 namespace AWS.Messaging.Services;
 
 /// <summary>
@@ -14,5 +16,5 @@ public interface ICommandPublisher
     /// </summary>
     /// <param name="message">The application message that will be serialized and sent.</param>
     /// <param name="token">The cancellation token used to cancel the request.</param>
-    Task SendAsync<T>(T message, CancellationToken token = default);
+    Task<IPublishResponse> SendAsync<T>(T message, CancellationToken token = default);
 }

--- a/src/AWS.Messaging/Services/IEventPublisher.cs
+++ b/src/AWS.Messaging/Services/IEventPublisher.cs
@@ -1,6 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\r
 // SPDX-License-Identifier: Apache-2.0
 
+using AWS.Messaging.Publishers;
+using AWS.Messaging.Publishers.EventBridge;
+
 namespace AWS.Messaging.Services;
 
 /// <summary>
@@ -14,5 +17,5 @@ public interface IEventPublisher
     /// </summary>
     /// <param name="message">The application message that will be serialized and published.</param>
     /// <param name="token">The cancellation token used to cancel the request.</param>
-    Task PublishAsync<T>(T message, CancellationToken token = default);
+    Task<IPublishResponse> PublishAsync<T>(T message, CancellationToken token = default);
 }

--- a/test/AWS.Messaging.UnitTests/MessagePublisherTests.cs
+++ b/test/AWS.Messaging.UnitTests/MessagePublisherTests.cs
@@ -94,7 +94,7 @@ public class MessagePublisherTests
                         request.QueueUrl.Equals("endpoint")),
                     It.IsAny<CancellationToken>()),
             Times.Exactly(1));
-        Assert.Equal("MessageId", result.EventId);
+        Assert.Equal("MessageId", result.MessageId);
     }
 
     [Fact]
@@ -133,7 +133,7 @@ public class MessagePublisherTests
                     It.Is<string>(request =>
                         request.Equals("AWS.Messaging.UnitTests.Models.ChatMessage"))),
             Times.Exactly(1));
-        Assert.Equal("MessageId", publishResponse.EventId);
+        Assert.Equal("MessageId", publishResponse.MessageId);
     }
 
     [Fact]
@@ -230,7 +230,7 @@ public class MessagePublisherTests
                 x.RecordTelemetryContext(
                     It.IsAny<MessageEnvelope>()),
             Times.Exactly(1));
-        Assert.Equal("MessageId", sendResult.EventId);
+        Assert.Equal("MessageId", sendResult.MessageId);
     }
 
     [Fact]
@@ -372,7 +372,7 @@ public class MessagePublisherTests
 
         // And not the endpoint configured for this message type via SetupSQSPublisherDIServices
         _sqsClient.VerifyNoOtherCalls();
-        Assert.Equal("MessageId", sendResult.EventId);
+        Assert.Equal("MessageId", sendResult.MessageId);
     }
 
     /// <summary>
@@ -406,7 +406,7 @@ public class MessagePublisherTests
         // And not the default client
         _sqsClient.VerifyNoOtherCalls();
 
-        Assert.Equal("MessageId", sendResult.EventId);
+        Assert.Equal("MessageId", sendResult.MessageId);
     }
 
     /// <summary>
@@ -477,7 +477,7 @@ public class MessagePublisherTests
                         request.TopicArn.Equals("endpoint")),
                     It.IsAny<CancellationToken>()),
             Times.Exactly(1));
-        Assert.Equal("MessageId", publishResult.EventId);
+        Assert.Equal("MessageId", publishResult.MessageId);
     }
 
     [Fact]
@@ -628,7 +628,7 @@ public class MessagePublisherTests
 
         // And not the topic arn configured for this message type via SetupSNSPublisherDIServices
         _snsClient.VerifyNoOtherCalls();
-        Assert.Equal("MessageId", publishResponse.EventId);
+        Assert.Equal("MessageId", publishResponse.MessageId);
     }
 
     /// <summary>
@@ -738,8 +738,7 @@ public class MessagePublisherTests
                     It.IsAny<CancellationToken>()),
             Times.Exactly(1));
 
-        Assert.Equal("ReturnedEventId", publishResponse.EventId);
-        Assert.Null(publishResponse.ErrorMessage);
+        Assert.Equal("ReturnedEventId", publishResponse.MessageId);
     }
 
     [Fact]
@@ -765,7 +764,7 @@ public class MessagePublisherTests
             new DefaultTelemetryFactory(serviceProvider)
         );
 
-        var publishResponse = await messagePublisher.PublishAsync(_chatMessage);
+        var publishResponse = Assert.ThrowsAsync<FailedToPublishException>(async () => await messagePublisher.PublishAsync(_chatMessage));
 
         _eventBridgeClient.Verify(x =>
                 x.PutEventsAsync(
@@ -775,11 +774,9 @@ public class MessagePublisherTests
                     It.IsAny<CancellationToken>()),
             Times.Exactly(1));
 
-        Assert.Equal("ErrorMessage", publishResponse.ErrorMessage);
-
-        Assert.Equal("ErrorMessage", ((EventBridgePublishResponse)publishResponse).ErrorMessage);
-        Assert.Equal("ErrorCode", ((EventBridgePublishResponse)publishResponse).ErrorCode);
-        Assert.Null(publishResponse.EventId);
+        Assert.Equal("Message failed to publish.", publishResponse.Result.Message);
+        Assert.Equal("ErrorMessage", publishResponse.Result.InnerException.Message);
+        Assert.Equal("ErrorCode", ((EventBridgePutEventsException)publishResponse.Result.InnerException).ErrorCode);
     }
 
     [Fact]
@@ -875,7 +872,7 @@ public class MessagePublisherTests
             telemetryFactory.Object
         );
 
-        await Assert.ThrowsAsync<Exception>(() => messagePublisher.PublishAsync(_chatMessage));
+        await Assert.ThrowsAsync<FailedToPublishException>(() => messagePublisher.PublishAsync(_chatMessage));
 
         telemetryTrace.Verify(x =>
                 x.AddException(

--- a/test/AWS.Messaging.UnitTests/MessagePublisherTests.cs
+++ b/test/AWS.Messaging.UnitTests/MessagePublisherTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System;
+using System.Collections.Generic;
 using AWS.Messaging.Configuration;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -59,7 +60,10 @@ public class MessagePublisherTests
         }));
 
 
-        _chatMessage = new ChatMessage { MessageDescription = "Test Description" };
+        _chatMessage = new ChatMessage
+        {
+            MessageDescription = "Test Description"
+        };
     }
 
     [Fact]
@@ -72,15 +76,25 @@ public class MessagePublisherTests
             _messageConfiguration.Object,
             _messagePublisherLogger.Object,
             new DefaultTelemetryFactory(serviceProvider)
-            );
-
-        await messagePublisher.PublishAsync(_chatMessage);
-
-        _sqsClient.Verify(x =>
+        );
+        _sqsClient.Setup(x =>
             x.SendMessageAsync(
                 It.Is<SendMessageRequest>(request =>
                     request.QueueUrl.Equals("endpoint")),
-                It.IsAny<CancellationToken>()), Times.Exactly(1));
+                It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageResponse()
+        {
+            MessageId = "MessageId"
+        });
+
+        var result = await messagePublisher.PublishAsync(_chatMessage);
+
+        _sqsClient.Verify(x =>
+                x.SendMessageAsync(
+                    It.Is<SendMessageRequest>(request =>
+                        request.QueueUrl.Equals("endpoint")),
+                    It.IsAny<CancellationToken>()),
+            Times.Exactly(1));
+        Assert.Equal("MessageId", result.EventId);
     }
 
     [Fact]
@@ -90,7 +104,10 @@ public class MessagePublisherTests
         var telemetryFactory = new Mock<ITelemetryFactory>();
         var telemetryTrace = new Mock<ITelemetryTrace>();
 
-        _sqsClient.Setup(x => x.SendMessageAsync(It.IsAny<SendMessageRequest>(), It.IsAny<CancellationToken>()));
+        _sqsClient.Setup(x => x.SendMessageAsync(It.IsAny<SendMessageRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageResponse()
+        {
+            MessageId = "MessageId"
+        });
         telemetryFactory.Setup(x => x.Trace(It.IsAny<string>())).Returns(telemetryTrace.Object);
         telemetryTrace.Setup(x => x.AddMetadata(It.IsAny<string>(), It.IsAny<string>()));
 
@@ -99,21 +116,24 @@ public class MessagePublisherTests
             _messageConfiguration.Object,
             _messagePublisherLogger.Object,
             telemetryFactory.Object
-            );
+        );
 
-        await messagePublisher.PublishAsync(_chatMessage);
+        var publishResponse = await messagePublisher.PublishAsync(_chatMessage);
 
         telemetryFactory.Verify(x =>
-            x.Trace(
-                It.Is<string>(request =>
-                    request.Equals("Routing message to AWS service"))), Times.Exactly(1));
+                x.Trace(
+                    It.Is<string>(request =>
+                        request.Equals("Routing message to AWS service"))),
+            Times.Exactly(1));
 
         telemetryTrace.Verify(x =>
-            x.AddMetadata(
-                It.Is<string>(request =>
-                    request.Equals(TelemetryKeys.ObjectType)),
-                It.Is<string>(request =>
-                    request.Equals("AWS.Messaging.UnitTests.Models.ChatMessage"))), Times.Exactly(1));
+                x.AddMetadata(
+                    It.Is<string>(request =>
+                        request.Equals(TelemetryKeys.ObjectType)),
+                    It.Is<string>(request =>
+                        request.Equals("AWS.Messaging.UnitTests.Models.ChatMessage"))),
+            Times.Exactly(1));
+        Assert.Equal("MessageId", publishResponse.EventId);
     }
 
     [Fact]
@@ -132,15 +152,16 @@ public class MessagePublisherTests
             _messageConfiguration.Object,
             _messagePublisherLogger.Object,
             telemetryFactory.Object
-            );
+        );
 
         await Assert.ThrowsAsync<Exception>(() => messagePublisher.PublishAsync(_chatMessage));
 
         telemetryTrace.Verify(x =>
-            x.AddException(
-                It.Is<Exception>(request =>
-                    request.Message.Equals("Telemetry exception")),
-                It.IsAny<bool>()), Times.Exactly(1));
+                x.AddException(
+                    It.Is<Exception>(request =>
+                        request.Message.Equals("Telemetry exception")),
+                    It.IsAny<bool>()),
+            Times.Exactly(1));
     }
 
     [Fact]
@@ -149,6 +170,10 @@ public class MessagePublisherTests
         var serviceProvider = SetupSQSPublisherDIServices();
         var telemetryFactory = new Mock<ITelemetryFactory>();
         var telemetryTrace = new Mock<ITelemetryTrace>();
+        _sqsClient.Setup(x => x.SendMessageAsync(It.IsAny<SendMessageRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageResponse()
+        {
+            MessageId = "MessageId"
+        });
 
         telemetryFactory.Setup(x => x.Trace(It.IsAny<string>())).Returns(telemetryTrace.Object);
         telemetryTrace.Setup(x => x.AddMetadata(It.IsAny<string>(), It.IsAny<string>()));
@@ -159,46 +184,53 @@ public class MessagePublisherTests
             _messageConfiguration.Object,
             _envelopeSerializer.Object,
             telemetryFactory.Object
-            );
+        );
 
-        await messagePublisher.SendAsync(_chatMessage);
+        var sendResult = await messagePublisher.SendAsync(_chatMessage);
 
         telemetryFactory.Verify(x =>
-            x.Trace(
-                It.Is<string>(request =>
-                    request.Equals("Publish to AWS SQS"))), Times.Exactly(1));
+                x.Trace(
+                    It.Is<string>(request =>
+                        request.Equals("Publish to AWS SQS"))),
+            Times.Exactly(1));
 
         telemetryTrace.Verify(x =>
-            x.AddMetadata(
-                It.Is<string>(request =>
-                    request.Equals(TelemetryKeys.ObjectType)),
-                It.Is<string>(request =>
-                    request.Equals("AWS.Messaging.UnitTests.Models.ChatMessage"))), Times.Exactly(1));
+                x.AddMetadata(
+                    It.Is<string>(request =>
+                        request.Equals(TelemetryKeys.ObjectType)),
+                    It.Is<string>(request =>
+                        request.Equals("AWS.Messaging.UnitTests.Models.ChatMessage"))),
+            Times.Exactly(1));
 
         telemetryTrace.Verify(x =>
-            x.AddMetadata(
-                It.Is<string>(request =>
-                    request.Equals(TelemetryKeys.MessageType)),
-                It.Is<string>(request =>
-                    request.Equals("AWS.Messaging.UnitTests.Models.ChatMessage"))), Times.Exactly(1));
+                x.AddMetadata(
+                    It.Is<string>(request =>
+                        request.Equals(TelemetryKeys.MessageType)),
+                    It.Is<string>(request =>
+                        request.Equals("AWS.Messaging.UnitTests.Models.ChatMessage"))),
+            Times.Exactly(1));
 
         telemetryTrace.Verify(x =>
-            x.AddMetadata(
-                It.Is<string>(request =>
-                    request.Equals(TelemetryKeys.QueueUrl)),
-                It.Is<string>(request =>
-                    request.Equals("endpoint"))), Times.Exactly(1));
+                x.AddMetadata(
+                    It.Is<string>(request =>
+                        request.Equals(TelemetryKeys.QueueUrl)),
+                    It.Is<string>(request =>
+                        request.Equals("endpoint"))),
+            Times.Exactly(1));
 
         telemetryTrace.Verify(x =>
-            x.AddMetadata(
-                It.Is<string>(request =>
-                    request.Equals(TelemetryKeys.MessageId)),
-                It.Is<string>(request =>
-                    request.Equals("1234"))), Times.Exactly(1));
+                x.AddMetadata(
+                    It.Is<string>(request =>
+                        request.Equals(TelemetryKeys.MessageId)),
+                    It.Is<string>(request =>
+                        request.Equals("1234"))),
+            Times.Exactly(1));
 
         telemetryTrace.Verify(x =>
-            x.RecordTelemetryContext(
-                It.IsAny<MessageEnvelope>()), Times.Exactly(1));
+                x.RecordTelemetryContext(
+                    It.IsAny<MessageEnvelope>()),
+            Times.Exactly(1));
+        Assert.Equal("MessageId", sendResult.EventId);
     }
 
     [Fact]
@@ -218,15 +250,16 @@ public class MessagePublisherTests
             _messageConfiguration.Object,
             _envelopeSerializer.Object,
             telemetryFactory.Object
-            );
+        );
 
         await Assert.ThrowsAsync<Exception>(() => messagePublisher.SendAsync(_chatMessage));
 
         telemetryTrace.Verify(x =>
-            x.AddException(
-                It.Is<Exception>(request =>
-                    request.Message.Equals("Telemetry exception")),
-                It.IsAny<bool>()), Times.Exactly(1));
+                x.AddException(
+                    It.Is<Exception>(request =>
+                        request.Message.Equals("Telemetry exception")),
+                    It.IsAny<bool>()),
+            Times.Exactly(1));
     }
 
     [Fact]
@@ -239,7 +272,7 @@ public class MessagePublisherTests
             _messageConfiguration.Object,
             _messagePublisherLogger.Object,
             new DefaultTelemetryFactory(serviceProvider)
-            );
+        );
 
         await Assert.ThrowsAsync<MissingMessageTypeConfigurationException>(() => messagePublisher.PublishAsync(_chatMessage));
     }
@@ -254,7 +287,7 @@ public class MessagePublisherTests
             _messageConfiguration.Object,
             _messagePublisherLogger.Object,
             new DefaultTelemetryFactory(serviceProvider)
-            );
+        );
 
         await Assert.ThrowsAsync<InvalidMessageException>(() => messagePublisher.PublishAsync<ChatMessage?>(null));
     }
@@ -280,12 +313,12 @@ public class MessagePublisherTests
     private ISQSPublisher SetupSQSPublisher(IServiceProvider serviceProvider)
     {
         return new SQSPublisher(
-          (IAWSClientProvider)serviceProvider.GetService(typeof(IAWSClientProvider))!,
-          _sqsPublisherLogger.Object,
-          _messageConfiguration.Object,
-          _envelopeSerializer.Object,
-          (ITelemetryFactory)serviceProvider.GetService(typeof(ITelemetryFactory))!
-          );
+            (IAWSClientProvider)serviceProvider.GetService(typeof(IAWSClientProvider))!,
+            _sqsPublisherLogger.Object,
+            _messageConfiguration.Object,
+            _envelopeSerializer.Object,
+            (ITelemetryFactory)serviceProvider.GetService(typeof(ITelemetryFactory))!
+        );
     }
 
     [Fact]
@@ -301,7 +334,7 @@ public class MessagePublisherTests
             _messageConfiguration.Object,
             _messagePublisherLogger.Object,
             new DefaultTelemetryFactory(serviceProvider)
-            );
+        );
 
         await Assert.ThrowsAsync<UnsupportedPublisherException>(() => messagePublisher.PublishAsync(_chatMessage));
     }
@@ -314,18 +347,32 @@ public class MessagePublisherTests
     {
         var serviceProvider = SetupSQSPublisherDIServices();
         var messagePublisher = SetupSQSPublisher(serviceProvider);
-
-        await messagePublisher.SendAsync(_chatMessage, new SQSOptions { QueueUrl = "overrideEndpoint" });
-
-        // Assert we used the override endpoint specified above
-        _sqsClient.Verify(x =>
+        _sqsClient.Setup(x =>
             x.SendMessageAsync(
                 It.Is<SendMessageRequest>(request =>
                     request.QueueUrl.Equals("overrideEndpoint")),
-                It.IsAny<CancellationToken>()), Times.Exactly(1));
+                It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageResponse()
+        {
+            MessageId = "MessageId"
+        });
+
+        var sendResult = await messagePublisher.SendAsync(_chatMessage,
+            new SQSOptions
+            {
+                QueueUrl = "overrideEndpoint"
+            });
+
+        // Assert we used the override endpoint specified above
+        _sqsClient.Verify(x =>
+                x.SendMessageAsync(
+                    It.Is<SendMessageRequest>(request =>
+                        request.QueueUrl.Equals("overrideEndpoint")),
+                    It.IsAny<CancellationToken>()),
+            Times.Exactly(1));
 
         // And not the endpoint configured for this message type via SetupSQSPublisherDIServices
         _sqsClient.VerifyNoOtherCalls();
+        Assert.Equal("MessageId", sendResult.EventId);
     }
 
     /// <summary>
@@ -338,21 +385,28 @@ public class MessagePublisherTests
         var messagePublisher = SetupSQSPublisher(serviceProvider);
 
         var overrideSQSClient = new Mock<IAmazonSQS>();
-        overrideSQSClient.Setup(x => x.SendMessageAsync(It.IsAny<SendMessageRequest>(), It.IsAny<CancellationToken>()));
-
-        await messagePublisher.SendAsync(_chatMessage, new SQSOptions
+        overrideSQSClient.Setup(x => x.SendMessageAsync(It.IsAny<SendMessageRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(new SendMessageResponse()
         {
-            OverrideClient = overrideSQSClient.Object
+            MessageId = "MessageId"
         });
+
+        var sendResult = await messagePublisher.SendAsync(_chatMessage,
+            new SQSOptions
+            {
+                OverrideClient = overrideSQSClient.Object
+            });
 
         // Assert that the override client was invoked
         overrideSQSClient.Verify(x =>
-            x.SendMessageAsync(
-                It.IsAny<SendMessageRequest>(),
-                It.IsAny<CancellationToken>()), Times.Exactly(1));
+                x.SendMessageAsync(
+                    It.IsAny<SendMessageRequest>(),
+                    It.IsAny<CancellationToken>()),
+            Times.Exactly(1));
 
         // And not the default client
         _sqsClient.VerifyNoOtherCalls();
+
+        Assert.Equal("MessageId", sendResult.EventId);
     }
 
     /// <summary>
@@ -394,7 +448,7 @@ public class MessagePublisherTests
             _messageConfiguration.Object,
             _envelopeSerializer.Object,
             (ITelemetryFactory)serviceProvider.GetService(typeof(ITelemetryFactory))!
-            );
+        );
     }
 
     [Fact]
@@ -407,15 +461,23 @@ public class MessagePublisherTests
             _messageConfiguration.Object,
             _messagePublisherLogger.Object,
             new DefaultTelemetryFactory(serviceProvider)
-            );
+        );
+        _snsClient.Setup(x => x.PublishAsync(It.Is<PublishRequest>(request =>
+                request.TopicArn.Equals("endpoint")),
+            It.IsAny<CancellationToken>())).ReturnsAsync(new PublishResponse()
+        {
+            MessageId = "MessageId"
+        });
 
-        await messagePublisher.PublishAsync(_chatMessage);
+        var publishResult = await messagePublisher.PublishAsync(_chatMessage);
 
         _snsClient.Verify(x =>
-            x.PublishAsync(
-                It.Is<PublishRequest>(request =>
-                    request.TopicArn.Equals("endpoint")),
-                It.IsAny<CancellationToken>()), Times.Exactly(1));
+                x.PublishAsync(
+                    It.Is<PublishRequest>(request =>
+                        request.TopicArn.Equals("endpoint")),
+                    It.IsAny<CancellationToken>()),
+            Times.Exactly(1));
+        Assert.Equal("MessageId", publishResult.EventId);
     }
 
     [Fact]
@@ -424,6 +486,13 @@ public class MessagePublisherTests
         var serviceProvider = SetupSNSPublisherDIServices();
         var telemetryFactory = new Mock<ITelemetryFactory>();
         var telemetryTrace = new Mock<ITelemetryTrace>();
+        _snsClient.Setup(x =>
+            x.PublishAsync(
+                It.IsAny<PublishRequest>(),
+                It.IsAny<CancellationToken>())).ReturnsAsync(new PublishResponse()
+        {
+            MessageId = "MessageId"
+        });
 
         telemetryFactory.Setup(x => x.Trace(It.IsAny<string>())).Returns(telemetryTrace.Object);
         telemetryTrace.Setup(x => x.AddMetadata(It.IsAny<string>(), It.IsAny<string>()));
@@ -434,46 +503,52 @@ public class MessagePublisherTests
             _messageConfiguration.Object,
             _envelopeSerializer.Object,
             telemetryFactory.Object
-            );
+        );
 
         await messagePublisher.PublishAsync(_chatMessage);
 
         telemetryFactory.Verify(x =>
-            x.Trace(
-                It.Is<string>(request =>
-                    request.Equals("Publish to AWS SNS"))), Times.Exactly(1));
+                x.Trace(
+                    It.Is<string>(request =>
+                        request.Equals("Publish to AWS SNS"))),
+            Times.Exactly(1));
 
         telemetryTrace.Verify(x =>
-            x.AddMetadata(
-                It.Is<string>(request =>
-                    request.Equals(TelemetryKeys.ObjectType)),
-                It.Is<string>(request =>
-                    request.Equals("AWS.Messaging.UnitTests.Models.ChatMessage"))), Times.Exactly(1));
+                x.AddMetadata(
+                    It.Is<string>(request =>
+                        request.Equals(TelemetryKeys.ObjectType)),
+                    It.Is<string>(request =>
+                        request.Equals("AWS.Messaging.UnitTests.Models.ChatMessage"))),
+            Times.Exactly(1));
 
         telemetryTrace.Verify(x =>
-            x.AddMetadata(
-                It.Is<string>(request =>
-                    request.Equals(TelemetryKeys.MessageType)),
-                It.Is<string>(request =>
-                    request.Equals("AWS.Messaging.UnitTests.Models.ChatMessage"))), Times.Exactly(1));
+                x.AddMetadata(
+                    It.Is<string>(request =>
+                        request.Equals(TelemetryKeys.MessageType)),
+                    It.Is<string>(request =>
+                        request.Equals("AWS.Messaging.UnitTests.Models.ChatMessage"))),
+            Times.Exactly(1));
 
         telemetryTrace.Verify(x =>
-            x.AddMetadata(
-                It.Is<string>(request =>
-                    request.Equals(TelemetryKeys.TopicUrl)),
-                It.Is<string>(request =>
-                    request.Equals("endpoint"))), Times.Exactly(1));
+                x.AddMetadata(
+                    It.Is<string>(request =>
+                        request.Equals(TelemetryKeys.TopicUrl)),
+                    It.Is<string>(request =>
+                        request.Equals("endpoint"))),
+            Times.Exactly(1));
 
         telemetryTrace.Verify(x =>
-            x.AddMetadata(
-                It.Is<string>(request =>
-                    request.Equals(TelemetryKeys.MessageId)),
-                It.Is<string>(request =>
-                    request.Equals("1234"))), Times.Exactly(1));
+                x.AddMetadata(
+                    It.Is<string>(request =>
+                        request.Equals(TelemetryKeys.MessageId)),
+                    It.Is<string>(request =>
+                        request.Equals("1234"))),
+            Times.Exactly(1));
 
         telemetryTrace.Verify(x =>
-            x.RecordTelemetryContext(
-                It.IsAny<MessageEnvelope>()), Times.Exactly(1));
+                x.RecordTelemetryContext(
+                    It.IsAny<MessageEnvelope>()),
+            Times.Exactly(1));
     }
 
     [Fact]
@@ -493,15 +568,16 @@ public class MessagePublisherTests
             _messageConfiguration.Object,
             _envelopeSerializer.Object,
             telemetryFactory.Object
-            );
+        );
 
         await Assert.ThrowsAsync<Exception>(() => messagePublisher.PublishAsync(_chatMessage));
 
         telemetryTrace.Verify(x =>
-            x.AddException(
-                It.Is<Exception>(request =>
-                    request.Message.Equals("Telemetry exception")),
-                It.IsAny<bool>()), Times.Exactly(1));
+                x.AddException(
+                    It.Is<Exception>(request =>
+                        request.Message.Equals("Telemetry exception")),
+                    It.IsAny<bool>()),
+            Times.Exactly(1));
     }
 
     [Fact]
@@ -514,7 +590,7 @@ public class MessagePublisherTests
             _messageConfiguration.Object,
             _messagePublisherLogger.Object,
             new DefaultTelemetryFactory(serviceProvider)
-            );
+        );
 
         await Assert.ThrowsAsync<InvalidMessageException>(() => messagePublisher.PublishAsync<ChatMessage?>(null));
     }
@@ -527,18 +603,32 @@ public class MessagePublisherTests
     {
         var serviceProvider = SetupSNSPublisherDIServices();
         var messagePublisher = SetupSNSPublisher(serviceProvider);
+        _snsClient.Setup(x =>
+            x.PublishAsync(
+                It.Is<PublishRequest>(request =>
+                    request.TopicArn.Equals("overrideTopicArn")),
+                It.IsAny<CancellationToken>())).ReturnsAsync(new PublishResponse()
+        {
+            MessageId = "MessageId"
+        });
 
-        await messagePublisher.PublishAsync(_chatMessage, new SNSOptions { TopicArn = "overrideTopicArn" });
+        var publishResponse = await messagePublisher.PublishAsync(_chatMessage,
+            new SNSOptions
+            {
+                TopicArn = "overrideTopicArn"
+            });
 
         // Assert we used the override topic arn specified above
         _snsClient.Verify(x =>
-          x.PublishAsync(
-              It.Is<PublishRequest>(request =>
-                  request.TopicArn.Equals("overrideTopicArn")),
-              It.IsAny<CancellationToken>()), Times.Exactly(1));
+                x.PublishAsync(
+                    It.Is<PublishRequest>(request =>
+                        request.TopicArn.Equals("overrideTopicArn")),
+                    It.IsAny<CancellationToken>()),
+            Times.Exactly(1));
 
         // And not the topic arn configured for this message type via SetupSNSPublisherDIServices
         _snsClient.VerifyNoOtherCalls();
+        Assert.Equal("MessageId", publishResponse.EventId);
     }
 
     /// <summary>
@@ -551,15 +641,20 @@ public class MessagePublisherTests
         var messagePublisher = SetupSNSPublisher(serviceProvider);
 
         var overrideSNSClient = new Mock<IAmazonSimpleNotificationService>();
-        overrideSNSClient.Setup(x => x.PublishAsync(It.IsAny<PublishRequest>(), It.IsAny<CancellationToken>()));
+        overrideSNSClient.Setup(x => x.PublishAsync(It.IsAny<PublishRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(new PublishResponse());
 
-        await messagePublisher.PublishAsync(_chatMessage, new SNSOptions { OverrideClient = overrideSNSClient.Object });
+        await messagePublisher.PublishAsync(_chatMessage,
+            new SNSOptions
+            {
+                OverrideClient = overrideSNSClient.Object
+            });
 
         // Assert that the override client was invoked
         overrideSNSClient.Verify(x =>
-         x.PublishAsync(
-             It.IsAny<PublishRequest>(),
-             It.IsAny<CancellationToken>()), Times.Exactly(1));
+                x.PublishAsync(
+                    It.IsAny<PublishRequest>(),
+                    It.IsAny<CancellationToken>()),
+            Times.Exactly(1));
 
         // And not the default client
         _snsClient.VerifyNoOtherCalls();
@@ -603,34 +698,88 @@ public class MessagePublisherTests
     private IEventBridgePublisher SetupEventBridgePublisher(IServiceProvider serviceProvider)
     {
         return new EventBridgePublisher(
-           (IAWSClientProvider)serviceProvider.GetService(typeof(IAWSClientProvider))!,
-           _messagePublisherLogger.Object,
-           _messageConfiguration.Object,
-           _envelopeSerializer.Object,
-           (ITelemetryFactory)serviceProvider.GetService(typeof(ITelemetryFactory))!
-           );
+            (IAWSClientProvider)serviceProvider.GetService(typeof(IAWSClientProvider))!,
+            _messagePublisherLogger.Object,
+            _messageConfiguration.Object,
+            _envelopeSerializer.Object,
+            (ITelemetryFactory)serviceProvider.GetService(typeof(ITelemetryFactory))!
+        );
     }
 
     [Fact]
     public async Task EventBridgePublisher_HappyPath()
     {
         var serviceProvider = SetupEventBridgePublisherDIServices("event-bus-123");
+        _eventBridgeClient.Setup(x => x.PutEventsAsync(It.IsAny<PutEventsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(new PutEventsResponse
+        {
+            Entries = new List<PutEventsResultEntry>
+            {
+                new()
+                {
+                    EventId = "ReturnedEventId"
+                }
+            }
+        });
 
         var messagePublisher = new MessageRoutingPublisher(
             serviceProvider,
             _messageConfiguration.Object,
             _messagePublisherLogger.Object,
             new DefaultTelemetryFactory(serviceProvider)
-            );
+        );
 
-        await messagePublisher.PublishAsync(_chatMessage);
+        var publishResponse = await messagePublisher.PublishAsync(_chatMessage);
 
         _eventBridgeClient.Verify(x =>
-            x.PutEventsAsync(
-                It.Is<PutEventsRequest>(request =>
-                    request.Entries[0].EventBusName.Equals("event-bus-123") && string.IsNullOrEmpty(request.EndpointId)
-                    && request.Entries[0].DetailType.Equals("AWS.Messaging.UnitTests.Models.ChatMessage") && request.Entries[0].Source.Equals("/aws/messaging/unittest")),
-                It.IsAny<CancellationToken>()), Times.Exactly(1));
+                x.PutEventsAsync(
+                    It.Is<PutEventsRequest>(request =>
+                        request.Entries[0].EventBusName.Equals("event-bus-123") && string.IsNullOrEmpty(request.EndpointId)
+                                                                                && request.Entries[0].DetailType.Equals("AWS.Messaging.UnitTests.Models.ChatMessage") && request.Entries[0].Source.Equals("/aws/messaging/unittest")),
+                    It.IsAny<CancellationToken>()),
+            Times.Exactly(1));
+
+        Assert.Equal("ReturnedEventId", publishResponse.EventId);
+        Assert.Null(publishResponse.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task EventBridgePublisher_UnhappyPath()
+    {
+        var serviceProvider = SetupEventBridgePublisherDIServices("event-bus-123");
+        _eventBridgeClient.Setup(x => x.PutEventsAsync(It.IsAny<PutEventsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(new PutEventsResponse
+        {
+            Entries = new List<PutEventsResultEntry>
+            {
+                new()
+                {
+                    ErrorMessage = "ErrorMessage",
+                    ErrorCode = "ErrorCode"
+                }
+            }
+        });
+
+        var messagePublisher = new MessageRoutingPublisher(
+            serviceProvider,
+            _messageConfiguration.Object,
+            _messagePublisherLogger.Object,
+            new DefaultTelemetryFactory(serviceProvider)
+        );
+
+        var publishResponse = await messagePublisher.PublishAsync(_chatMessage);
+
+        _eventBridgeClient.Verify(x =>
+                x.PutEventsAsync(
+                    It.Is<PutEventsRequest>(request =>
+                        request.Entries[0].EventBusName.Equals("event-bus-123") && string.IsNullOrEmpty(request.EndpointId)
+                                                                                && request.Entries[0].DetailType.Equals("AWS.Messaging.UnitTests.Models.ChatMessage") && request.Entries[0].Source.Equals("/aws/messaging/unittest")),
+                    It.IsAny<CancellationToken>()),
+            Times.Exactly(1));
+
+        Assert.Equal("ErrorMessage", publishResponse.ErrorMessage);
+
+        Assert.Equal("ErrorMessage", ((EventBridgePublishResponse)publishResponse).ErrorMessage);
+        Assert.Equal("ErrorCode", ((EventBridgePublishResponse)publishResponse).ErrorCode);
+        Assert.Null(publishResponse.EventId);
     }
 
     [Fact]
@@ -649,46 +798,62 @@ public class MessagePublisherTests
             _messageConfiguration.Object,
             _envelopeSerializer.Object,
             telemetryFactory.Object
-            );
+        );
+        _eventBridgeClient.Setup(x => x.PutEventsAsync(It.IsAny<PutEventsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(new PutEventsResponse
+        {
+            Entries = new List<PutEventsResultEntry>
+            {
+                new()
+                {
+                    EventId = "ReturnedEventId"
+                }
+            }
+        });
 
         await messagePublisher.PublishAsync(_chatMessage);
 
         telemetryFactory.Verify(x =>
-            x.Trace(
-                It.Is<string>(request =>
-                    request.Equals("Publish to AWS EventBridge"))), Times.Exactly(1));
+                x.Trace(
+                    It.Is<string>(request =>
+                        request.Equals("Publish to AWS EventBridge"))),
+            Times.Exactly(1));
 
         telemetryTrace.Verify(x =>
-            x.AddMetadata(
-                It.Is<string>(request =>
-                    request.Equals(TelemetryKeys.ObjectType)),
-                It.Is<string>(request =>
-                    request.Equals("AWS.Messaging.UnitTests.Models.ChatMessage"))), Times.Exactly(1));
+                x.AddMetadata(
+                    It.Is<string>(request =>
+                        request.Equals(TelemetryKeys.ObjectType)),
+                    It.Is<string>(request =>
+                        request.Equals("AWS.Messaging.UnitTests.Models.ChatMessage"))),
+            Times.Exactly(1));
 
         telemetryTrace.Verify(x =>
-            x.AddMetadata(
-                It.Is<string>(request =>
-                    request.Equals(TelemetryKeys.MessageType)),
-                It.Is<string>(request =>
-                    request.Equals("AWS.Messaging.UnitTests.Models.ChatMessage"))), Times.Exactly(1));
+                x.AddMetadata(
+                    It.Is<string>(request =>
+                        request.Equals(TelemetryKeys.MessageType)),
+                    It.Is<string>(request =>
+                        request.Equals("AWS.Messaging.UnitTests.Models.ChatMessage"))),
+            Times.Exactly(1));
 
         telemetryTrace.Verify(x =>
-            x.AddMetadata(
-                It.Is<string>(request =>
-                    request.Equals(TelemetryKeys.EventBusName)),
-                It.Is<string>(request =>
-                    request.Equals("event-bus-123"))), Times.Exactly(1));
+                x.AddMetadata(
+                    It.Is<string>(request =>
+                        request.Equals(TelemetryKeys.EventBusName)),
+                    It.Is<string>(request =>
+                        request.Equals("event-bus-123"))),
+            Times.Exactly(1));
 
         telemetryTrace.Verify(x =>
-            x.AddMetadata(
-                It.Is<string>(request =>
-                    request.Equals(TelemetryKeys.MessageId)),
-                It.Is<string>(request =>
-                    request.Equals("1234"))), Times.Exactly(1));
+                x.AddMetadata(
+                    It.Is<string>(request =>
+                        request.Equals(TelemetryKeys.MessageId)),
+                    It.Is<string>(request =>
+                        request.Equals("1234"))),
+            Times.Exactly(1));
 
         telemetryTrace.Verify(x =>
-            x.RecordTelemetryContext(
-                It.IsAny<MessageEnvelope>()), Times.Exactly(1));
+                x.RecordTelemetryContext(
+                    It.IsAny<MessageEnvelope>()),
+            Times.Exactly(1));
     }
 
     [Fact]
@@ -708,37 +873,49 @@ public class MessagePublisherTests
             _messageConfiguration.Object,
             _envelopeSerializer.Object,
             telemetryFactory.Object
-            );
+        );
 
         await Assert.ThrowsAsync<Exception>(() => messagePublisher.PublishAsync(_chatMessage));
 
         telemetryTrace.Verify(x =>
-            x.AddException(
-                It.Is<Exception>(request =>
-                    request.Message.Equals("Telemetry exception")),
-                It.IsAny<bool>()), Times.Exactly(1));
+                x.AddException(
+                    It.Is<Exception>(request =>
+                        request.Message.Equals("Telemetry exception")),
+                    It.IsAny<bool>()),
+            Times.Exactly(1));
     }
 
     [Fact]
     public async Task EventBridgePublisher_GlobalEP()
     {
         var serviceProvider = SetupEventBridgePublisherDIServices("event-bus-123", "endpoint.123");
+        _eventBridgeClient.Setup(x => x.PutEventsAsync(It.IsAny<PutEventsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(new PutEventsResponse
+        {
+            Entries = new List<PutEventsResultEntry>
+            {
+                new()
+                {
+                    EventId = "ReturnedEventId"
+                }
+            }
+        });
 
         var messagePublisher = new MessageRoutingPublisher(
             serviceProvider,
             _messageConfiguration.Object,
             _messagePublisherLogger.Object,
             new DefaultTelemetryFactory(serviceProvider)
-            );
+        );
 
         await messagePublisher.PublishAsync(_chatMessage);
 
         _eventBridgeClient.Verify(x =>
-            x.PutEventsAsync(
-                It.Is<PutEventsRequest>(request =>
-                    request.Entries[0].EventBusName.Equals("event-bus-123") && request.EndpointId.Equals("endpoint.123")
-                    && request.Entries[0].DetailType.Equals("AWS.Messaging.UnitTests.Models.ChatMessage") && request.Entries[0].Source.Equals("/aws/messaging/unittest")),
-                It.IsAny<CancellationToken>()), Times.Exactly(1));
+                x.PutEventsAsync(
+                    It.Is<PutEventsRequest>(request =>
+                        request.Entries[0].EventBusName.Equals("event-bus-123") && request.EndpointId.Equals("endpoint.123")
+                                                                                && request.Entries[0].DetailType.Equals("AWS.Messaging.UnitTests.Models.ChatMessage") && request.Entries[0].Source.Equals("/aws/messaging/unittest")),
+                    It.IsAny<CancellationToken>()),
+            Times.Exactly(1));
     }
 
     [Fact]
@@ -747,17 +924,30 @@ public class MessagePublisherTests
         var serviceProvider = SetupEventBridgePublisherDIServices("event-bus-123");
         var messagePublisher = SetupEventBridgePublisher(serviceProvider);
 
-        await messagePublisher.PublishAsync(_chatMessage, new EventBridgeOptions
+        _eventBridgeClient.Setup(x => x.PutEventsAsync(It.IsAny<PutEventsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(new PutEventsResponse
         {
-            Source = "/aws/custom"
+            Entries = new List<PutEventsResultEntry>
+            {
+                new()
+                {
+                    EventId = "ReturnedEventId"
+                }
+            }
         });
 
+        await messagePublisher.PublishAsync(_chatMessage,
+            new EventBridgeOptions
+            {
+                Source = "/aws/custom"
+            });
+
         _eventBridgeClient.Verify(x =>
-            x.PutEventsAsync(
-                It.Is<PutEventsRequest>(request =>
-                    request.Entries[0].EventBusName.Equals("event-bus-123") && string.IsNullOrEmpty(request.EndpointId)
-                    && request.Entries[0].DetailType.Equals("AWS.Messaging.UnitTests.Models.ChatMessage") && request.Entries[0].Source.Equals("/aws/custom")),
-                It.IsAny<CancellationToken>()), Times.Exactly(1));
+                x.PutEventsAsync(
+                    It.Is<PutEventsRequest>(request =>
+                        request.Entries[0].EventBusName.Equals("event-bus-123") && string.IsNullOrEmpty(request.EndpointId)
+                                                                                && request.Entries[0].DetailType.Equals("AWS.Messaging.UnitTests.Models.ChatMessage") && request.Entries[0].Source.Equals("/aws/custom")),
+                    It.IsAny<CancellationToken>()),
+            Times.Exactly(1));
     }
 
     [Fact]
@@ -766,21 +956,32 @@ public class MessagePublisherTests
         var serviceProvider = SetupEventBridgePublisherDIServices("event-bus-123");
         var messagePublisher = SetupEventBridgePublisher(serviceProvider);
 
+        _eventBridgeClient.Setup(x => x.PutEventsAsync(It.IsAny<PutEventsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(new PutEventsResponse
+        {
+            Entries = new List<PutEventsResultEntry>
+            {
+                new()
+                {
+                    EventId = "ReturnedEventId"
+                }
+            }
+        });
         DateTimeOffset dateTimeOffset = new DateTimeOffset(2015, 2, 17, 0, 0, 0, TimeSpan.Zero);
 
-        await messagePublisher.PublishAsync(_chatMessage, new EventBridgeOptions
-        {
-            TraceHeader = "trace-header1",
-            Time = dateTimeOffset
-        });
+        await messagePublisher.PublishAsync(_chatMessage,
+            new EventBridgeOptions
+            {
+                TraceHeader = "trace-header1",
+                Time = dateTimeOffset
+            });
 
         _eventBridgeClient.Verify(x =>
-            x.PutEventsAsync(
-                It.Is<PutEventsRequest>(request =>
-                    request.Entries[0].EventBusName.Equals("event-bus-123") && string.IsNullOrEmpty(request.EndpointId)
-                    && request.Entries[0].TraceHeader.Equals("trace-header1") && request.Entries[0].Time.Year == dateTimeOffset.Year),
-
-                It.IsAny<CancellationToken>()), Times.Exactly(1));
+                x.PutEventsAsync(
+                    It.Is<PutEventsRequest>(request =>
+                        request.Entries[0].EventBusName.Equals("event-bus-123") && string.IsNullOrEmpty(request.EndpointId)
+                                                                                && request.Entries[0].TraceHeader.Equals("trace-header1") && request.Entries[0].Time.Year == dateTimeOffset.Year),
+                    It.IsAny<CancellationToken>()),
+            Times.Exactly(1));
     }
 
     [Fact]
@@ -793,7 +994,7 @@ public class MessagePublisherTests
             _messageConfiguration.Object,
             _messagePublisherLogger.Object,
             new DefaultTelemetryFactory(serviceProvider)
-            );
+        );
 
         await Assert.ThrowsAsync<InvalidMessageException>(() => messagePublisher.PublishAsync<ChatMessage?>(null));
     }
@@ -806,20 +1007,31 @@ public class MessagePublisherTests
     {
         var serviceProvider = SetupEventBridgePublisherDIServices("defaultBus", "defaultEndpoint");
         var messagePublisher = SetupEventBridgePublisher(serviceProvider);
-
-        await messagePublisher.PublishAsync(_chatMessage, new EventBridgeOptions
+        _eventBridgeClient.Setup(x => x.PutEventsAsync(It.IsAny<PutEventsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(new PutEventsResponse
         {
-            EventBusName = "overrideBus",
-            EndpointID = "overrideEndpoint"
+            Entries = new List<PutEventsResultEntry>
+            {
+                new()
+                {
+                    EventId = "ReturnedEventId"
+                }
+            }
         });
+        await messagePublisher.PublishAsync(_chatMessage,
+            new EventBridgeOptions
+            {
+                EventBusName = "overrideBus",
+                EndpointID = "overrideEndpoint"
+            });
 
         // Assert we used the event bus and endpointspecified above
         _eventBridgeClient.Verify(x =>
-                    x.PutEventsAsync(
-                        It.Is<PutEventsRequest>(request =>
-                            request.Entries[0].EventBusName.Equals("overrideBus") &&
-                            request.EndpointId == "overrideEndpoint"),
-                        It.IsAny<CancellationToken>()), Times.Exactly(1));
+                x.PutEventsAsync(
+                    It.Is<PutEventsRequest>(request =>
+                        request.Entries[0].EventBusName.Equals("overrideBus") &&
+                        request.EndpointId == "overrideEndpoint"),
+                    It.IsAny<CancellationToken>()),
+            Times.Exactly(1));
 
         // And not the desination configured for this message type via SetupEventBridgePublisherDIServices
         _eventBridgeClient.VerifyNoOtherCalls();
@@ -835,15 +1047,28 @@ public class MessagePublisherTests
         var messagePublisher = SetupEventBridgePublisher(serviceProvider);
 
         var overrideEventBridgeClient = new Mock<IAmazonEventBridge>();
-        overrideEventBridgeClient.Setup(x => x.PutEventsAsync(It.IsAny<PutEventsRequest>(), It.IsAny<CancellationToken>()));
-
-        await messagePublisher.PublishAsync(_chatMessage, new EventBridgeOptions { OverrideClient = overrideEventBridgeClient.Object });
+        overrideEventBridgeClient.Setup(x => x.PutEventsAsync(It.IsAny<PutEventsRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(new PutEventsResponse
+        {
+            Entries = new List<PutEventsResultEntry>
+            {
+                new()
+                {
+                    EventId = "ReturnedEventId"
+                }
+            }
+        });
+        await messagePublisher.PublishAsync(_chatMessage,
+            new EventBridgeOptions
+            {
+                OverrideClient = overrideEventBridgeClient.Object
+            });
 
         // Assert that the override client was invoked
         overrideEventBridgeClient.Verify(x =>
-                    x.PutEventsAsync(
-                        It.IsAny<PutEventsRequest>(),
-                        It.IsAny<CancellationToken>()), Times.Exactly(1));
+                x.PutEventsAsync(
+                    It.IsAny<PutEventsRequest>(),
+                    It.IsAny<CancellationToken>()),
+            Times.Exactly(1));
 
         // And not the default client
         _eventBridgeClient.VerifyNoOtherCalls();
@@ -872,7 +1097,7 @@ public class MessagePublisherTests
             _messageConfiguration.Object,
             _messagePublisherLogger.Object,
             new DefaultTelemetryFactory(serviceProvider)
-            );
+        );
 
         var sqsMessagePublisher = new SQSPublisher(
             (IAWSClientProvider)serviceProvider.GetService(typeof(IAWSClientProvider))!,
@@ -880,7 +1105,7 @@ public class MessagePublisherTests
             _messageConfiguration.Object,
             _envelopeSerializer.Object,
             new DefaultTelemetryFactory(serviceProvider)
-            );
+        );
 
         await Assert.ThrowsAsync<InvalidFifoPublishingRequestException>(() => messagePublisher.PublishAsync<ChatMessage?>(new ChatMessage()));
         await Assert.ThrowsAsync<InvalidFifoPublishingRequestException>(() => sqsMessagePublisher.SendAsync<ChatMessage?>(new ChatMessage(), new SQSOptions()));
@@ -896,7 +1121,7 @@ public class MessagePublisherTests
             _messageConfiguration.Object,
             _messagePublisherLogger.Object,
             new DefaultTelemetryFactory(serviceProvider)
-            );
+        );
 
         var snsMessagePublisher = SetupSNSPublisher(serviceProvider);
 


### PR DESCRIPTION
*Description of changes:*

When an exception happens at eventbridge there is no way to retrieve it. An `FailedToPublishException` with an `EventBridgePutEventsException ` is added to signal errors to the end user. 
To have a good user experience, exception from SNS and SQS will also be wrapped into the `FailedToPublishException`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
