### PR TITLE
Issue-147: Add feature to pause/resume SQSMessagePoller

### DIFF
--- a/.autover/changes/276cbae4-0a14-4efa-9fd2-760cf4529b0a.json
+++ b/.autover/changes/276cbae4-0a14-4efa-9fd2-760cf4529b0a.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Messaging",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Implement a start/stop mechanism for message consumption. (ISSUE 147)"
+      ]
+    }
+  ]
+}

--- a/sampleapps/SubscriberService/Program.cs
+++ b/sampleapps/SubscriberService/Program.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Text.Json;
+using AWS.Messaging.Configuration;
 using AWS.Messaging.Telemetry.OpenTelemetry;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -47,6 +48,13 @@ await Host.CreateDefaultBuilder(args)
                 {
                     x.CapBackoffTime = 60;
                 });
+            });
+
+            // Optional: Configure a PollingControlToken, you can call Start()/Stop() to start and stop message processing, by default it will be started
+            builder.ConfigurePollingControlToken(new PollingControlToken()
+            {
+                // Optional: Set how frequently it will check for changes to the state of the PollingControlToken
+                PollingWaitTime = TimeSpan.FromMilliseconds(200)
             });
 
             // Logging data messages is disabled by default to protect sensitive user data. If you want this enabled, uncomment the line below.

--- a/sampleapps/SubscriberService/Program.cs
+++ b/sampleapps/SubscriberService/Program.cs
@@ -51,7 +51,7 @@ await Host.CreateDefaultBuilder(args)
             });
 
             // Optional: Configure a PollingControlToken, you can call Start()/Stop() to start and stop message processing, by default it will be started
-            builder.ConfigurePollingControlToken(new PollingControlToken()
+            builder.ConfigurePollingControlToken(new PollingControlToken
             {
                 // Optional: Set how frequently it will check for changes to the state of the PollingControlToken
                 PollingWaitTime = TimeSpan.FromMilliseconds(200)

--- a/src/AWS.Messaging/Configuration/IMessageConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/IMessageConfiguration.cs
@@ -3,6 +3,7 @@
 
 using AWS.Messaging.Configuration.Internal;
 using AWS.Messaging.Serialization;
+using AWS.Messaging.Services;
 using AWS.Messaging.Services.Backoff;
 using AWS.Messaging.Services.Backoff.Policies;
 using AWS.Messaging.Services.Backoff.Policies.Options;
@@ -93,4 +94,9 @@ public interface IMessageConfiguration
     /// Holds an instance of <see cref="CappedExponentialBackoffOptions"/> to control the behavior of <see cref="CappedExponentialBackoffPolicy"/>.
     /// </summary>
     CappedExponentialBackoffOptions CappedExponentialBackoffOptions { get; }
+
+    /// <summary>
+    /// Holds an instance of <see cref="PollingControlToken"/> to control behaviour of <see cref="IMessagePoller"/>
+    /// </summary>
+    PollingControlToken PollingControlToken { get; }
 }

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -323,7 +323,7 @@ public class MessageBusBuilder : IMessageBusBuilder
         _serviceCollection.TryAdd(ServiceDescriptor.Singleton<ILoggerFactory, NullLoggerFactory>());
         _serviceCollection.TryAdd(ServiceDescriptor.Singleton(typeof(ILogger<>), typeof(NullLogger<>)));
 
-		_serviceCollection.TryAddSingleton(_messageConfiguration.PollingControlToken);
+        _serviceCollection.TryAddSingleton(_messageConfiguration.PollingControlToken);
         _serviceCollection.TryAddSingleton<IMessageConfiguration>(_messageConfiguration);
         _serviceCollection.TryAddSingleton<IMessageSerializer, MessageSerializer>();
         _serviceCollection.TryAddSingleton<IEnvelopeSerializer, EnvelopeSerializer>();

--- a/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
+++ b/src/AWS.Messaging/Configuration/MessageBusBuilder.cs
@@ -173,6 +173,13 @@ public class MessageBusBuilder : IMessageBusBuilder
     }
 
     /// <inheritdoc/>
+    public IMessageBusBuilder ConfigurePollingControlToken(PollingControlToken pollingControlToken)
+    {
+        _messageConfiguration.PollingControlToken = pollingControlToken;
+        return this;
+    }
+
+    /// <inheritdoc/>
     public IMessageBusBuilder LoadConfigurationFromSettings(IConfiguration configuration)
     {
         // This call needs to happen in this function so that the calling assembly is the customer's assembly.
@@ -316,6 +323,7 @@ public class MessageBusBuilder : IMessageBusBuilder
         _serviceCollection.TryAdd(ServiceDescriptor.Singleton<ILoggerFactory, NullLoggerFactory>());
         _serviceCollection.TryAdd(ServiceDescriptor.Singleton(typeof(ILogger<>), typeof(NullLogger<>)));
 
+		_serviceCollection.TryAddSingleton(_messageConfiguration.PollingControlToken);
         _serviceCollection.TryAddSingleton<IMessageConfiguration>(_messageConfiguration);
         _serviceCollection.TryAddSingleton<IMessageSerializer, MessageSerializer>();
         _serviceCollection.TryAddSingleton<IEnvelopeSerializer, EnvelopeSerializer>();

--- a/src/AWS.Messaging/Configuration/MessageConfiguration.cs
+++ b/src/AWS.Messaging/Configuration/MessageConfiguration.cs
@@ -65,4 +65,7 @@ public class MessageConfiguration : IMessageConfiguration
 
     /// <inheritdoc/>
     public CappedExponentialBackoffOptions CappedExponentialBackoffOptions { get; set; } = new();
+
+    /// <inheritdoc/>
+    public PollingControlToken PollingControlToken { get; set; } = new();
 }

--- a/src/AWS.Messaging/Configuration/PollingControlToken.cs
+++ b/src/AWS.Messaging/Configuration/PollingControlToken.cs
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Configuration
+{
+    /// <summary>
+    /// Control token to start and stop message polling for a service.
+    /// </summary>
+    public record PollingControlToken
+    {
+        /// <summary>
+        /// Indicates if polling is enabled.
+        /// </summary>
+        internal bool IsPollingEnabled { get; private set; } = true;
+
+        /// <summary>
+        /// Start polling of the SQS Queue.
+        /// </summary>
+        public void StartPolling() => IsPollingEnabled = true;
+
+        /// <summary>
+        /// Stop polling of the SQS Queue.
+        /// </summary>
+        public void StopPolling() => IsPollingEnabled = false;
+
+        /// <summary>
+        /// Configurable amount of time to wait between polling for a change in status
+        /// </summary>
+        public TimeSpan PollingWaitTime { get; set; } = TimeSpan.FromMilliseconds(200);
+    }
+
+    
+}

--- a/test/AWS.Messaging.IntegrationTests/SubscriberTests.cs
+++ b/test/AWS.Messaging.IntegrationTests/SubscriberTests.cs
@@ -181,7 +181,7 @@ public class SubscriberTests : IAsyncLifetime
         Assert.NotNull(pump);
         var source = new CancellationTokenSource();
 
-        await pump.StartAsync(source.Token);
+        await pump.StartAsync(source.Token).ConfigureAwait(true);
 
         // Wait for the pump to shut down after processing the expected number of messages,
         // with some padding to ensure messages aren't being processed more than once
@@ -189,7 +189,7 @@ public class SubscriberTests : IAsyncLifetime
 
         // Stop polling and wait for the polling cycle to complete with a buffer
         pollingControlToken.StopPolling();
-        await Task.Delay(pollingControlToken.PollingWaitTime * 2);
+        await Task.Delay(pollingControlToken.PollingWaitTime * 2, source.Token);
 
         // Publish the next 5 messages that should not be received due to stopping polling
         for (int i = 5; i < 10; i++)

--- a/test/AWS.Messaging.IntegrationTests/SubscriberTests.cs
+++ b/test/AWS.Messaging.IntegrationTests/SubscriberTests.cs
@@ -189,7 +189,8 @@ public class SubscriberTests : IAsyncLifetime
 
         // Stop polling and wait for the polling cycle to complete with a buffer
         pollingControlToken.StopPolling();
-        await Task.Delay(pollingControlToken.PollingWaitTime * 2, source.Token);
+
+        SpinWait.SpinUntil(() => false, pollingControlToken.PollingWaitTime * 3);
 
         // Publish the next 5 messages that should not be received due to stopping polling
         for (int i = 5; i < 10; i++)
@@ -200,7 +201,7 @@ public class SubscriberTests : IAsyncLifetime
             });
         }
 
-        while (!source.IsCancellationRequested) { }
+        SpinWait.SpinUntil(() => source.IsCancellationRequested);
 
         var inMemoryLogger = serviceProvider.GetRequiredService<InMemoryLogger>();
         var tempStorage = serviceProvider.GetRequiredService<TempStorage<ChatMessage>>();

--- a/test/AWS.Messaging.UnitTests/MessagePublisherTests.cs
+++ b/test/AWS.Messaging.UnitTests/MessagePublisherTests.cs
@@ -764,7 +764,7 @@ public class MessagePublisherTests
             new DefaultTelemetryFactory(serviceProvider)
         );
 
-        var publishResponse = Assert.ThrowsAsync<FailedToPublishException>(async () => await messagePublisher.PublishAsync(_chatMessage));
+        var publishResponse = await Assert.ThrowsAsync<FailedToPublishException>(async () => await messagePublisher.PublishAsync(_chatMessage));
 
         _eventBridgeClient.Verify(x =>
                 x.PutEventsAsync(
@@ -774,9 +774,9 @@ public class MessagePublisherTests
                     It.IsAny<CancellationToken>()),
             Times.Exactly(1));
 
-        Assert.Equal("Message failed to publish.", publishResponse.Result.Message);
-        Assert.Equal("ErrorMessage", publishResponse.Result.InnerException.Message);
-        Assert.Equal("ErrorCode", ((EventBridgePutEventsException)publishResponse.Result.InnerException).ErrorCode);
+        Assert.Equal("Message failed to publish.", publishResponse.Message);
+        Assert.Equal("ErrorMessage", publishResponse.InnerException.Message);
+        Assert.Equal("ErrorCode", ((EventBridgePutEventsException)publishResponse.InnerException).ErrorCode);
     }
 
     [Fact]

--- a/test/AWS.Messaging.UnitTests/SQSMessagePollerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SQSMessagePollerTests.cs
@@ -89,11 +89,12 @@ public class SQSMessagePollerTests
         var source = new CancellationTokenSource();
         var pump = BuildMessagePumpService(client, pollingControlToken: pollingControlToken);
         var task = pump.StartAsync(source.Token);
+        await task.ConfigureAwait(true);
 
         client.Verify(x => x.ReceiveMessageAsync(It.IsAny<ReceiveMessageRequest>(), It.IsAny<CancellationToken>()), Times.Never);
 
         pollingControlToken.StartPolling();
-        await Task.Delay(pollingControlToken.PollingWaitTime * 2);
+        await Task.Delay(pollingControlToken.PollingWaitTime * 2, source.Token);
 
         client.Verify(x => x.ReceiveMessageAsync(It.IsAny<ReceiveMessageRequest>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce());
 

--- a/test/AWS.Messaging.UnitTests/SQSMessagePollerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SQSMessagePollerTests.cs
@@ -26,6 +26,12 @@ public class SQSMessagePollerTests
 {
     private const string TEST_QUEUE_URL = "queueUrl";
     private InMemoryLogger? _inMemoryLogger;
+    private readonly ServiceCollection _serviceCollection;
+
+    public SQSMessagePollerTests()
+    {
+        _serviceCollection = new ServiceCollection();
+    }
 
     /// <summary>
     /// Tests that starting an SQS poller with default settings begins polling SQS
@@ -40,6 +46,59 @@ public class SQSMessagePollerTests
         await RunSQSMessagePollerTest(client);
 
         client.Verify(x => x.ReceiveMessageAsync(It.IsAny<ReceiveMessageRequest>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce());
+    }
+
+    /// <summary>
+    /// Tests that starting an SQS poller with <see cref="PollingControlToken.IsPollingEnabled"/>
+    /// set to false, will not poll any messages.
+    /// </summary>
+    [Fact]
+    public async Task SQSMessagePoller_PollingControlStopped_DoesNotPollSQS()
+    {
+        var client = new Mock<IAmazonSQS>();
+        client.Setup(x => x.ReceiveMessageAsync(It.IsAny<ReceiveMessageRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ReceiveMessageResponse(), TimeSpan.FromMilliseconds(50));
+        var pollingControlToken = new PollingControlToken
+        {
+            PollingWaitTime = TimeSpan.FromMilliseconds(25)
+        };
+        pollingControlToken.StopPolling();
+
+        await RunSQSMessagePollerTest(client, pollingControlToken: pollingControlToken);
+
+        client.Verify(x => x.ReceiveMessageAsync(It.IsAny<ReceiveMessageRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>
+    /// Tests that starting an SQS poller with <see cref="PollingControlToken.IsPollingEnabled"/>
+    /// set to false, will not poll any messages first. Then when changing the value to true
+    /// polling resumes and messages are received.
+    /// </summary>
+    [Fact]
+    public async Task SQSMessagePoller_PollingControlRestarted_PollsSQS()
+    {
+        var client = new Mock<IAmazonSQS>();
+        client.Setup(x => x.ReceiveMessageAsync(It.IsAny<ReceiveMessageRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ReceiveMessageResponse(), TimeSpan.FromMilliseconds(50));
+        var pollingControlToken = new PollingControlToken
+        {
+            PollingWaitTime = TimeSpan.FromMilliseconds(25)
+        };
+        pollingControlToken.StopPolling();
+
+        var source = new CancellationTokenSource();
+        var pump = BuildMessagePumpService(client, pollingControlToken: pollingControlToken);
+        var task = pump.StartAsync(source.Token);
+
+        client.Verify(x => x.ReceiveMessageAsync(It.IsAny<ReceiveMessageRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        pollingControlToken.StartPolling();
+        await Task.Delay(pollingControlToken.PollingWaitTime * 2);
+
+        client.Verify(x => x.ReceiveMessageAsync(It.IsAny<ReceiveMessageRequest>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce());
+
+        source.Cancel();
+        await task;
     }
 
     /// <summary>
@@ -251,20 +310,38 @@ public class SQSMessagePollerTests
     /// </summary>
     /// <param name="mockSqsClient">Mocked SQS client</param>
     /// <param name="options">SQS MessagePoller options</param>
-    private async Task RunSQSMessagePollerTest(Mock<IAmazonSQS> mockSqsClient, Action<SQSMessagePollerOptions>? options = null)
+    /// <param name="pollingControlToken">Polling control token to start or stop message receipt</param>
+    private async Task RunSQSMessagePollerTest(Mock<IAmazonSQS> mockSqsClient, Action<SQSMessagePollerOptions>? options = null, PollingControlToken? pollingControlToken = null)
     {
-        var serviceCollection = new ServiceCollection();
-        serviceCollection.AddLogging();
+        var pump = BuildMessagePumpService(mockSqsClient, options, pollingControlToken);
 
-        serviceCollection.AddAWSMessageBus(builder =>
+        var source = new CancellationTokenSource();
+        source.CancelAfter(500);
+
+        await pump.StartAsync(source.Token);
+    }
+
+    /// <summary>
+    /// Helper function that initializes but does not start a <see cref="MessagePumpService"/> with
+    /// a mocked SQS client
+    /// </summary>
+    /// <param name="mockSqsClient">Mocked SQS client</param>
+    /// <param name="options">SQS MessagePoller options</param>
+    /// <param name="pollingControlToken">Polling control token to start or stop message receipt</param>
+    private MessagePumpService BuildMessagePumpService(Mock<IAmazonSQS> mockSqsClient, Action<SQSMessagePollerOptions>? options = null, PollingControlToken? pollingControlToken = null)
+    {
+        _serviceCollection.AddLogging();
+
+        _serviceCollection.AddAWSMessageBus(builder =>
         {
+            if (pollingControlToken is not null) builder.ConfigurePollingControlToken(pollingControlToken);
             builder.AddSQSPoller(TEST_QUEUE_URL, options);
             builder.AddMessageHandler<ChatMessageHandler, ChatMessage>();
         });
 
-        serviceCollection.AddSingleton(mockSqsClient.Object);
+        _serviceCollection.AddSingleton(mockSqsClient.Object);
 
-        var serviceProvider = serviceCollection.BuildServiceProvider();
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
 
         var pump = serviceProvider.GetService<IHostedService>() as MessagePumpService;
 
@@ -273,10 +350,7 @@ public class SQSMessagePollerTests
             Assert.Fail($"Unable to get the {nameof(MessagePumpService)} from the service provider.");
         }
 
-        var source = new CancellationTokenSource();
-        source.CancelAfter(500);
-
-        await pump.StartAsync(source.Token);
+        return pump;
     }
 
     /// <summary>

--- a/test/AWS.Messaging.UnitTests/SQSMessagePollerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SQSMessagePollerTests.cs
@@ -89,12 +89,12 @@ public class SQSMessagePollerTests
         var source = new CancellationTokenSource();
         var pump = BuildMessagePumpService(client, pollingControlToken: pollingControlToken);
         var task = pump.StartAsync(source.Token);
-        await task.ConfigureAwait(true);
 
         client.Verify(x => x.ReceiveMessageAsync(It.IsAny<ReceiveMessageRequest>(), It.IsAny<CancellationToken>()), Times.Never);
 
         pollingControlToken.StartPolling();
-        await Task.Delay(pollingControlToken.PollingWaitTime * 2, source.Token);
+
+        SpinWait.SpinUntil(() => false, pollingControlToken.PollingWaitTime * 5);
 
         client.Verify(x => x.ReceiveMessageAsync(It.IsAny<ReceiveMessageRequest>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce());
 


### PR DESCRIPTION
*Issue #147 :*

*Description of changes:*
**Use case** Blue/Green deployments, where the inactive service can change and we want to stop/start the message consumption dependent upon the active service.

I have followed the [contribution guideline](https://github.com/awslabs/aws-dotnet-messaging/blob/1e818f42dbc6ae374fbfde6f817bcccd12ab708a/CONTRIBUTING.md) and have aimed to follow the existing repositories coding style. 

I added a PollingControlToken with Start()/Stop() methods that is setup initially by the MessageBusBuilder and stored in the MessageConfiguration, but is also registered as a singleton in the ServiceCollection.

Consumers can retrieve the PollingControlToken via DI and can then call the Start()/Stop() methods against it when they need to control the message receipt.

Testing:

- Unit tests added.
- Integration tests added but I have not been able to run these locally.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
