### PR TITLE
Refactor code for EnvelopeSerializer. Remove JSONSerialize.Deserialize logic for whole message

### DIFF
--- a/.autover/changes/3347e2c9-b0f5-4145-a8b4-b32b1e6fd511.json
+++ b/.autover/changes/3347e2c9-b0f5-4145-a8b4-b32b1e6fd511.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Messaging",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Refactor EnvelopeSerializerCode."
+      ]
+    }
+  ]
+}

--- a/.autover/changes/3347e2c9-b0f5-4145-a8b4-b32b1e6fd511.json
+++ b/.autover/changes/3347e2c9-b0f5-4145-a8b4-b32b1e6fd511.json
@@ -4,7 +4,7 @@
       "Name": "AWS.Messaging",
       "Type": "Patch",
       "ChangelogMessages": [
-        "Refactor EnvelopeSerializerCode."
+        "Refactor logic for serialization."
       ]
     }
   ]

--- a/src/AWS.Messaging/EventBridgeMetadata.cs
+++ b/src/AWS.Messaging/EventBridgeMetadata.cs
@@ -1,11 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace AWS.Messaging
 {

--- a/src/AWS.Messaging/Serialization/EnvelopeSerializer.cs
+++ b/src/AWS.Messaging/Serialization/EnvelopeSerializer.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Amazon.SQS.Model;
 using AWS.Messaging.Configuration;
+using AWS.Messaging.Serialization.Helpers;
 using AWS.Messaging.Services;
 using Microsoft.Extensions.Logging;
 using AWS.Messaging.Serialization.Parsers;

--- a/src/AWS.Messaging/Serialization/Handlers/MessageMetadataHandler.cs
+++ b/src/AWS.Messaging/Serialization/Handlers/MessageMetadataHandler.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using Amazon.SQS.Model;
+using AWS.Messaging.Serialization.Helpers;
 using MessageAttributeValue = Amazon.SimpleNotificationService.Model.MessageAttributeValue;
 
 namespace AWS.Messaging.Serialization.Handlers;

--- a/src/AWS.Messaging/Serialization/Handlers/MessageMetadataHandler.cs
+++ b/src/AWS.Messaging/Serialization/Handlers/MessageMetadataHandler.cs
@@ -55,8 +55,12 @@ internal static class MessageMetadataHandler
             TopicArn = root.GetProperty("TopicArn").GetString(),
             Timestamp = root.GetProperty("Timestamp").GetDateTimeOffset(),
             UnsubscribeURL = root.GetProperty("UnsubscribeURL").GetString(),
-            Subject = root.GetProperty("Subject").GetString()
         };
+
+        if (root.TryGetProperty("Subject", out var subject))
+        {
+            metadata.Subject = subject.GetString();
+        }
 
         if (root.TryGetProperty("MessageAttributes", out var messageAttributes))
         {

--- a/src/AWS.Messaging/Serialization/Handlers/MessageMetadataHandler.cs
+++ b/src/AWS.Messaging/Serialization/Handlers/MessageMetadataHandler.cs
@@ -28,8 +28,8 @@ internal static class MessageMetadataHandler
 
         if (message.Attributes != null)
         {
-            metadata.MessageGroupId = GetAttributeValue(message.Attributes, "MessageGroupId");
-            metadata.MessageDeduplicationId = GetAttributeValue(message.Attributes, "MessageDeduplicationId");
+            metadata.MessageGroupId = JsonPropertyHelper.GetAttributeValue(message.Attributes, "MessageGroupId");
+            metadata.MessageDeduplicationId = JsonPropertyHelper.GetAttributeValue(message.Attributes, "MessageDeduplicationId");
         }
 
         return metadata;
@@ -44,11 +44,11 @@ internal static class MessageMetadataHandler
     {
         var metadata = new SNSMetadata
         {
-            MessageId = GetStringProperty(root, "MessageId"),
-            TopicArn = GetStringProperty(root, "TopicArn"),
-            Timestamp = GetDateTimeOffsetProperty(root, "Timestamp") ?? default,
-            UnsubscribeURL = GetStringProperty(root, "UnsubscribeURL"),
-            Subject = GetStringProperty(root, "Subject")
+            MessageId = JsonPropertyHelper.GetStringProperty(root, "MessageId"),
+            TopicArn = JsonPropertyHelper.GetStringProperty(root, "TopicArn"),
+            Timestamp = JsonPropertyHelper.GetDateTimeOffsetProperty(root, "Timestamp") ?? default,
+            UnsubscribeURL = JsonPropertyHelper.GetStringProperty(root, "UnsubscribeURL"),
+            Subject = JsonPropertyHelper.GetStringProperty(root, "Subject")
         };
 
         if (root.TryGetProperty("MessageAttributes", out var messageAttributes))
@@ -68,12 +68,12 @@ internal static class MessageMetadataHandler
     {
         var metadata = new EventBridgeMetadata
         {
-            EventId = GetStringProperty(root, "id"),
-            DetailType = GetStringProperty(root, "detail-type"),
-            Source = GetStringProperty(root, "source"),
-            AWSAccount = GetStringProperty(root, "account"),
-            Time = GetDateTimeOffsetProperty(root, "time") ?? default,
-            AWSRegion = GetStringProperty(root, "region"),
+            EventId = JsonPropertyHelper.GetStringProperty(root, "id"),
+            DetailType = JsonPropertyHelper.GetStringProperty(root, "detail-type"),
+            Source = JsonPropertyHelper.GetStringProperty(root, "source"),
+            AWSAccount = JsonPropertyHelper.GetStringProperty(root, "account"),
+            Time = JsonPropertyHelper.GetDateTimeOffsetProperty(root, "time") ?? default,
+            AWSRegion = JsonPropertyHelper.GetStringProperty(root, "region"),
         };
 
         if (root.TryGetProperty("resources", out var resources))
@@ -85,21 +85,5 @@ internal static class MessageMetadataHandler
         }
 
         return metadata;
-    }
-
-    private static T? GetPropertyValue<T>(JsonElement root, string propertyName, Func<JsonElement, T> getValue)
-    {
-        return root.TryGetProperty(propertyName, out var property) ? getValue(property) : default;
-    }
-
-    private static string? GetStringProperty(JsonElement root, string propertyName)
-        => GetPropertyValue(root, propertyName, element => element.GetString());
-
-    private static DateTimeOffset? GetDateTimeOffsetProperty(JsonElement root, string propertyName)
-        => GetPropertyValue(root, propertyName, element => element.GetDateTimeOffset());
-
-    private static string? GetAttributeValue(Dictionary<string, string> attributes, string key)
-    {
-        return attributes.TryGetValue(key, out var value) ? value : null;
     }
 }

--- a/src/AWS.Messaging/Serialization/Handlers/MessageMetadataHandler.cs
+++ b/src/AWS.Messaging/Serialization/Handlers/MessageMetadataHandler.cs
@@ -1,0 +1,90 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Text.Json;
+using Amazon.SQS.Model;
+using MessageAttributeValue = Amazon.SimpleNotificationService.Model.MessageAttributeValue;
+
+namespace AWS.Messaging.Serialization.Handlers;
+
+/// <summary>
+/// Handles the creation of metadata objects from various AWS messaging services.
+/// </summary>
+internal static class MessageMetadataHandler
+{
+    /// <summary>
+    /// Creates SQS metadata from an SQS message.
+    /// </summary>
+    /// <param name="message">The SQS message containing metadata information.</param>
+    /// <returns>An SQSMetadata object containing the extracted metadata.</returns>
+    public static SQSMetadata CreateSQSMetadata(Message message)
+    {
+        var metadata = new SQSMetadata
+        {
+            MessageID = message.MessageId,
+            ReceiptHandle = message.ReceiptHandle,
+            MessageAttributes = message.MessageAttributes,
+        };
+
+        // Get FIFO queue attributes from message.Attributes
+        if (message.Attributes != null)
+        {
+            if (message.Attributes.TryGetValue("MessageGroupId", out var groupId))
+            {
+                metadata.MessageGroupId = groupId;
+            }
+            if (message.Attributes.TryGetValue("MessageDeduplicationId", out var deduplicationId))
+            {
+                metadata.MessageDeduplicationId = deduplicationId;
+            }
+        }
+
+        return metadata;
+    }
+
+    /// <summary>
+    /// Creates SNS metadata from a JSON element representing an SNS message.
+    /// </summary>
+    /// <param name="root">The root JSON element containing SNS metadata information.</param>
+    /// <returns>An SNSMetadata object containing the extracted metadata.</returns>
+    public static SNSMetadata CreateSNSMetadata(JsonElement root)
+    {
+        var metadata = new SNSMetadata
+        {
+            MessageId = root.GetProperty("MessageId").GetString(),
+            TopicArn = root.GetProperty("TopicArn").GetString(),
+            Timestamp = root.GetProperty("Timestamp").GetDateTimeOffset(),
+            UnsubscribeURL = root.GetProperty("UnsubscribeURL").GetString(),
+            Subject = root.GetProperty("Subject").GetString()
+        };
+
+        if (root.TryGetProperty("MessageAttributes", out var messageAttributes))
+        {
+            metadata.MessageAttributes = JsonSerializer.Deserialize<Dictionary<string, MessageAttributeValue>>(messageAttributes);
+        }
+
+        return metadata;
+    }
+
+    /// <summary>
+    /// Creates EventBridge metadata from a JSON element representing an EventBridge event.
+    /// </summary>
+    /// <param name="root">The root JSON element containing EventBridge metadata information.</param>
+    /// <returns>An EventBridgeMetadata object containing the extracted metadata.</returns>
+    public static EventBridgeMetadata CreateEventBridgeMetadata(JsonElement root)
+    {
+        return new EventBridgeMetadata
+        {
+            EventId = root.GetProperty("id").GetString(),
+            DetailType = root.GetProperty("detail-type").GetString(),
+            Source = root.GetProperty("source").GetString(),
+            AWSAccount = root.GetProperty("account").GetString(),
+            Time = root.GetProperty("time").GetDateTimeOffset(),
+            AWSRegion = root.GetProperty("region").GetString(),
+            Resources = root.GetProperty("resources").EnumerateArray()
+                .Select(x => x.GetString())
+                .Where(x => x != null)
+                .ToList()!
+        };
+    }
+}

--- a/src/AWS.Messaging/Serialization/Helpers/JsonPropertyHelper.cs
+++ b/src/AWS.Messaging/Serialization/Helpers/JsonPropertyHelper.cs
@@ -3,7 +3,7 @@
 
 using System.Text.Json;
 
-namespace AWS.Messaging.Serialization;
+namespace AWS.Messaging.Serialization.Helpers;
 
 /// <summary>
 /// Provides helper methods for safely extracting values from JsonElement and Dictionary objects.
@@ -20,6 +20,12 @@ internal static class JsonPropertyHelper
     /// <returns>The converted value or default if the property doesn't exist.</returns>
     public static T? GetPropertyValue<T>(JsonElement root, string propertyName, Func<JsonElement, T> getValue)
     {
+        if (getValue == null)
+        {
+            throw new ArgumentNullException(nameof(getValue));
+        }
+
+
         return root.TryGetProperty(propertyName, out var property) ? getValue(property) : default;
     }
 

--- a/src/AWS.Messaging/Serialization/JsonPropertyHelper.cs
+++ b/src/AWS.Messaging/Serialization/JsonPropertyHelper.cs
@@ -1,0 +1,88 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Text.Json;
+
+namespace AWS.Messaging.Serialization;
+
+/// <summary>
+/// Provides helper methods for safely extracting values from JsonElement and Dictionary objects.
+/// </summary>
+internal static class JsonPropertyHelper
+{
+    /// <summary>
+    /// Safely extracts a value from a JsonElement using the provided conversion function.
+    /// </summary>
+    /// <typeparam name="T">The type to convert the property value to.</typeparam>
+    /// <param name="root">The root JsonElement containing the property.</param>
+    /// <param name="propertyName">The name of the property to extract.</param>
+    /// <param name="getValue">The function to convert the property value to type T.</param>
+    /// <returns>The converted value or default if the property doesn't exist.</returns>
+    public static T? GetPropertyValue<T>(JsonElement root, string propertyName, Func<JsonElement, T> getValue)
+    {
+        return root.TryGetProperty(propertyName, out var property) ? getValue(property) : default;
+    }
+
+    /// <summary>
+    /// Extracts a required value from a JsonElement using the provided conversion function.
+    /// </summary>
+    /// <typeparam name="T">The type to convert the property value to.</typeparam>
+    /// <param name="root">The root JsonElement containing the property.</param>
+    /// <param name="propertyName">The name of the property to extract.</param>
+    /// <param name="getValue">The function to convert the property value to type T.</param>
+    /// <returns>The converted value.</returns>
+    /// <exception cref="InvalidDataException">Thrown when the property is missing or conversion fails.</exception>
+    public static T GetRequiredProperty<T>(JsonElement root, string propertyName, Func<JsonElement, T> getValue)
+    {
+        if (root.TryGetProperty(propertyName, out var property))
+        {
+            try
+            {
+                return getValue(property);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidDataException($"Failed to get or convert property '{propertyName}'", ex);
+            }
+        }
+        throw new InvalidDataException($"Required property '{propertyName}' is missing");
+    }
+
+    /// <summary>
+    /// Safely extracts a string value from a JsonElement.
+    /// </summary>
+    /// <param name="root">The root JsonElement containing the property.</param>
+    /// <param name="propertyName">The name of the property to extract.</param>
+    /// <returns>The string value or null if the property doesn't exist.</returns>
+    public static string? GetStringProperty(JsonElement root, string propertyName)
+        => GetPropertyValue(root, propertyName, element => element.GetString());
+
+    /// <summary>
+    /// Safely extracts a DateTimeOffset value from a JsonElement.
+    /// </summary>
+    /// <param name="root">The root JsonElement containing the property.</param>
+    /// <param name="propertyName">The name of the property to extract.</param>
+    /// <returns>The DateTimeOffset value or null if the property doesn't exist.</returns>
+    public static DateTimeOffset? GetDateTimeOffsetProperty(JsonElement root, string propertyName)
+        => GetPropertyValue(root, propertyName, element => element.GetDateTimeOffset());
+
+    /// <summary>
+    /// Safely extracts a Uri value from a JsonElement.
+    /// </summary>
+    /// <param name="root">The root JsonElement containing the property.</param>
+    /// <param name="propertyName">The name of the property to extract.</param>
+    /// <returns>The Uri value or null if the property doesn't exist.</returns>
+    public static Uri? GetUriProperty(JsonElement root, string propertyName)
+        => GetPropertyValue(root, propertyName, element => new Uri(element.GetString()!, UriKind.RelativeOrAbsolute));
+
+    /// <summary>
+    /// Safely extracts a value from a dictionary.
+    /// </summary>
+    /// <param name="attributes">The dictionary containing the value.</param>
+    /// <param name="key">The key of the value to extract.</param>
+    /// <returns>The value or null if the key doesn't exist.</returns>
+    public static string? GetAttributeValue(Dictionary<string, string> attributes, string key)
+    {
+        return attributes.TryGetValue(key, out var value) ? value : null;
+    }
+}

--- a/src/AWS.Messaging/Serialization/MessageMetadata.cs
+++ b/src/AWS.Messaging/Serialization/MessageMetadata.cs
@@ -1,0 +1,45 @@
+namespace AWS.Messaging.Serialization;
+
+/// <summary>
+/// Represents metadata associated with a message, including SQS, SNS, and EventBridge specific information.
+/// </summary>
+internal class MessageMetadata
+{
+    /// <summary>
+    /// Gets or sets the SQS-specific metadata.
+    /// </summary>
+    public SQSMetadata? SQSMetadata { get; set; }
+
+    /// <summary>
+    /// Gets or sets the SNS-specific metadata.
+    /// </summary>
+    public SNSMetadata? SNSMetadata { get; set; }
+
+    /// <summary>
+    /// Gets or sets the EventBridge-specific metadata.
+    /// </summary>
+    public EventBridgeMetadata? EventBridgeMetadata { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the MessageMetadata class.
+    /// </summary>
+    public MessageMetadata()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the MessageMetadata class with specified metadata.
+    /// </summary>
+    /// <param name="sqsMetadata">The SQS metadata.</param>
+    /// <param name="snsMetadata">The SNS metadata.</param>
+    /// <param name="eventBridgeMetadata">The EventBridge metadata.</param>
+    public MessageMetadata(
+        SQSMetadata? sqsMetadata = null,
+        SNSMetadata? snsMetadata = null,
+        EventBridgeMetadata? eventBridgeMetadata = null)
+    {
+        SQSMetadata = sqsMetadata;
+        SNSMetadata = snsMetadata;
+        EventBridgeMetadata = eventBridgeMetadata;
+    }
+}

--- a/src/AWS.Messaging/Serialization/Parsers/EventBridgeMessageParser.cs
+++ b/src/AWS.Messaging/Serialization/Parsers/EventBridgeMessageParser.cs
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Text.Json;
+using Amazon.SQS.Model;
+using AWS.Messaging.Serialization.Handlers;
+
+namespace AWS.Messaging.Serialization.Parsers
+{
+    /// <summary>
+    /// Parser for messages originating from Amazon EventBridge.
+    /// </summary>
+    internal class EventBridgeMessageParser : IMessageParser
+    {
+        /// <summary>
+        /// Determines if the JSON element represents an EventBridge message by checking for required properties.
+        /// </summary>
+        /// <param name="root">The root JSON element to examine.</param>
+        /// <returns>True if the message can be parsed as an EventBridge message; otherwise, false.</returns>
+        public bool CanParse(JsonElement root)
+        {
+            return root.TryGetProperty("detail", out _) &&
+                   root.TryGetProperty("detail-type", out _) &&
+                   root.TryGetProperty("source", out _) &&
+                   root.TryGetProperty("time", out _);
+        }
+
+        /// <summary>
+        /// Parses an EventBridge message, extracting the message body and metadata.
+        /// </summary>
+        /// <param name="root">The root JSON element containing the EventBridge message.</param>
+        /// <param name="originalMessage">The original SQS message.</param>
+        /// <returns>A tuple containing the message body and associated metadata.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the EventBridge message does not contain a valid detail property.</exception>
+        public (string MessageBody, MessageMetadata Metadata) Parse(JsonElement root, Message originalMessage)
+        {
+            // The detail property can be either a string or an object
+            var detailElement = root.GetProperty("detail");
+            var messageBody = detailElement.ValueKind == JsonValueKind.String
+                ? detailElement.GetString()
+                : detailElement.GetRawText();
+
+            if (string.IsNullOrEmpty(messageBody))
+            {
+                throw new InvalidOperationException("EventBridge message does not contain a valid detail property");
+            }
+
+            var metadata = new MessageMetadata
+            {
+                EventBridgeMetadata = MessageMetadataHandler.CreateEventBridgeMetadata(root)
+            };
+
+            return (messageBody, metadata);
+        }
+    }
+}

--- a/src/AWS.Messaging/Serialization/Parsers/EventBridgeMessageParser.cs
+++ b/src/AWS.Messaging/Serialization/Parsers/EventBridgeMessageParser.cs
@@ -36,6 +36,13 @@ namespace AWS.Messaging.Serialization.Parsers
         {
             // The detail property can be either a string or an object
             var detailElement = root.GetProperty("detail");
+
+            // Add explicit check for null detail
+            if (detailElement.ValueKind == JsonValueKind.Null)
+            {
+                throw new InvalidOperationException("EventBridge message does not contain a valid detail property");
+            }
+
             var messageBody = detailElement.ValueKind == JsonValueKind.String
                 ? detailElement.GetString()
                 : detailElement.GetRawText();

--- a/src/AWS.Messaging/Serialization/Parsers/IMessageParser.cs
+++ b/src/AWS.Messaging/Serialization/Parsers/IMessageParser.cs
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Text.Json;
+using Amazon.SQS.Model;
+using AWS.Messaging.Serialization;
+
+namespace AWS.Messaging.Serialization.Parsers;
+
+/// <summary>
+/// Defines the contract for message parsers capable of handling different message formats.
+/// </summary>
+internal interface IMessageParser
+{
+    /// <summary>
+    /// Determines if the parser can handle the given JSON element.
+    /// </summary>
+    /// <param name="root">The root JSON element to examine.</param>
+    /// <returns>True if the parser can handle the message; otherwise, false.</returns>
+    bool CanParse(JsonElement root);
+
+    /// <summary>
+    /// Parses the message, extracting the message body and associated metadata.
+    /// </summary>
+    /// <param name="root">The root JSON element containing the message to parse.</param>
+    /// <param name="originalMessage">The original SQS message.</param>
+    /// <returns>A tuple containing the extracted message body and associated metadata.</returns>
+    (string MessageBody, MessageMetadata Metadata) Parse(JsonElement root, Message originalMessage);
+}

--- a/src/AWS.Messaging/Serialization/Parsers/SNSMessageParser.cs
+++ b/src/AWS.Messaging/Serialization/Parsers/SNSMessageParser.cs
@@ -1,0 +1,49 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Text.Json;
+using Amazon.SQS.Model;
+using AWS.Messaging.Serialization.Handlers;
+
+namespace AWS.Messaging.Serialization.Parsers
+{
+    /// <summary>
+    /// Parser for messages originating from Amazon Simple Notification Service (SNS).
+    /// </summary>
+    internal class SNSMessageParser : IMessageParser
+    {
+        /// <summary>
+        /// Determines if the JSON element represents an SNS message by checking for required properties.
+        /// </summary>
+        /// <param name="root">The root JSON element to examine.</param>
+        /// <returns>True if the message can be parsed as an SNS message; otherwise, false.</returns>
+        public bool CanParse(JsonElement root)
+        {
+            return root.TryGetProperty("Type", out var type) &&
+                   type.GetString() == "Notification" &&
+                   root.TryGetProperty("MessageId", out _) &&
+                   root.TryGetProperty("TopicArn", out _);
+        }
+
+        /// <summary>
+        /// Parses an SNS message, extracting the inner message body and metadata.
+        /// </summary>
+        /// <param name="root">The root JSON element containing the SNS message.</param>
+        /// <param name="originalMessage">The original SQS message.</param>
+        /// <returns>A tuple containing the extracted message body and associated metadata.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the SNS message does not contain a valid Message property.</exception>
+        public (string MessageBody, MessageMetadata Metadata) Parse(JsonElement root, Message originalMessage)
+        {
+            // Extract the inner message from the SNS wrapper
+            var messageBody = root.GetProperty("Message").GetString()
+                ?? throw new InvalidOperationException("SNS message does not contain a valid Message property");
+
+            var metadata = new MessageMetadata
+            {
+                SNSMetadata = MessageMetadataHandler.CreateSNSMetadata(root)
+            };
+
+            return (messageBody, metadata);
+        }
+    }
+}

--- a/src/AWS.Messaging/Serialization/Parsers/SQSMessageParser.cs
+++ b/src/AWS.Messaging/Serialization/Parsers/SQSMessageParser.cs
@@ -1,0 +1,39 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Text.Json;
+using Amazon.SQS.Model;
+using AWS.Messaging.Serialization.Handlers;
+
+namespace AWS.Messaging.Serialization.Parsers;
+
+/// <summary>
+/// Default fallback parser for Amazon Simple Queue Service (SQS) messages.
+/// This parser handles messages that don't match other specialized parsers.
+/// </summary>
+internal class SQSMessageParser : IMessageParser
+{
+    /// <summary>
+    /// Always returns true as this is the default fallback parser for any message format.
+    /// </summary>
+    /// <param name="_">The root JSON element (unused in this implementation).</param>
+    /// <returns>Always returns true, indicating this parser can handle any remaining message format.</returns>
+    public bool CanParse(JsonElement _) => true; // Default fallback parser
+
+    /// <summary>
+    /// Parses an SQS message, preserving the original message body and adding SQS metadata.
+    /// </summary>
+    /// <param name="root">The root JSON element containing the message content.</param>
+    /// <param name="originalMessage">The original SQS message containing metadata information.</param>
+    /// <returns>A tuple containing the unchanged message body and associated SQS metadata.</returns>
+    public (string MessageBody, MessageMetadata Metadata) Parse(JsonElement root, Message originalMessage)
+    {
+        var metadata = new MessageMetadata
+        {
+            SQSMetadata = MessageMetadataHandler.CreateSQSMetadata(originalMessage)
+        };
+
+        // Return the raw message without modification since this is the base parser
+        return (root.GetRawText(), metadata);
+    }
+}

--- a/test/AWS.Messaging.UnitTests/SerializationTests/Handlers/MessageDataHandlerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SerializationTests/Handlers/MessageDataHandlerTests.cs
@@ -1,0 +1,188 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Amazon.SQS.Model;
+using AWS.Messaging.Serialization.Handlers;
+using Xunit;
+
+namespace AWS.Messaging.UnitTests.SerializationTests.Handlers;
+
+public class MessageMetadataHandlerTests
+{
+    [Fact]
+    public void CreateSQSMetadata_WithBasicMessage_ReturnsCorrectMetadata()
+    {
+        // Arrange
+        var message = new Message
+        {
+            MessageId = "test-message-id",
+            ReceiptHandle = "test-receipt-handle",
+            MessageAttributes = new Dictionary<string, MessageAttributeValue>
+            {
+                { "TestAttribute", new MessageAttributeValue { StringValue = "TestValue" } }
+            }
+        };
+
+        // Act
+        var metadata = MessageMetadataHandler.CreateSQSMetadata(message);
+
+        // Assert
+        Assert.Equal("test-message-id", metadata.MessageID);
+        Assert.Equal("test-receipt-handle", metadata.ReceiptHandle);
+        Assert.Single(metadata.MessageAttributes);
+        Assert.Equal("TestValue", metadata.MessageAttributes["TestAttribute"].StringValue);
+    }
+
+    [Fact]
+    public void CreateSQSMetadata_WithFIFOAttributes_ReturnsCorrectMetadata()
+    {
+        // Arrange
+        var message = new Message
+        {
+            MessageId = "test-message-id",
+            Attributes = new Dictionary<string, string>
+            {
+                { "MessageGroupId", "group-1" },
+                { "MessageDeduplicationId", "dedup-1" }
+            }
+        };
+
+        // Act
+        var metadata = MessageMetadataHandler.CreateSQSMetadata(message);
+
+        // Assert
+        Assert.Equal("group-1", metadata.MessageGroupId);
+        Assert.Equal("dedup-1", metadata.MessageDeduplicationId);
+    }
+
+    [Fact]
+    public void CreateSNSMetadata_WithValidJson_ReturnsCorrectMetadata()
+    {
+        // Arrange
+        var json = @"{
+            ""MessageId"": ""test-message-id"",
+            ""TopicArn"": ""arn:aws:sns:region:account:topic"",
+            ""Timestamp"": ""2024-03-15T10:00:00.000Z"",
+            ""UnsubscribeURL"": ""https://sns.region.amazonaws.com/unsubscribe"",
+            ""Subject"": ""Test Subject"",
+            ""MessageAttributes"": {
+                ""TestAttribute"": {
+                    ""Type"": ""String"",
+                    ""Value"": ""TestValue""
+                }
+            }
+        }";
+        var root = JsonDocument.Parse(json).RootElement;
+
+        // Act
+        var metadata = MessageMetadataHandler.CreateSNSMetadata(root);
+
+        // Assert
+        Assert.Equal("test-message-id", metadata.MessageId);
+        Assert.Equal("arn:aws:sns:region:account:topic", metadata.TopicArn);
+        Assert.Equal(DateTimeOffset.Parse("2024-03-15T10:00:00.000Z"), metadata.Timestamp);
+        Assert.Equal("https://sns.region.amazonaws.com/unsubscribe", metadata.UnsubscribeURL);
+        Assert.Equal("Test Subject", metadata.Subject);
+        Assert.NotNull(metadata.MessageAttributes);
+        Assert.Single(metadata.MessageAttributes);
+    }
+
+    [Fact]
+    public void CreateSNSMetadata_WithMissingOptionalFields_ReturnsPartialMetadata()
+    {
+        // Arrange
+        var json = @"{
+            ""MessageId"": ""test-message-id"",
+            ""TopicArn"": ""arn:aws:sns:region:account:topic""
+        }";
+        var root = JsonDocument.Parse(json).RootElement;
+
+        // Act
+        var metadata = MessageMetadataHandler.CreateSNSMetadata(root);
+
+        // Assert
+        Assert.Equal("test-message-id", metadata.MessageId);
+        Assert.Equal("arn:aws:sns:region:account:topic", metadata.TopicArn);
+        Assert.Equal(default, metadata.Timestamp);
+        Assert.Null(metadata.UnsubscribeURL);
+        Assert.Null(metadata.Subject);
+        Assert.Null(metadata.MessageAttributes);
+    }
+
+    [Fact]
+    public void CreateEventBridgeMetadata_WithValidJson_ReturnsCorrectMetadata()
+    {
+        // Arrange
+        var json = @"{
+            ""id"": ""test-event-id"",
+            ""detail-type"": ""test-detail-type"",
+            ""source"": ""test-source"",
+            ""account"": ""123456789012"",
+            ""time"": ""2024-03-15T10:00:00Z"",
+            ""region"": ""us-east-1"",
+            ""resources"": [
+                ""resource1"",
+                ""resource2""
+            ]
+        }";
+        var root = JsonDocument.Parse(json).RootElement;
+
+        // Act
+        var metadata = MessageMetadataHandler.CreateEventBridgeMetadata(root);
+
+        // Assert
+        Assert.Equal("test-event-id", metadata.EventId);
+        Assert.Equal("test-detail-type", metadata.DetailType);
+        Assert.Equal("test-source", metadata.Source);
+        Assert.Equal("123456789012", metadata.AWSAccount);
+        Assert.Equal(DateTimeOffset.Parse("2024-03-15T10:00:00Z"), metadata.Time);
+        Assert.Equal("us-east-1", metadata.AWSRegion);
+        Assert.Equal(2, metadata.Resources.Count);
+        Assert.Contains("resource1", metadata.Resources);
+        Assert.Contains("resource2", metadata.Resources);
+    }
+
+    [Fact]
+    public void CreateEventBridgeMetadata_WithMissingOptionalFields_ReturnsPartialMetadata()
+    {
+        // Arrange
+        var json = @"{
+            ""id"": ""test-event-id"",
+            ""source"": ""test-source""
+        }";
+        var root = JsonDocument.Parse(json).RootElement;
+
+        // Act
+        var metadata = MessageMetadataHandler.CreateEventBridgeMetadata(root);
+
+        // Assert
+        Assert.Equal("test-event-id", metadata.EventId);
+        Assert.Equal("test-source", metadata.Source);
+        Assert.Null(metadata.DetailType);
+        Assert.Null(metadata.AWSAccount);
+        Assert.Equal(default, metadata.Time);
+        Assert.Null(metadata.AWSRegion);
+        Assert.Null(metadata.Resources);
+    }
+
+    [Fact]
+    public void CreateEventBridgeMetadata_WithEmptyResources_ReturnsEmptyResourcesList()
+    {
+        // Arrange
+        var json = @"{
+            ""id"": ""test-event-id"",
+            ""resources"": []
+        }";
+        var root = JsonDocument.Parse(json).RootElement;
+
+        // Act
+        var metadata = MessageMetadataHandler.CreateEventBridgeMetadata(root);
+
+        // Assert
+        Assert.NotNull(metadata.Resources);
+        Assert.Empty(metadata.Resources);
+    }
+}

--- a/test/AWS.Messaging.UnitTests/SerializationTests/Helpers/JsonPropertyHelperTests.cs
+++ b/test/AWS.Messaging.UnitTests/SerializationTests/Helpers/JsonPropertyHelperTests.cs
@@ -1,0 +1,209 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using AWS.Messaging.Serialization.Helpers;
+using Xunit;
+
+namespace AWS.Messaging.UnitTests.SerializationTests.Helpers;
+
+public class JsonPropertyHelperTests
+{
+    [Fact]
+    public void GetPropertyValue_WithExistingProperty_ReturnsValue()
+    {
+        // Arrange
+        var json = @"{""testProperty"": ""testValue""}";
+        var root = JsonDocument.Parse(json).RootElement;
+
+        // Act
+        var result = JsonPropertyHelper.GetPropertyValue(root, "testProperty", element => element.GetString());
+
+        // Assert
+        Assert.Equal("testValue", result);
+    }
+
+    [Fact]
+    public void GetPropertyValue_WithMissingProperty_ReturnsDefault()
+    {
+        // Arrange
+        var json = @"{""otherProperty"": ""value""}";
+        var root = JsonDocument.Parse(json).RootElement;
+
+        // Act
+        var result = JsonPropertyHelper.GetPropertyValue(root, "testProperty", element => element.GetString());
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetRequiredProperty_WithExistingProperty_ReturnsValue()
+    {
+        // Arrange
+        var json = @"{""testProperty"": ""testValue""}";
+        var root = JsonDocument.Parse(json).RootElement;
+
+        // Act
+        var result = JsonPropertyHelper.GetRequiredProperty(root, "testProperty", element => element.GetString());
+
+        // Assert
+        Assert.Equal("testValue", result);
+    }
+
+    [Fact]
+    public void GetRequiredProperty_WithMissingProperty_ThrowsException()
+    {
+        // Arrange
+        var json = @"{""otherProperty"": ""value""}";
+        var root = JsonDocument.Parse(json).RootElement;
+
+        // Act & Assert
+        var exception = Assert.Throws<InvalidDataException>(
+            () => JsonPropertyHelper.GetRequiredProperty(root, "testProperty", element => element.GetString()));
+        Assert.Equal("Required property 'testProperty' is missing", exception.Message);
+    }
+
+    [Fact]
+    public void GetRequiredProperty_WithInvalidConversion_ThrowsException()
+    {
+        // Arrange
+        var json = @"{""testProperty"": ""not-a-number""}";
+        var root = JsonDocument.Parse(json).RootElement;
+
+        // Act & Assert
+        var exception = Assert.Throws<InvalidDataException>(
+            () => JsonPropertyHelper.GetRequiredProperty(root, "testProperty", element => element.GetInt32()));
+        Assert.Equal("Failed to get or convert property 'testProperty'", exception.Message);
+    }
+
+    [Fact]
+    public void GetStringProperty_WithValidString_ReturnsString()
+    {
+        // Arrange
+        var json = @"{""testProperty"": ""testValue""}";
+        var root = JsonDocument.Parse(json).RootElement;
+
+        // Act
+        var result = JsonPropertyHelper.GetStringProperty(root, "testProperty");
+
+        // Assert
+        Assert.Equal("testValue", result);
+    }
+
+    [Fact]
+    public void GetStringProperty_WithMissingProperty_ReturnsNull()
+    {
+        // Arrange
+        var json = @"{""otherProperty"": ""value""}";
+        var root = JsonDocument.Parse(json).RootElement;
+
+        // Act
+        var result = JsonPropertyHelper.GetStringProperty(root, "testProperty");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetDateTimeOffsetProperty_WithValidDate_ReturnsDateTimeOffset()
+    {
+        // Arrange
+        var json = @"{""testDate"": ""2024-03-15T10:00:00Z""}";
+        var root = JsonDocument.Parse(json).RootElement;
+        var expectedDate = DateTimeOffset.Parse("2024-03-15T10:00:00Z");
+
+        // Act
+        var result = JsonPropertyHelper.GetDateTimeOffsetProperty(root, "testDate");
+
+        // Assert
+        Assert.Equal(expectedDate, result);
+    }
+
+    [Fact]
+    public void GetDateTimeOffsetProperty_WithInvalidDate_ReturnsNull()
+    {
+        // Arrange
+        var json = @"{""testDate"": ""invalid-date""}";
+        var root = JsonDocument.Parse(json).RootElement;
+
+        // Act & Assert
+        Assert.Throws<FormatException>(
+            () => JsonPropertyHelper.GetDateTimeOffsetProperty(root, "testDate"));
+    }
+
+    [Fact]
+    public void GetUriProperty_WithValidUri_ReturnsUri()
+    {
+        // Arrange
+        var json = @"{""testUri"": ""https://example.com""}";
+        var root = JsonDocument.Parse(json).RootElement;
+        var expectedUri = new Uri("https://example.com");
+
+        // Act
+        var result = JsonPropertyHelper.GetUriProperty(root, "testUri");
+
+        // Assert
+        Assert.Equal(expectedUri, result);
+    }
+
+    [Fact]
+    public void GetAttributeValue_WithExistingKey_ReturnsValue()
+    {
+        // Arrange
+        var attributes = new Dictionary<string, string>
+        {
+            { "testKey", "testValue" }
+        };
+
+        // Act
+        var result = JsonPropertyHelper.GetAttributeValue(attributes, "testKey");
+
+        // Assert
+        Assert.Equal("testValue", result);
+    }
+
+    [Fact]
+    public void GetAttributeValue_WithMissingKey_ReturnsNull()
+    {
+        // Arrange
+        var attributes = new Dictionary<string, string>
+        {
+            { "otherKey", "value" }
+        };
+
+        // Act
+        var result = JsonPropertyHelper.GetAttributeValue(attributes, "testKey");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetAttributeValue_WithEmptyDictionary_ReturnsNull()
+    {
+        // Arrange
+        var attributes = new Dictionary<string, string>();
+
+        // Act
+        var result = JsonPropertyHelper.GetAttributeValue(attributes, "testKey");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetPropertyValue_WithNullConverter_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var json = @"{""testProperty"": ""testValue""}";
+        var root = JsonDocument.Parse(json).RootElement;
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            JsonPropertyHelper.GetPropertyValue<string>(root, "testProperty", null!));
+    }
+}

--- a/test/AWS.Messaging.UnitTests/SerializationTests/Parsers/EventBridgeMessageParserTests.cs
+++ b/test/AWS.Messaging.UnitTests/SerializationTests/Parsers/EventBridgeMessageParserTests.cs
@@ -1,0 +1,174 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Text.Json;
+using Amazon.SQS.Model;
+using AWS.Messaging.Serialization.Parsers;
+using Xunit;
+
+namespace AWS.Messaging.UnitTests.SerializationTests.Parsers;
+
+public class EventBridgeMessageParserTests
+{
+    private readonly EventBridgeMessageParser _parser;
+
+    public EventBridgeMessageParserTests()
+    {
+        _parser = new EventBridgeMessageParser();
+    }
+
+    [Fact]
+    public void CanParse_WithValidEventBridgeMessage_ReturnsTrue()
+    {
+        // Arrange
+        var json = @"{
+            ""detail"": { ""someData"": ""value"" },
+            ""detail-type"": ""test-type"",
+            ""source"": ""test-source"",
+            ""time"": ""2024-03-15T10:00:00Z""
+        }";
+        var root = JsonDocument.Parse(json).RootElement;
+
+        // Act
+        var result = _parser.CanParse(root);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidEventBridgeMessages))]
+    public void CanParse_WithInvalidEventBridgeMessage_ReturnsFalse(string json)
+    {
+        // Arrange
+        var root = JsonDocument.Parse(json).RootElement;
+
+        // Act
+        var result = _parser.CanParse(root);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Parse_WithObjectDetail_ReturnsRawJson()
+    {
+        // Arrange
+        var json = @"{
+            ""detail"": { ""someData"": ""value"" },
+            ""detail-type"": ""test-type"",
+            ""source"": ""test-source"",
+            ""time"": ""2024-03-15T10:00:00Z"",
+            ""id"": ""test-id"",
+            ""account"": ""123456789012"",
+            ""region"": ""us-east-1"",
+            ""resources"": [""resource1"", ""resource2""]
+        }";
+        var root = JsonDocument.Parse(json).RootElement;
+        var message = new Message();
+
+        // Act
+        var (messageBody, metadata) = _parser.Parse(root, message);
+
+        // Assert
+        Assert.Contains("\"someData\"", messageBody);
+        Assert.Contains("\"value\"", messageBody);
+        Assert.NotNull(metadata.EventBridgeMetadata);
+        Assert.Equal("test-type", metadata.EventBridgeMetadata.DetailType);
+        Assert.Equal("test-source", metadata.EventBridgeMetadata.Source);
+        Assert.Equal("test-id", metadata.EventBridgeMetadata.EventId);
+        Assert.Equal(2, metadata.EventBridgeMetadata.Resources?.Count);
+    }
+
+    [Fact]
+    public void Parse_WithStringDetail_ReturnsString()
+    {
+        // Arrange
+        var json = @"{
+            ""detail"": ""string message"",
+            ""detail-type"": ""test-type"",
+            ""source"": ""test-source"",
+            ""time"": ""2024-03-15T10:00:00Z"",
+            ""id"": ""test-id""
+        }";
+        var root = JsonDocument.Parse(json).RootElement;
+        var message = new Message();
+
+        // Act
+        var (messageBody, metadata) = _parser.Parse(root, message);
+
+        // Assert
+        Assert.Equal("string message", messageBody);
+        Assert.NotNull(metadata.EventBridgeMetadata);
+        Assert.Equal("test-type", metadata.EventBridgeMetadata.DetailType);
+    }
+
+    [Fact]
+    public void Parse_WithEmptyDetail_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var json = @"{
+            ""detail"": """",
+            ""detail-type"": ""test-type"",
+            ""source"": ""test-source"",
+            ""time"": ""2024-03-15T10:00:00Z""
+        }";
+        var root = JsonDocument.Parse(json).RootElement;
+        var message = new Message();
+
+        // Act & Assert
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => _parser.Parse(root, message));
+        Assert.Equal("EventBridge message does not contain a valid detail property", exception.Message);
+    }
+
+    [Fact]
+    public void Parse_WithNullDetail_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var json = @"{
+            ""detail"": null,
+            ""detail-type"": ""test-type"",
+            ""source"": ""test-source"",
+            ""time"": ""2024-03-15T10:00:00Z""
+        }";
+        var root = JsonDocument.Parse(json).RootElement;
+        var message = new Message();
+
+        // Act & Assert
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => _parser.Parse(root, message));
+        Assert.Equal("EventBridge message does not contain a valid detail property", exception.Message);
+    }
+
+    public static TheoryData<string> InvalidEventBridgeMessages => new()
+    {
+        // Missing detail
+        @"{
+            ""detail-type"": ""test-type"",
+            ""source"": ""test-source"",
+            ""time"": ""2024-03-15T10:00:00Z""
+        }",
+        // Missing detail-type
+        @"{
+            ""detail"": { ""someData"": ""value"" },
+            ""source"": ""test-source"",
+            ""time"": ""2024-03-15T10:00:00Z""
+        }",
+        // Missing source
+        @"{
+            ""detail"": { ""someData"": ""value"" },
+            ""detail-type"": ""test-type"",
+            ""time"": ""2024-03-15T10:00:00Z""
+        }",
+        // Missing time
+        @"{
+            ""detail"": { ""someData"": ""value"" },
+            ""detail-type"": ""test-type"",
+            ""source"": ""test-source""
+        }",
+        // Empty object
+        @"{}"
+    };
+}

--- a/test/AWS.Messaging.UnitTests/SerializationTests/Parsers/SNSMessageParserTests.cs
+++ b/test/AWS.Messaging.UnitTests/SerializationTests/Parsers/SNSMessageParserTests.cs
@@ -1,0 +1,199 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Amazon.SQS.Model;
+using AWS.Messaging.Serialization.Parsers;
+using Xunit;
+
+namespace AWS.Messaging.UnitTests.SerializationTests.Parsers;
+
+public class SNSMessageParserTests
+{
+    private readonly SNSMessageParser _parser;
+
+    public SNSMessageParserTests()
+    {
+        _parser = new SNSMessageParser();
+    }
+
+    [Fact]
+    public void CanParse_WithValidSNSMessage_ReturnsTrue()
+    {
+        // Arrange
+        var json = @"{
+            ""Type"": ""Notification"",
+            ""MessageId"": ""test-message-id"",
+            ""TopicArn"": ""arn:aws:sns:region:account:topic"",
+            ""Message"": ""test message""
+        }";
+        var root = JsonDocument.Parse(json).RootElement;
+
+        // Act
+        var result = _parser.CanParse(root);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidSNSMessages))]
+    public void CanParse_WithInvalidSNSMessage_ReturnsFalse(string json)
+    {
+        // Arrange
+        var root = JsonDocument.Parse(json).RootElement;
+
+        // Act
+        var result = _parser.CanParse(root);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Parse_WithValidMessage_ReturnsMessageAndMetadata()
+    {
+        // Arrange
+        var json = @"{
+            ""Type"": ""Notification"",
+            ""MessageId"": ""test-message-id"",
+            ""TopicArn"": ""arn:aws:sns:region:account:topic"",
+            ""Message"": ""test message"",
+            ""Timestamp"": ""2024-03-15T10:00:00.000Z"",
+            ""Subject"": ""Test Subject"",
+            ""UnsubscribeURL"": ""https://sns.region.amazonaws.com/unsubscribe"",
+            ""MessageAttributes"": {
+                ""TestAttribute"": {
+                    ""Type"": ""String"",
+                    ""Value"": ""TestValue""
+                }
+            }
+        }";
+        var root = JsonDocument.Parse(json).RootElement;
+        var message = new Message();
+
+        // Act
+        var (messageBody, metadata) = _parser.Parse(root, message);
+
+        // Assert
+        Assert.Equal("test message", messageBody);
+        Assert.NotNull(metadata.SNSMetadata);
+        Assert.Equal("test-message-id", metadata.SNSMetadata.MessageId);
+        Assert.Equal("arn:aws:sns:region:account:topic", metadata.SNSMetadata.TopicArn);
+        Assert.Equal("Test Subject", metadata.SNSMetadata.Subject);
+        Assert.Equal("https://sns.region.amazonaws.com/unsubscribe", metadata.SNSMetadata.UnsubscribeURL);
+    }
+
+    [Fact]
+    public void Parse_WithMissingMessage_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var json = @"{
+            ""Type"": ""Notification"",
+            ""MessageId"": ""test-message-id"",
+            ""TopicArn"": ""arn:aws:sns:region:account:topic""
+        }";
+        var root = JsonDocument.Parse(json).RootElement;
+        var message = new Message();
+
+        // Act & Assert
+        var exception = Assert.Throws<KeyNotFoundException>(
+            () => _parser.Parse(root, message));
+    }
+
+    [Fact]
+    public void Parse_WithNullMessage_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var json = @"{
+            ""Type"": ""Notification"",
+            ""MessageId"": ""test-message-id"",
+            ""TopicArn"": ""arn:aws:sns:region:account:topic"",
+            ""Message"": null
+        }";
+        var root = JsonDocument.Parse(json).RootElement;
+        var message = new Message();
+
+        // Act & Assert
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => _parser.Parse(root, message));
+        Assert.Equal("SNS message does not contain a valid Message property", exception.Message);
+    }
+
+    [Fact]
+    public void Parse_WithEmptyMessage_ReturnsEmptyString()
+    {
+        // Arrange
+        var json = @"{
+            ""Type"": ""Notification"",
+            ""MessageId"": ""test-message-id"",
+            ""TopicArn"": ""arn:aws:sns:region:account:topic"",
+            ""Message"": """"
+        }";
+        var root = JsonDocument.Parse(json).RootElement;
+        var message = new Message();
+
+        // Act
+        var (messageBody, metadata) = _parser.Parse(root, message);
+
+        // Assert
+        Assert.Equal("", messageBody);
+        Assert.NotNull(metadata.SNSMetadata);
+    }
+
+    public static TheoryData<string> InvalidSNSMessages => new()
+    {
+        // Missing Type
+        @"{
+            ""MessageId"": ""test-message-id"",
+            ""TopicArn"": ""arn:aws:sns:region:account:topic"",
+            ""Message"": ""test message""
+        }",
+        // Wrong Type
+        @"{
+            ""Type"": ""WrongType"",
+            ""MessageId"": ""test-message-id"",
+            ""TopicArn"": ""arn:aws:sns:region:account:topic"",
+            ""Message"": ""test message""
+        }",
+        // Missing MessageId
+        @"{
+            ""Type"": ""Notification"",
+            ""TopicArn"": ""arn:aws:sns:region:account:topic"",
+            ""Message"": ""test message""
+        }",
+        // Missing TopicArn
+        @"{
+            ""Type"": ""Notification"",
+            ""MessageId"": ""test-message-id"",
+            ""Message"": ""test message""
+        }",
+        // Empty object
+        @"{}"
+    };
+
+    [Fact]
+    public void Parse_WithJsonObjectMessage_ReturnsJsonString()
+    {
+        // Arrange
+        var json = @"{
+        ""Type"": ""Notification"",
+        ""MessageId"": ""test-message-id"",
+        ""TopicArn"": ""arn:aws:sns:region:account:topic"",
+        ""Message"": ""{\""key\"":\""value\""}""
+    }";
+        var root = JsonDocument.Parse(json).RootElement;
+        var message = new Message();
+
+        // Act
+        var (messageBody, metadata) = _parser.Parse(root, message);
+
+        // Assert
+        Assert.Equal("{\"key\":\"value\"}", messageBody);
+        Assert.NotNull(metadata.SNSMetadata);
+    }
+
+
+}

--- a/test/AWS.Messaging.UnitTests/SerializationTests/Parsers/SQSMessageParserTests.cs
+++ b/test/AWS.Messaging.UnitTests/SerializationTests/Parsers/SQSMessageParserTests.cs
@@ -1,0 +1,184 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections.Generic;
+using System.Text.Json;
+using Amazon.SQS.Model;
+using AWS.Messaging.Serialization.Parsers;
+using Xunit;
+
+namespace AWS.Messaging.UnitTests.SerializationTests.Parsers;
+
+public class SQSMessageParserTests
+{
+    private readonly SQSMessageParser _parser;
+
+    public SQSMessageParserTests()
+    {
+        _parser = new SQSMessageParser();
+    }
+
+    [Fact]
+    public void CanParse_AlwaysReturnsTrue()
+    {
+        // Arrange
+        var validJson = @"{""key"": ""value""}";
+        var emptyJson = "{}";
+        var arrayJson = @"[1,2,3]";
+        var validRoot = JsonDocument.Parse(validJson).RootElement;
+        var emptyRoot = JsonDocument.Parse(emptyJson).RootElement;
+        var arrayRoot = JsonDocument.Parse(arrayJson).RootElement;
+
+        // Act & Assert
+        Assert.True(_parser.CanParse(validRoot));
+        Assert.True(_parser.CanParse(emptyRoot));
+        Assert.True(_parser.CanParse(arrayRoot));
+    }
+
+    [Fact]
+    public void Parse_WithSimpleMessage_ReturnsOriginalMessageAndMetadata()
+    {
+        // Arrange
+        var json = @"{""key"": ""value""}";
+        var root = JsonDocument.Parse(json).RootElement;
+        var originalMessage = new Message
+        {
+            MessageId = "test-message-id",
+            ReceiptHandle = "test-receipt-handle"
+        };
+
+        // Act
+        var (messageBody, metadata) = _parser.Parse(root, originalMessage);
+
+        // Assert
+        Assert.Equal(json, messageBody);
+        Assert.NotNull(metadata.SQSMetadata);
+        Assert.Equal("test-message-id", metadata.SQSMetadata.MessageID);
+        Assert.Equal("test-receipt-handle", metadata.SQSMetadata.ReceiptHandle);
+    }
+
+    [Fact]
+    public void Parse_WithMessageAttributes_IncludesAttributesInMetadata()
+    {
+        // Arrange
+        var json = @"{""content"": ""test""}";
+        var root = JsonDocument.Parse(json).RootElement;
+        var originalMessage = new Message
+        {
+            MessageId = "test-message-id",
+            MessageAttributes = new Dictionary<string, Amazon.SQS.Model.MessageAttributeValue>
+            {
+                {
+                    "TestAttribute",
+                    new Amazon.SQS.Model.MessageAttributeValue { StringValue = "TestValue" }
+                }
+            }
+        };
+
+        // Act
+        var (messageBody, metadata) = _parser.Parse(root, originalMessage);
+
+        // Assert
+        Assert.Equal(json, messageBody);
+        Assert.NotNull(metadata.SQSMetadata);
+        Assert.Single(metadata.SQSMetadata.MessageAttributes);
+        Assert.Equal("TestValue", metadata.SQSMetadata.MessageAttributes["TestAttribute"].StringValue);
+    }
+
+    [Fact]
+    public void Parse_WithFIFOQueueAttributes_IncludesAttributesInMetadata()
+    {
+        // Arrange
+        var json = @"{""data"": ""test""}";
+        var root = JsonDocument.Parse(json).RootElement;
+        var originalMessage = new Message
+        {
+            MessageId = "test-message-id",
+            Attributes = new Dictionary<string, string>
+            {
+                { "MessageGroupId", "group-1" },
+                { "MessageDeduplicationId", "dedup-1" }
+            }
+        };
+
+        // Act
+        var (messageBody, metadata) = _parser.Parse(root, originalMessage);
+
+        // Assert
+        Assert.Equal(json, messageBody);
+        Assert.NotNull(metadata.SQSMetadata);
+        Assert.Equal("group-1", metadata.SQSMetadata.MessageGroupId);
+        Assert.Equal("dedup-1", metadata.SQSMetadata.MessageDeduplicationId);
+    }
+
+    [Fact]
+    public void Parse_WithArrayMessage_ReturnsOriginalArray()
+    {
+        // Arrange
+        var json = @"[1,2,3]";
+        var root = JsonDocument.Parse(json).RootElement;
+        var originalMessage = new Message
+        {
+            MessageId = "test-message-id"
+        };
+
+        // Act
+        var (messageBody, metadata) = _parser.Parse(root, originalMessage);
+
+        // Assert
+        Assert.Equal(json, messageBody);
+        Assert.NotNull(metadata.SQSMetadata);
+    }
+
+    [Fact]
+    public void Parse_WithEmptyMessage_ReturnsEmptyObject()
+    {
+        // Arrange
+        var json = "{}";
+        var root = JsonDocument.Parse(json).RootElement;
+        var originalMessage = new Message
+        {
+            MessageId = "test-message-id"
+        };
+
+        // Act
+        var (messageBody, metadata) = _parser.Parse(root, originalMessage);
+
+        // Assert
+        Assert.Equal(json, messageBody);
+        Assert.NotNull(metadata.SQSMetadata);
+    }
+
+    [Fact]
+    public void Parse_WithComplexNestedMessage_PreservesStructure()
+    {
+        // Arrange
+        var json = @"{
+            ""id"": 1,
+            ""nested"": {
+                ""array"": [1,2,3],
+                ""object"": {
+                    ""key"": ""value""
+                }
+            }
+        }";
+        var root = JsonDocument.Parse(json).RootElement;
+        var originalMessage = new Message
+        {
+            MessageId = "test-message-id"
+        };
+
+        // Act
+        var (messageBody, _) = _parser.Parse(root, originalMessage);
+
+        // Assert
+        var deserializedMessage = JsonDocument.Parse(messageBody).RootElement;
+        Assert.Equal(1, deserializedMessage.GetProperty("id").GetInt32());
+        Assert.True(deserializedMessage.GetProperty("nested").TryGetProperty("array", out var array));
+        Assert.Equal(3, array.GetArrayLength());
+        Assert.Equal("value", deserializedMessage.GetProperty("nested")
+            .GetProperty("object")
+            .GetProperty("key")
+            .GetString());
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* DOTNET-7873

*Description of changes:* 
The main change is that we no longer use `JsonSerializer.Deserialize` on the whole `sqs.Body`. This was parsing both the envelope (Which contains metadata fields and things) and also the `data` field inside. Previously this was all fine because were always storing `data` as an encoded json string. However, since I am working on [changing ](https://github.com/awslabs/aws-dotnet-messaging/pull/190) that behavior in the future to store `data` as the actual json object, we can no longer use `JsonSerializer.Deserialize` on the whole body (because JsonSerializer.Deserialize fails). Instead we have to do:
1. Parse outer wrapper using JsonDocument.Parse. This will parse everything except the `data` field.
2. Deserialize `data` using `_messageSerializer.Deserialize`.

This way it allows users to implement and kind of message serializer logic for the `data` field. It could be json, xml, etc

I also made some improvements by creating separate class for each parser and metadata creator.

## Testing
1. Unit and integration tests pass
2. I made a console app to verify it still works

```
using Microsoft.Extensions.DependencyInjection;
using Microsoft.Extensions.Hosting;

namespace AWS.Messaging.SerializationIssue;

internal class Program
{
    private static async Task Main(string[] args)
    {
        var builder = Host.CreateApplicationBuilder(args);

        builder.Services.AddAWSMessageBus(bus =>
        {
            bus.AddEventBridgePublisher<Payload>("arn:aws:events:us-east-1:147997163238:event-bus/new-bus", nameof(Payload));
            
            bus.AddSQSPublisher<Payload>("https://sqs.us-east-1.amazonaws.com/147997163238/newqueue");

            
            // Register an SQS Queue that the framework will poll for messages
            bus.AddSQSPoller("https://sqs.us-east-1.amazonaws.com/147997163238/newqueue");

            // Register all IMessageHandler implementations with the message type they should process. 
            // Here messages that match our ChatMessage .NET type will be handled by our ChatMessageHandler
            bus.AddMessageHandler<ChatMessageHandler, Payload>();
            
        });
        
      

        builder.Services.AddHostedService<Worker>();

        var host = builder.Build();
        await host.RunAsync();
    }
}

public class ChatMessageHandler : IMessageHandler<Payload>
{
    public Task<MessageProcessStatus> HandleAsync(MessageEnvelope<Payload> messageEnvelope, CancellationToken token = default)
    {
        // Add business and validation logic here
        if (messageEnvelope == null)
        {
            return Task.FromResult(MessageProcessStatus.Failed());
        }

        if (messageEnvelope.Message == null)
        {
            return Task.FromResult(MessageProcessStatus.Failed());
        }

        Payload message = messageEnvelope.Message;

        Console.WriteLine($"Message Description: {message.Id}");

        // Return success so the framework will delete the message from the queue
        return Task.FromResult(MessageProcessStatus.Success());
    }
}
```

```
using Microsoft.Extensions.Hosting;
using Microsoft.Extensions.Logging;

namespace AWS.Messaging.SerializationIssue;

internal class Worker(
    ILogger<Worker> logger,
    IHostApplicationLifetime lifetime,
    IMessagePublisher messagePublisher
)
    : IHostedService
{
    public async Task StartAsync(CancellationToken cancellationToken)
    {
        try
        {
            var payload = new Payload
            {
                Id = Guid.NewGuid(),
                Name = "Test",
                SomeValue = 42
            };
            await messagePublisher.PublishAsync(payload, cancellationToken);
        }
        catch (Exception e)
        {
            logger.LogError(e, "An error occured");
        }
        finally
        {
            lifetime.StopApplication();
        }
    }

    public Task StopAsync(CancellationToken cancellationToken)
    {
        return Task.CompletedTask;
    }
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
