### PR TITLE
Fix issue with fifo queues message failure reporint issue

### DIFF
--- a/.autover/changes/0529a49e-6b48-4eea-874b-1a5c2be8b029.json
+++ b/.autover/changes/0529a49e-6b48-4eea-874b-1a5c2be8b029.json
@@ -1,0 +1,18 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Messaging",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fix issue with fifo when a message is failed to process the later messages are not retried"
+      ]
+    },
+	{
+      "Name": "AWS.Messaging.Lambda",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update AWS.Messaging dependency"
+      ]
+    }	
+  ]
+}

--- a/.github/workflows/BuildandTest.yml
+++ b/.github/workflows/BuildandTest.yml
@@ -15,6 +15,10 @@ jobs:
       uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # pinning V4
       with:
         dotnet-version: 6.0.x
+    - name: Setup .NET Core 8.0
+      uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # pinning V4
+      with:
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/src/AWS.Messaging/Services/DefaultMessageManager.cs
+++ b/src/AWS.Messaging/Services/DefaultMessageManager.cs
@@ -133,7 +133,7 @@ public class DefaultMessageManager : IMessageManager
             var remaining = messageGroup.Count;
 
             // Sequentially process each message within the group
-            for(var i = 0; i < messageGroup.Count; i += 1)
+            for(var i = 0; i < messageGroup.Count; i++)
             {
                 var message = messageGroup[i];
 

--- a/src/AWS.Messaging/Services/DefaultMessageManager.cs
+++ b/src/AWS.Messaging/Services/DefaultMessageManager.cs
@@ -133,12 +133,19 @@ public class DefaultMessageManager : IMessageManager
             var remaining = messageGroup.Count;
 
             // Sequentially process each message within the group
-            foreach (var message in messageGroup)
+            for(var i = 0; i < messageGroup.Count; i += 1)
             {
+                var message = messageGroup[i];
+
                 var isSuccessful = await InvokeHandler(message.Envelope, message.Mapping, token);
                 if (!isSuccessful)
                 {
-                    // If the handler invocation fails for any message, skip processing subsequent messages in the group.
+                    // If the handler invocation fails for any message, report failure for the rest in the group so they are reported back to Lambda
+                    // as not failure that should be retried. Otherwise Lambda will think the messages were successfully processed and delete the messages.
+                    for (var unprocessedIndex = i + 1; unprocessedIndex < messageGroup.Count; unprocessedIndex++)
+                    {
+                        await _sqsMessageCommunication.ReportMessageFailureAsync(messageGroup[unprocessedIndex].Envelope, token);
+                    }
                     _logger.LogError("Handler invocation failed for a message belonging to message group '{GroupdId}' having message ID '{MessageID}'. Skipping processing of {Remaining} messages from the same group.", groupId, message.Envelope.Id, remaining);
                     break;
                 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-dotnet-messaging/issues/174

*Description of changes:*
While processing messages in Lambda if we get a failure in a message group we skip processing the remaining messages. We should be reporting to Lambda as part of the SQSBatchResponse the items we skipped as failures so Lambda doesn't think they were successfully processed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
