### PR TITLE
Avoid logging errors during shutdown due to SQS client call being cancelled

### DIFF
--- a/.autover/changes/cddcba75-9039-4f3c-967c-72841ed2af9d.json
+++ b/.autover/changes/cddcba75-9039-4f3c-967c-72841ed2af9d.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Messaging",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Avoid logging error during shutdown"
+      ]
+    }
+  ]
+}

--- a/src/AWS.Messaging/SQS/SQSMessagePoller.cs
+++ b/src/AWS.Messaging/SQS/SQSMessagePoller.cs
@@ -116,8 +116,16 @@ internal class SQSMessagePoller : IMessagePoller, ISQSMessageCommunication
                 {
                     _logger.LogTrace("Retrieving up to {NumberOfMessagesToRead} messages from {QueueUrl}",
                         receiveMessageRequest.MaxNumberOfMessages, receiveMessageRequest.QueueUrl);
-
-                    var receiveMessageResponse = await _sqsClient.ReceiveMessageAsync(receiveMessageRequest, token);
+                    ReceiveMessageResponse receiveMessageResponse;
+                    try
+                    {
+                        receiveMessageResponse = await _sqsClient.ReceiveMessageAsync(receiveMessageRequest, token);
+                    }
+                    catch (TaskCanceledException)
+                    {
+                        _logger.LogTrace("Cancellation requested while receiving messages, probably due to shutdown. Returning empty list of messages");
+                        return new List<Message>();
+                    }
 
                     _logger.LogTrace("Retrieved {MessagesCount} messages from {QueueUrl} via request ID {RequestId}",
                         receiveMessageResponse.Messages.Count, receiveMessageRequest.QueueUrl, receiveMessageResponse.ResponseMetadata.RequestId);


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
When an app gets shut down, the CancellationToken passed in the BackgroundService gets cancelled. When that happens, the SQS poller throws an exception, which gets logged as an error. This means a consuming app logs error + warning every time the app shuts down. This change catches the exception and returns empty list of messages, so the app can gracefully shut down without any errors being logged.

Logs from sampleapps/SubscriberService before the change:

```console
info: AWS.Messaging.Services.MessagePumpService[0]
      Starting polling: <queue url>
info: Microsoft.Hosting.Lifetime[0]
      Application started. Press Ctrl+C to shut down.
info: Microsoft.Hosting.Lifetime[0]
      Hosting environment: Production
info: Microsoft.Hosting.Lifetime[0]
      Content root path: C:\src\aws-dotnet-messaging\sampleapps\SubscriberService\bin\Debug\net6.0
info: Microsoft.Hosting.Lifetime[0]
      Application is shutting down...
fail: AWS.Messaging.Services.Backoff.BackoffHandler[0]
      An unknown exception occurred while polling '<queue url>'.
      System.Threading.Tasks.TaskCanceledException: A task was canceled.
         at Amazon.Runtime.Internal.RetryHandler.InvokeAsync[T](IExecutionContext executionContext)
         at Amazon.Runtime.Internal.CallbackHandler.InvokeAsync[T](IExecutionContext executionContext)
         at Amazon.Runtime.Internal.CallbackHandler.InvokeAsync[T](IExecutionContext executionContext)
         at Amazon.Runtime.Internal.ErrorCallbackHandler.InvokeAsync[T](IExecutionContext executionContext)
         at Amazon.Runtime.Internal.MetricsHandler.InvokeAsync[T](IExecutionContext executionContext)
         at AWS.Messaging.SQS.SQSMessagePoller.<>c__DisplayClass12_1.<<PollQueue>b__0>d.MoveNext() in C:\src\aws-dotnet-messaging\src\AWS.Messaging\SQS\SQSMessagePoller.cs:line 122
      --- End of stack trace from previous location ---
         at AWS.Messaging.Services.Backoff.BackoffHandler.BackoffAsync[T](Func`1 task, SQSMessagePollerConfiguration configuration, CancellationToken token) in C:\src\aws-dotnet-messaging\src\AWS.Messaging\Services\Backoff\BackoffHandler.cs:line 51
warn: AWS.Messaging.Services.Backoff.BackoffHandler[0]
      Backing off polling from SQS for messages for 0s before trying again...
```

Logs from sampleapps/SubscriberService after the change

```console
info: AWS.Messaging.Services.MessagePumpService[0]
      Starting polling: <queue url>
info: Microsoft.Hosting.Lifetime[0]
      Application started. Press Ctrl+C to shut down.
info: Microsoft.Hosting.Lifetime[0]
      Hosting environment: Production
info: Microsoft.Hosting.Lifetime[0]
      Content root path: C:\src\aws-dotnet-messaging\sampleapps\SubscriberService\bin\Debug\net6.0
info: Microsoft.Hosting.Lifetime[0]
      Application is shutting down...
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
