### PR TITLE
Update error message for when subscribermapping is null

### DIFF
--- a/.autover/changes/01370ae5-3537-4723-80b3-ee82e79e80b9.json
+++ b/.autover/changes/01370ae5-3537-4723-80b3-ee82e79e80b9.json
@@ -4,7 +4,7 @@
       "Name": "AWS.Messaging",
       "Type": "Patch",
       "ChangelogMessages": [
-        "Update error message for handling scenario where subscribermapping does not exist."
+        "Update error message for handling scenario where subscriber mapping is not valid."
       ]
     }
   ]

--- a/.autover/changes/01370ae5-3537-4723-80b3-ee82e79e80b9.json
+++ b/.autover/changes/01370ae5-3537-4723-80b3-ee82e79e80b9.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Messaging",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update error message for handling scenario where subscribermapping does not exist."
+      ]
+    }
+  ]
+}

--- a/src/AWS.Messaging/Serialization/EnvelopeSerializer.cs
+++ b/src/AWS.Messaging/Serialization/EnvelopeSerializer.cs
@@ -145,13 +145,12 @@ internal class EnvelopeSerializer : IEnvelopeSerializer
             if (subscriberMapping is null)
             {
                 var availableMappings = string.Join(", ", _messageConfiguration.SubscriberMappings.Select(m => m.MessageTypeIdentifier));
-                _logger.LogError("'{MessageTypeIdentifier}' is not a valid subscriber mapping for message ID '{MessageId}'. Available mappings: {AvailableMappings}",
+                _logger.LogError("'{MessageTypeIdentifier}' is not a valid subscriber mapping. Available mappings: {AvailableMappings}",
                     messageTypeIdentifier,
-                    intermediateEnvelope.Id,
                     string.IsNullOrEmpty(availableMappings) ? "none" : availableMappings);
 
                 throw new InvalidDataException(
-                    $"'{messageTypeIdentifier}' is not a valid subscriber mapping for message ID {intermediateEnvelope.Id}. " +
+                    $"'{messageTypeIdentifier}' is not a valid subscriber mapping. " +
                     $"Available mappings: {(string.IsNullOrEmpty(availableMappings) ? "none" : availableMappings)}");
             }
 

--- a/src/AWS.Messaging/Serialization/EnvelopeSerializer.cs
+++ b/src/AWS.Messaging/Serialization/EnvelopeSerializer.cs
@@ -144,8 +144,15 @@ internal class EnvelopeSerializer : IEnvelopeSerializer
             var subscriberMapping = _messageConfiguration.GetSubscriberMapping(messageTypeIdentifier);
             if (subscriberMapping is null)
             {
-                _logger.LogError("{MessageConfiguration} does not have a valid subscriber mapping for message ID '{MessageTypeIdentifier}'", nameof(_messageConfiguration), messageTypeIdentifier);
-                throw new InvalidDataException($"{nameof(_messageConfiguration)} does not have a valid subscriber mapping for {nameof(messageTypeIdentifier)} '{messageTypeIdentifier}'");
+                var availableMappings = string.Join(", ", _messageConfiguration.SubscriberMappings.Select(m => m.MessageTypeIdentifier));
+                _logger.LogError("'{MessageTypeIdentifier}' is not a valid subscriber mapping for message ID '{MessageId}'. Available mappings: {AvailableMappings}",
+                    messageTypeIdentifier,
+                    intermediateEnvelope.Id,
+                    string.IsNullOrEmpty(availableMappings) ? "none" : availableMappings);
+
+                throw new InvalidDataException(
+                    $"'{messageTypeIdentifier}' is not a valid subscriber mapping for message ID {intermediateEnvelope.Id}. " +
+                    $"Available mappings: {(string.IsNullOrEmpty(availableMappings) ? "none" : availableMappings)}");
             }
 
             var messageType = subscriberMapping.MessageType;

--- a/test/AWS.Messaging.IntegrationTests/FifoSubscriberTests.cs
+++ b/test/AWS.Messaging.IntegrationTests/FifoSubscriberTests.cs
@@ -162,7 +162,7 @@ public class FifoSubscriberTests : IAsyncLifetime
         var timeElapsed = DateTime.UtcNow - processStartTime;
 
         var inMemoryLogger = serviceProvider.GetRequiredService<InMemoryLogger>();
-        var errorMessages = inMemoryLogger.Logs.Where(x => x.Message.Equals("_messageConfiguration does not have a valid subscriber mapping for message ID 'AWS.Messaging.Tests.Common.Models.TransactionInfo'"));
+        var errorMessages = inMemoryLogger.Logs.Where(x => x.Message.StartsWith("'") && x.Message.Contains("is not a valid subscriber mapping"));
         Assert.NotEmpty(errorMessages);
         Assert.True(errorMessages.Count() >= numberOfMessages);
         Assert.True(timeElapsed.TotalSeconds > 29);

--- a/test/AWS.Messaging.IntegrationTests/SubscriberTests.cs
+++ b/test/AWS.Messaging.IntegrationTests/SubscriberTests.cs
@@ -316,7 +316,7 @@ public class SubscriberTests : IAsyncLifetime
         var timeElapsed = DateTime.UtcNow - processStartTime;
 
         var inMemoryLogger = serviceProvider.GetRequiredService<InMemoryLogger>();
-        var errorMessages = inMemoryLogger.Logs.Where(x => x.Message.Equals("_messageConfiguration does not have a valid subscriber mapping for message ID 'AWS.Messaging.IntegrationTests.Models.ChatMessage'"));
+        var errorMessages = inMemoryLogger.Logs.Where(x => x.Message.StartsWith("'") && x.Message.Contains("is not a valid subscriber mapping"));
         Assert.NotEmpty(errorMessages);
         Assert.True(errorMessages.Count() >= numberOfMessages);
         Assert.True(timeElapsed.TotalSeconds > 59);

--- a/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
@@ -604,7 +604,7 @@ public class EnvelopeSerializerTests
         // Verify the inner exception type and message
         Assert.IsType<InvalidDataException>(exception.InnerException);
         var innerException = exception.InnerException as InvalidDataException;
-        Assert.Contains("'unknownMessageType' is not a valid subscriber mapping.sr", innerException.Message);
+        Assert.Contains("'unknownMessageType' is not a valid subscriber mapping.", innerException.Message);
         Assert.Contains("Available mappings:", innerException.Message);
         Assert.Contains("addressInfo", innerException.Message);
     }

--- a/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
@@ -604,7 +604,7 @@ public class EnvelopeSerializerTests
         // Verify the inner exception type and message
         Assert.IsType<InvalidDataException>(exception.InnerException);
         var innerException = exception.InnerException as InvalidDataException;
-        Assert.Contains("'unknownMessageType' is not a valid subscriber mapping for message ID", innerException.Message);
+        Assert.Contains("'unknownMessageType' is not a valid subscriber mapping.sr", innerException.Message);
         Assert.Contains("Available mappings:", innerException.Message);
         Assert.Contains("addressInfo", innerException.Message);
     }

--- a/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -564,6 +565,50 @@ public class EnvelopeSerializerTests
             Assert.Null(exception.InnerException);
         }
     }
+
+    [Fact]
+    public async Task ConvertToEnvelope_NullSubscriberMapping_ThrowsException()
+    {
+        // ARRANGE
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+        var envelopeSerializer = serviceProvider.GetRequiredService<IEnvelopeSerializer>();
+        var messageEnvelope = new MessageEnvelope<AddressInfo>
+        {
+            Id = "66659d05-e4ff-462f-81c4-09e560e66a5c",
+            Source = new Uri("/aws/messaging", UriKind.Relative),
+            Version = "1.0",
+            MessageTypeIdentifier = "unknownMessageType", // Using an unknown message type
+            TimeStamp = _testdate,
+            Message = new AddressInfo
+            {
+                Street = "Prince St",
+                Unit = 123,
+                ZipCode = "00001"
+            }
+        };
+
+        var sqsMessage = new Message
+        {
+            Body = await envelopeSerializer.SerializeAsync(messageEnvelope),
+            ReceiptHandle = "receipt-handle"
+        };
+
+        // ACT & ASSERT
+        var exception = await Assert.ThrowsAsync<FailedToCreateMessageEnvelopeException>(
+            async () => await envelopeSerializer.ConvertToEnvelopeAsync(sqsMessage)
+        );
+
+        // Verify the exception message
+        Assert.Equal("Failed to create MessageEnvelope", exception.Message);
+
+        // Verify the inner exception type and message
+        Assert.IsType<InvalidDataException>(exception.InnerException);
+        var innerException = exception.InnerException as InvalidDataException;
+        Assert.Contains("'unknownMessageType' is not a valid subscriber mapping for message ID", innerException.Message);
+        Assert.Contains("Available mappings:", innerException.Message);
+        Assert.Contains("addressInfo", innerException.Message);
+    }
+
 }
 
 public class MockSerializationCallback : ISerializationCallback


### PR DESCRIPTION
*Issue #, if available:* DOTNET-7438

*Description of changes:*
1. Update error message when subscriber mapping is null.
2. I was trying to reproduce the other bugs mentioned in above ticket, but was not able to, so I am just updating the error message for now

Example error message

```
{
  "errorType": "FailedToCreateMessageEnvelopeException",
  "errorMessage": "Failed to create MessageEnvelope",
  "stackTrace": [
    "at AWS.Messaging.Serialization.EnvelopeSerializer.ConvertToEnvelopeAsync(Message sqsMessage) in C:\\dev\\repos\\aws-dotnet-messaging\\src\\AWS.Messaging\\Serialization\\EnvelopeSerializer.cs:line 192",
    "at AWS.Messaging.Lambda.Services.DefaultLambdaMessageProcessor.ProcessMessagesAsync(CancellationToken token) in C:\\dev\\repos\\aws-dotnet-messaging\\src\\AWS.Messaging.Lambda\\Services\\DefaultLambdaMessageProcessor.cs:line 92",
    "at AWS.Messaging.Lambda.DefaultLambdaMessaging.ProcessLambdaEventWithBatchResponseAsync(SQSEvent sqsEvent, ILambdaContext context) in C:\\dev\\repos\\aws-dotnet-messaging\\src\\AWS.Messaging.Lambda\\DefaultLambdaMessaging.cs:line 96",
    "at MessagingTestProject.Functions.Handler(SQSEvent evnt, ILambdaContext context) in C:\\dev\\repos\\aws-dotnet-messaging\\MessagingTestProject\\src\\MessagingTestProject\\Functions.cs:line 63",
    "at MessagingTestProject.Functions_Handler_Generated.Handler(SQSEvent __evnt__, ILambdaContext __context__) in C:\\dev\\repos\\aws-dotnet-messaging\\MessagingTestProject\\src\\MessagingTestProject\\obj\\Debug\\net8.0\\Amazon.Lambda.Annotations.SourceGenerator\\Amazon.Lambda.Annotations.SourceGenerator.Generator\\Functions_Handler_Generated.g.cs:line 60",
    "at Amazon.Lambda.RuntimeSupport.HandlerWrapper.<>c__DisplayClass26_0`2.<<GetHandlerWrapper>b__0>d.MoveNext()",
    "--- End of stack trace from previous location ---",
    "at Amazon.Lambda.RuntimeSupport.LambdaBootstrap.InvokeOnceAsync(CancellationToken cancellationToken)"
  ],
  "cause":   {
    "errorType": "InvalidDataException",
    "errorMessage": "'MessagingTestProject.GreetingMessage' is not a valid subscriber mapping. Available mappings: greetingMessage",
    "stackTrace": [
      "at AWS.Messaging.Serialization.EnvelopeSerializer.ConvertToEnvelopeAsync(Message sqsMessage) in C:\\dev\\repos\\aws-dotnet-messaging\\src\\AWS.Messaging\\Serialization\\EnvelopeSerializer.cs:line 152"
    ]
  }
}

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
