### PR TITLE
Use static MessageConfiguration tied to ServiceCollection

### DIFF
--- a/.autover/changes/7affc078-3e1b-4baa-a27b-67280b0e95d5.json
+++ b/.autover/changes/7affc078-3e1b-4baa-a27b-67280b0e95d5.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Messaging",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Add support for AddAWSMessageBus being invoked multiple times against the same ServiceCollection. This allows different modules to register their own handlers rather than requiring a centralized registration."
+      ]
+    }
+  ]
+}

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -25,6 +25,7 @@ namespace AWS.Messaging.Configuration;
 /// </summary>
 public class MessageBusBuilder : IMessageBusBuilder
 {
+    private static readonly Dictionary<IServiceCollection, MessageConfiguration> _messageConfigurations = new();
     private readonly MessageConfiguration _messageConfiguration;
     private readonly IList<ServiceDescriptor> _additionalServices = new List<ServiceDescriptor>();
     private readonly IServiceCollection _serviceCollection;
@@ -35,7 +36,15 @@ public class MessageBusBuilder : IMessageBusBuilder
     public MessageBusBuilder(IServiceCollection services)
     {
         _serviceCollection = services;
-        _messageConfiguration = new MessageConfiguration();
+        if (_messageConfigurations.TryGetValue(services, out var config))
+        {
+            _messageConfiguration = config;
+        }
+        else
+        {
+            _messageConfiguration = new MessageConfiguration();
+            _messageConfigurations[services] = _messageConfiguration;
+        }
     }
 
     /// <inheritdoc/>
@@ -129,7 +138,6 @@ public class MessageBusBuilder : IMessageBusBuilder
             VisibilityTimeoutExtensionHeartbeatInterval = sqsMessagePollerOptions.VisibilityTimeoutExtensionHeartbeatInterval,
             WaitTimeSeconds = sqsMessagePollerOptions.WaitTimeSeconds,
             IsExceptionFatal = sqsMessagePollerOptions.IsExceptionFatal
-
         };
 
         _messageConfiguration.MessagePollerConfigurations.Add(sqsMessagePollerConfiguration);
@@ -308,7 +316,7 @@ public class MessageBusBuilder : IMessageBusBuilder
         _serviceCollection.TryAdd(ServiceDescriptor.Singleton<ILoggerFactory, NullLoggerFactory>());
         _serviceCollection.TryAdd(ServiceDescriptor.Singleton(typeof(ILogger<>), typeof(NullLogger<>)));
 
-        _serviceCollection.AddSingleton<IMessageConfiguration>(_messageConfiguration);
+        _serviceCollection.TryAddSingleton<IMessageConfiguration>(_messageConfiguration);
         _serviceCollection.TryAddSingleton<IMessageSerializer, MessageSerializer>();
         _serviceCollection.TryAddSingleton<IEnvelopeSerializer, EnvelopeSerializer>();
         _serviceCollection.TryAddSingleton<IDateTimeHandler, DateTimeHandler>();
@@ -326,18 +334,20 @@ public class MessageBusBuilder : IMessageBusBuilder
 
         if (_messageConfiguration.PublisherMappings.Any())
         {
-            _serviceCollection.AddSingleton<IMessagePublisher, MessageRoutingPublisher>();
+            _serviceCollection.TryAddSingleton<IMessagePublisher, MessageRoutingPublisher>();
 
             if (_messageConfiguration.PublisherMappings.Any(x => x.PublishTargetType == PublisherTargetType.SQS_PUBLISHER))
             {
                 _serviceCollection.TryAddAWSService<Amazon.SQS.IAmazonSQS>();
                 _serviceCollection.TryAddSingleton<ISQSPublisher, SQSPublisher>();
             }
+
             if (_messageConfiguration.PublisherMappings.Any(x => x.PublishTargetType == PublisherTargetType.SNS_PUBLISHER))
             {
                 _serviceCollection.TryAddAWSService<Amazon.SimpleNotificationService.IAmazonSimpleNotificationService>();
                 _serviceCollection.TryAddSingleton<ISNSPublisher, SNSPublisher>();
             }
+
             if (_messageConfiguration.PublisherMappings.Any(x => x.PublishTargetType == PublisherTargetType.EVENTBRIDGE_PUBLISHER))
             {
                 _serviceCollection.TryAddAWSService<Amazon.EventBridge.IAmazonEventBridge>();
@@ -351,7 +361,7 @@ public class MessageBusBuilder : IMessageBusBuilder
 
             foreach (var subscriberMapping in _messageConfiguration.SubscriberMappings)
             {
-                _serviceCollection.AddScoped(subscriberMapping.HandlerType);
+                _serviceCollection.TryAddScoped(subscriberMapping.HandlerType);
             }
         }
 
@@ -387,7 +397,7 @@ public class MessageBusBuilder : IMessageBusBuilder
 
         foreach (var service in _additionalServices)
         {
-            _serviceCollection.Add(service);
+            _serviceCollection.TryAdd(service);
         }
     }
 

--- a/test/AWS.Messaging.UnitTests/MessageBusBuilderTests.cs
+++ b/test/AWS.Messaging.UnitTests/MessageBusBuilderTests.cs
@@ -58,6 +58,35 @@ public class MessageBusBuilderTests
     }
 
     [Fact]
+    public void BuildMessageBus_MultipleInvocations()
+    {
+        _serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddSQSPublisher<OrderInfo>("sqsQueueUrl");
+            builder.AddMessageHandler<AddressInfoHandler, AddressInfo>();
+        });
+
+        _serviceCollection.AddAWSMessageBus(builder =>
+        {
+            builder.AddMessageHandler<ChatMessageHandler, ChatMessage>();
+        });
+
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+
+        var messagePublisher = serviceProvider.GetService<IMessagePublisher>();
+        Assert.NotNull(messagePublisher);
+
+        CheckRequiredServices(serviceProvider);
+
+        var mesageConfiguration = serviceProvider.GetRequiredService<IMessageConfiguration>();
+        Assert.Equal(2, mesageConfiguration.SubscriberMappings.Count);
+        Assert.Equal(typeof(AddressInfo), mesageConfiguration.SubscriberMappings[0].MessageType);
+        Assert.Equal(typeof(AddressInfoHandler), mesageConfiguration.SubscriberMappings[0].HandlerType);
+        Assert.Equal(typeof(ChatMessage), mesageConfiguration.SubscriberMappings[1].MessageType);
+        Assert.Equal(typeof(ChatMessageHandler), mesageConfiguration.SubscriberMappings[1].HandlerType);
+    }
+
+    [Fact]
     public void MessageBus_ConfigureBackoffPolicy_Default()
     {
         _serviceCollection.AddAWSMessageBus(builder =>


### PR DESCRIPTION
This is a way to support multiple invocations of AddAWSMessageBus against same ServiceCollection with the least amount of changes.

Submitting for feedback. Possible you may want to take a different approach.

Issue #152

*Description of changes:*
Change `MessageConfiguration` to a static, so it can be shared across implementations. 
Add unit test for scenario and fix unit test scaffold to support setting up new `MessageConfiguration` contexts for each test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
