### PR TITLE
Removes references to SNS in EventBridge publisher

### DIFF
--- a/.autover/changes/1cc6641e-f4c6-4db6-b480-cb3d96fdaab7.json
+++ b/.autover/changes/1cc6641e-f4c6-4db6-b480-cb3d96fdaab7.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Messaging",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Removes references to SNS in EventBridge publisher"
+      ]
+    }
+  ]
+}

--- a/src/AWS.Messaging/Publishers/EventBridge/IEventBridgePublisher.cs
+++ b/src/AWS.Messaging/Publishers/EventBridge/IEventBridgePublisher.cs
@@ -13,9 +13,9 @@ namespace AWS.Messaging.Publishers.EventBridge
     public interface IEventBridgePublisher : IEventPublisher
     {
         /// <summary>
-        /// Publishes the application message to SNS.
+        /// Publishes the application message to EventBridge.
         /// </summary>
-        /// <param name="message">The application message that will be serialized and sent to an SNS topic</param>
+        /// <param name="message">The application message that will be serialized and sent to an EventBridge event bus</param>
         /// <param name="eventBridgeOptions">Contains additional parameters that can be set while sending a message to EventBridge</param>
         /// <param name="token">The cancellation token used to cancel the request.</param>
         Task<EventBridgePublishResponse> PublishAsync<T>(T message, EventBridgeOptions? eventBridgeOptions, CancellationToken token = default);


### PR DESCRIPTION
Hi, thanks for the library it's been a huge help. Just noticed that the EventBridge publisher was referencing SNS instead of EventBridge.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
