### PR TITLE
Add configurable visibility timeout default when using partial batch failures

### DIFF
--- a/.autover/changes/237dcfa7-055f-4342-8633-de16951d29c2.json
+++ b/.autover/changes/237dcfa7-055f-4342-8633-de16951d29c2.json
@@ -2,7 +2,7 @@
   "Projects": [
     {
       "Name": "AWS.Messaging.Lambda",
-      "Type": "Patch",
+      "Type": "Minor",
       "ChangelogMessages": [
         "Add default visibility timeout for failed partial batch response."
       ]

--- a/.autover/changes/237dcfa7-055f-4342-8633-de16951d29c2.json
+++ b/.autover/changes/237dcfa7-055f-4342-8633-de16951d29c2.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Messaging.Lambda",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Add default visibility timeout for failed partial batch response."
+      ]
+    }
+  ]
+}

--- a/src/AWS.Messaging.Lambda/DefaultLambdaMessaging.cs
+++ b/src/AWS.Messaging.Lambda/DefaultLambdaMessaging.cs
@@ -125,6 +125,7 @@ internal class DefaultLambdaMessaging : ILambdaMessaging
         {
             SQSEvent = sqsEvent,
             UseBatchResponse = useBatchResponse,
+            VisibilityTimeoutForBatchFailures = options?.VisibilityTimeoutForBatchFailures,
             DeleteMessagesWhenCompleted = options?.DeleteMessagesWhenCompleted ?? false,
             // TODO: This value should be set differently when working with FIFO queues.
             MaxNumberOfConcurrentMessages = options?.MaxNumberOfConcurrentMessages ?? LambdaMessagingOptions.DEFAULT_MAX_NUMBER_OF_CONCURRENT_MESSAGES

--- a/src/AWS.Messaging.Lambda/LambdaMessagingOptions.cs
+++ b/src/AWS.Messaging.Lambda/LambdaMessagingOptions.cs
@@ -29,6 +29,13 @@ public class LambdaMessagingOptions
     public bool DeleteMessagesWhenCompleted { get; set; } = false;
 
     /// <summary>
+    /// How many seconds to set the VisibilityTimeout value to on partial batch failures.
+    ///
+    /// Only applies for to Lambda functions that are configured for partial failure and return an <see cref="Amazon.Lambda.SQSEvents.SQSEvent"/>.
+    /// </summary>
+    public int? VisibilityTimeoutForBatchFailures { get; set; }
+
+    /// <summary>
     /// Validates that the options are valid against the message framework's and/or SQS limits
     /// </summary>
     /// <exception cref="InvalidLambdaMessagingOptionsException">Thrown when one or more invalid options are found</exception>

--- a/src/AWS.Messaging.Lambda/Services/DefaultLambdaMessageProcessor.cs
+++ b/src/AWS.Messaging.Lambda/Services/DefaultLambdaMessageProcessor.cs
@@ -76,7 +76,7 @@ internal class DefaultLambdaMessageProcessor : ILambdaMessageProcessor, ISQSMess
                 var sqsEvent = _configuration.SQSEvent;
 
                 trace.AddMetadata(TelemetryKeys.QueueUrl, _configuration.SubscriberEndpoint);
-                
+
                 if (sqsEvent is null || !sqsEvent.Records.Any())
                 {
                     return _sqsBatchResponse;
@@ -218,7 +218,7 @@ internal class DefaultLambdaMessageProcessor : ILambdaMessageProcessor, ISQSMess
         if(!messages.Any())
         {
             return;
-        }
+        }    
 
         var request = new DeleteMessageBatchRequest
         {

--- a/src/AWS.Messaging.Lambda/Services/DefaultLambdaMessageProcessor.cs
+++ b/src/AWS.Messaging.Lambda/Services/DefaultLambdaMessageProcessor.cs
@@ -76,7 +76,7 @@ internal class DefaultLambdaMessageProcessor : ILambdaMessageProcessor, ISQSMess
                 var sqsEvent = _configuration.SQSEvent;
 
                 trace.AddMetadata(TelemetryKeys.QueueUrl, _configuration.SubscriberEndpoint);
-
+                
                 if (sqsEvent is null || !sqsEvent.Records.Any())
                 {
                     return _sqsBatchResponse;
@@ -175,8 +175,7 @@ internal class DefaultLambdaMessageProcessor : ILambdaMessageProcessor, ISQSMess
             if (messageGroupMapping.TryGetValue(groupId, out var messageGroup))
                 messageGroup.Add(messageEnvelopResult);
             else
-                messageGroupMapping[groupId] = new List<ConvertToEnvelopeResult>
-                    { messageEnvelopResult };
+                messageGroupMapping[groupId] = new() { messageEnvelopResult };
         }
 
         var messageGroups = messageGroupMapping.Keys.ToList();

--- a/src/AWS.Messaging.Lambda/Services/DefaultLambdaMessageProcessor.cs
+++ b/src/AWS.Messaging.Lambda/Services/DefaultLambdaMessageProcessor.cs
@@ -218,7 +218,7 @@ internal class DefaultLambdaMessageProcessor : ILambdaMessageProcessor, ISQSMess
         if(!messages.Any())
         {
             return;
-        }    
+        }
 
         var request = new DeleteMessageBatchRequest
         {

--- a/src/AWS.Messaging.Lambda/Services/DefaultLambdaMessageProcessor.cs
+++ b/src/AWS.Messaging.Lambda/Services/DefaultLambdaMessageProcessor.cs
@@ -264,11 +264,15 @@ internal class DefaultLambdaMessageProcessor : ILambdaMessageProcessor, ISQSMess
     /// </summary>
     private async Task ResetVisibilityTimeoutForFailures()
     {
-        if (_configuration.SQSEvent == null) return;
-        if (!_configuration.UseBatchResponse) return;
-        if (!_configuration.VisibilityTimeoutForBatchFailures.HasValue) return;
+        if (_configuration.SQSEvent == null || !_configuration.UseBatchResponse || !_configuration.VisibilityTimeoutForBatchFailures.HasValue)
+        {
+            return;
+        }
         var failureCount = _sqsBatchResponse.BatchItemFailures?.Count ?? 0;
-        if (failureCount == 0) return;
+        if (failureCount == 0)
+        {
+            return;
+        }
 
         var lookup = _configuration.SQSEvent.Records.ToDictionary(x => x.MessageId);
         var visibilityTimeout = _configuration.VisibilityTimeoutForBatchFailures.Value;

--- a/src/AWS.Messaging.Lambda/Services/DefaultLambdaMessageProcessor.cs
+++ b/src/AWS.Messaging.Lambda/Services/DefaultLambdaMessageProcessor.cs
@@ -76,7 +76,7 @@ internal class DefaultLambdaMessageProcessor : ILambdaMessageProcessor, ISQSMess
                 var sqsEvent = _configuration.SQSEvent;
 
                 trace.AddMetadata(TelemetryKeys.QueueUrl, _configuration.SubscriberEndpoint);
-                
+
                 if (sqsEvent is null || !sqsEvent.Records.Any())
                 {
                     return _sqsBatchResponse;
@@ -115,6 +115,8 @@ internal class DefaultLambdaMessageProcessor : ILambdaMessageProcessor, ISQSMess
                 {
                     throw new LambdaInvocationFailureException($"Lambda invocation failed because {_sqsBatchResponse.BatchItemFailures.Count} message reported failures during handling");
                 }
+
+                await ResetVisibilityTimeoutForFailures();
 
                 return _configuration.UseBatchResponse ? _sqsBatchResponse : null;
             }
@@ -173,7 +175,8 @@ internal class DefaultLambdaMessageProcessor : ILambdaMessageProcessor, ISQSMess
             if (messageGroupMapping.TryGetValue(groupId, out var messageGroup))
                 messageGroup.Add(messageEnvelopResult);
             else
-                messageGroupMapping[groupId] = new() { messageEnvelopResult };
+                messageGroupMapping[groupId] = new List<ConvertToEnvelopeResult>
+                    { messageEnvelopResult };
         }
 
         var messageGroups = messageGroupMapping.Keys.ToList();
@@ -216,7 +219,7 @@ internal class DefaultLambdaMessageProcessor : ILambdaMessageProcessor, ISQSMess
         if(!messages.Any())
         {
             return;
-        }    
+        }
 
         var request = new DeleteMessageBatchRequest
         {
@@ -254,6 +257,48 @@ internal class DefaultLambdaMessageProcessor : ILambdaMessageProcessor, ISQSMess
             _logger.LogError("Failed to delete message {FailedMessageId} from queue {SubscriberEndpoint}: {FailedMessage}",
                 failedMessage.Id, _configuration.SubscriberEndpoint, failedMessage.Message);
         }
+    }
+
+    /// <summary>
+    /// If configured for <see cref="AWS.Messaging.Lambda.Services.LambdaMessageProcessorConfiguration.VisibilityTimeoutForBatchFailures"/>
+    /// then change the visibility timeout on the failed items in the batch response.
+    /// </summary>
+    private async Task ResetVisibilityTimeoutForFailures()
+    {
+        if (_configuration.SQSEvent == null) return;
+        if (!_configuration.UseBatchResponse) return;
+        if (!_configuration.VisibilityTimeoutForBatchFailures.HasValue) return;
+        var failureCount = _sqsBatchResponse.BatchItemFailures?.Count ?? 0;
+        if (failureCount == 0) return;
+
+        var lookup = _configuration.SQSEvent.Records.ToDictionary(x => x.MessageId);
+        var visibilityTimeout = _configuration.VisibilityTimeoutForBatchFailures.Value;
+
+        if (failureCount == 1)
+        {
+            _logger.LogInformation("ChangeMessageVisibility to {VisibilityTimeout}", visibilityTimeout);
+            await _sqsClient.ChangeMessageVisibilityAsync(new ChangeMessageVisibilityRequest
+            {
+                QueueUrl = _configuration.SubscriberEndpoint,
+                ReceiptHandle = lookup[_sqsBatchResponse!.BatchItemFailures![0].ItemIdentifier].ReceiptHandle,
+                VisibilityTimeout = visibilityTimeout
+            });
+            return;
+        }
+
+        _logger.LogInformation("ChangeMessageVisibilityBatch on {FailureCount} to {VisibilityTimeout}", failureCount, visibilityTimeout);
+        await _sqsClient.ChangeMessageVisibilityBatchAsync(new ChangeMessageVisibilityBatchRequest
+        {
+            QueueUrl = _configuration.SubscriberEndpoint,
+            Entries = _sqsBatchResponse!.BatchItemFailures!
+                .Select(x => new ChangeMessageVisibilityBatchRequestEntry
+                {
+                    Id = x.ItemIdentifier,
+                    ReceiptHandle = lookup[x.ItemIdentifier].ReceiptHandle,
+                    VisibilityTimeout = visibilityTimeout
+                })
+                .ToList()
+        });
     }
 
     /// <inheritdoc/>

--- a/src/AWS.Messaging.Lambda/Services/LambdaMessageProcessorConfiguration.cs
+++ b/src/AWS.Messaging.Lambda/Services/LambdaMessageProcessorConfiguration.cs
@@ -32,6 +32,13 @@ public class LambdaMessageProcessorConfiguration
     public bool UseBatchResponse { get; init; } = false;
 
     /// <summary>
+    /// How many seconds to set the VisibilityTimeout value to on partial batch failures.
+    ///
+    /// This is only applicable if <see cref="AWS.Messaging.Lambda.Services.LambdaMessageProcessorConfiguration.UseBatchResponse"/> is true.
+    /// </summary>
+    public int? VisibilityTimeoutForBatchFailures { get; init; }
+
+    /// <summary>
     /// The SQS event that will be processed by the Lambda function.
     /// </summary>
     public SQSEvent? SQSEvent { get; init; }

--- a/test/AWS.Messaging.UnitTests/LambdaTests.cs
+++ b/test/AWS.Messaging.UnitTests/LambdaTests.cs
@@ -152,8 +152,6 @@ public class LambdaTests
         _mockSqs!.Verify(
             expression: x => x.ChangeMessageVisibilityBatchAsync(It.IsAny<ChangeMessageVisibilityBatchRequest>(), It.IsAny<CancellationToken>()),
             times: Times.Once);
-        Assert.Single(tuple.batchResponse.BatchItemFailures);
-        Assert.Equal("1", tuple.batchResponse.BatchItemFailures[0].ItemIdentifier);
     }
 
     [Fact]

--- a/test/AWS.Messaging.UnitTests/LambdaTests.cs
+++ b/test/AWS.Messaging.UnitTests/LambdaTests.cs
@@ -107,6 +107,51 @@ public class LambdaTests
         };
 
         var tuple = await ExecuteWithBatchResponse(new SimulatedMessage[] { failedMessage });
+        _mockSqs!.Verify(
+            expression: x => x.ChangeMessageVisibilityAsync(It.IsAny<ChangeMessageVisibilityRequest>(), It.IsAny<CancellationToken>()),
+            times: Times.Never);
+        Assert.Single(tuple.batchResponse.BatchItemFailures);
+        Assert.Equal("1", tuple.batchResponse.BatchItemFailures[0].ItemIdentifier);
+    }
+
+    [Fact]
+    public async Task MessageHandlerResetsVisibilityWhenFailedStatusBatchResponse()
+    {
+        var failedMessage = new SimulatedMessage
+        {
+            Id = "failed-message-1",
+            ReturnFailedStatus = true
+        };
+
+        var tuple = await ExecuteWithBatchResponse(new SimulatedMessage[] { failedMessage }, visibilityTimeoutForBatchFailures: 10);
+        _mockSqs!.Verify(
+            expression: x => x.ChangeMessageVisibilityAsync(It.IsAny<ChangeMessageVisibilityRequest>(), It.IsAny<CancellationToken>()),
+            times: Times.Once);
+        Assert.Single(tuple.batchResponse.BatchItemFailures);
+        Assert.Equal("1", tuple.batchResponse.BatchItemFailures[0].ItemIdentifier);
+    }
+
+    [Fact]
+    public async Task MessageHandlerResetsVisibilityBatchWhenFailedStatusBatchResponse()
+    {
+        var failedMessage1 = new SimulatedMessage
+        {
+            Id = "failed-message-1",
+            ReturnFailedStatus = true
+        };
+        var failedMessage2 = new SimulatedMessage
+        {
+            Id = "failed-message-2",
+            ReturnFailedStatus = true
+        };
+
+        var tuple = await ExecuteWithBatchResponse(new SimulatedMessage[] { failedMessage1, failedMessage2 }, visibilityTimeoutForBatchFailures: 10);
+        _mockSqs!.Verify(
+            expression: x => x.ChangeMessageVisibilityAsync(It.IsAny<ChangeMessageVisibilityRequest>(), It.IsAny<CancellationToken>()),
+            times: Times.Never);
+        _mockSqs!.Verify(
+            expression: x => x.ChangeMessageVisibilityBatchAsync(It.IsAny<ChangeMessageVisibilityBatchRequest>(), It.IsAny<CancellationToken>()),
+            times: Times.Once);
         Assert.Single(tuple.batchResponse.BatchItemFailures);
         Assert.Equal("1", tuple.batchResponse.BatchItemFailures[0].ItemIdentifier);
     }
@@ -257,9 +302,16 @@ public class LambdaTests
         return logger.Buffer.ToString();
     }
 
-    private async Task<(string log, SQSBatchResponse batchResponse)> ExecuteWithBatchResponse(SimulatedMessage[] messages, int maxNumberOfConcurrentMessages = 1, bool deleteMessagesWhenCompleted = false)
+    private async Task<(string log, SQSBatchResponse batchResponse)> ExecuteWithBatchResponse(
+        SimulatedMessage[] messages,
+        int maxNumberOfConcurrentMessages = 1,
+        bool deleteMessagesWhenCompleted = false,
+        int? visibilityTimeoutForBatchFailures = default)
     {
-        var provider = CreateServiceProvider(maxNumberOfConcurrentMessages: maxNumberOfConcurrentMessages, deleteMessagesWhenCompleted: deleteMessagesWhenCompleted);
+        var provider = CreateServiceProvider(
+            maxNumberOfConcurrentMessages: maxNumberOfConcurrentMessages,
+            deleteMessagesWhenCompleted: deleteMessagesWhenCompleted,
+            visibilityTimeoutForBatchFailures: visibilityTimeoutForBatchFailures);
         var sqsEvent = await CreateLambdaEvent(provider, messages);
 
         var logger = new TestLambdaLogger();
@@ -277,7 +329,7 @@ public class LambdaTests
     private async Task<SQSEvent> CreateLambdaEvent(IServiceProvider provider,  SimulatedMessage[] messages, bool addInvalidMessageFormatRecord = false, bool isFifoQueue = false)
     {
         var envelopeSerializer = provider.GetRequiredService<IEnvelopeSerializer>();
-        
+
         var sqsEvent = new SQSEvent()
         {
             Records = new List<SQSMessage>()
@@ -333,7 +385,11 @@ public class LambdaTests
         return sqsEvent;
     }
 
-    private IServiceProvider CreateServiceProvider(int maxNumberOfConcurrentMessages = 1, bool deleteMessagesWhenCompleted = false, bool isFifoQueue = false)
+    private IServiceProvider CreateServiceProvider(
+        int maxNumberOfConcurrentMessages = 1,
+        bool deleteMessagesWhenCompleted = false,
+        bool isFifoQueue = false,
+        int? visibilityTimeoutForBatchFailures = default)
     {
         _mockSqs = new Mock<IAmazonSQS>();
 
@@ -360,6 +416,7 @@ public class LambdaTests
             {
                 options.MaxNumberOfConcurrentMessages = maxNumberOfConcurrentMessages;
                 options.DeleteMessagesWhenCompleted = deleteMessagesWhenCompleted;
+                options.VisibilityTimeoutForBatchFailures = visibilityTimeoutForBatchFailures;
             });
         });
 


### PR DESCRIPTION
Issue #150

*Description of changes:*

Adds a configuration option to [LambdaMessagingOptions](https://github.com/awslabs/aws-dotnet-messaging/blob/main/src/AWS.Messaging.Lambda/LambdaMessagingOptions.cs) for a `VisibilityTimeout` value when there are partial batch failures. In that scenario, the failed messages will have their message visibility set to this default value.

Prior to this change, the message visibility would not be set/changed. Which, if you were using a FIFO queue, would mean that other messages in that message group would be blocked until the original message visibility timeout occurred, which could be a while.

After this change, the message visibility will be changed on failure.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
