### PR TITLE
Updates the `MessageSerializer` to store the json value as the actual json object in the `data` field.Update data field serialization

### DIFF
--- a/.autover/changes/56a61b2c-4302-4077-9dc6-3fc3bc60a998.json
+++ b/.autover/changes/56a61b2c-4302-4077-9dc6-3fc3bc60a998.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Messaging",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Update MessageSerializer to store data as actual json. Fixes #168"
+      ]
+    }
+  ]
+}

--- a/src/AWS.Messaging/AWS.Messaging.csproj
+++ b/src/AWS.Messaging/AWS.Messaging.csproj
@@ -18,7 +18,7 @@
     <NoWarn>CS1591</NoWarn>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\public.snk</AssemblyOriginatorKeyFile>
-    <Version>0.20.0-preview</Version>
+    <Version>0.20.12-preview</Version>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/AWS.Messaging/AWS.Messaging.csproj
+++ b/src/AWS.Messaging/AWS.Messaging.csproj
@@ -18,7 +18,7 @@
     <NoWarn>CS1591</NoWarn>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\public.snk</AssemblyOriginatorKeyFile>
-    <Version>0.20.12-preview</Version>
+    <Version>0.20.0-preview</Version>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/AWS.Messaging/MessageEnvelope.cs
+++ b/src/AWS.Messaging/MessageEnvelope.cs
@@ -45,6 +45,12 @@ public abstract class MessageEnvelope
     public DateTimeOffset TimeStamp { get; set; } = DateTimeOffset.MinValue;
 
     /// <summary>
+    /// The data content type.
+    /// </summary>
+    [JsonPropertyName("datacontenttype")]
+    public string? DataContentType { get; set; }
+
+    /// <summary>
     /// This stores different metadata that is not modeled as a top-level property in MessageEnvelope class.
     /// These entries will also be serialized as top-level properties when sending the message, which
     /// can be used for CloudEvents Extension Attributes.

--- a/src/AWS.Messaging/Serialization/EnvelopeSerializer.cs
+++ b/src/AWS.Messaging/Serialization/EnvelopeSerializer.cs
@@ -78,8 +78,7 @@ internal class EnvelopeSerializer : IEnvelopeSerializer
             Version = CLOUD_EVENT_SPEC_VERSION,
             MessageTypeIdentifier = publisherMapping.MessageTypeIdentifier,
             TimeStamp = timeStamp,
-            Message = message,
-            DataContentType = _messageSerializer.DataContentType
+            Message = message
         };
     }
 
@@ -103,17 +102,20 @@ internal class EnvelopeSerializer : IEnvelopeSerializer
                 ["source"] = envelope.Source?.ToString(),
                 ["specversion"] = envelope.Version,
                 ["type"] = envelope.MessageTypeIdentifier,
-                ["time"] = envelope.TimeStamp,
-                ["datacontenttype"] = envelope.DataContentType ?? "application/json"
+                ["time"] = envelope.TimeStamp
             };
 
-            if (IsJsonContentType(envelope.DataContentType))
+            var messageSerializerResults = _messageSerializer.Serialize(message);
+
+            blob["datacontenttype"] = messageSerializerResults.ContentType;
+
+            if (IsJsonContentType(messageSerializerResults.ContentType))
             {
-                blob["data"] = JsonNode.Parse(_messageSerializer.Serialize(message));
+                blob["data"] = JsonNode.Parse(messageSerializerResults.Data);
             }
             else
             {
-                blob["data"] = _messageSerializer.Serialize(message);
+                blob["data"] = messageSerializerResults.Data;
 
             }
 

--- a/src/AWS.Messaging/Serialization/IMessageSerializer.cs
+++ b/src/AWS.Messaging/Serialization/IMessageSerializer.cs
@@ -9,9 +9,10 @@ namespace AWS.Messaging.Serialization;
 public interface IMessageSerializer
 {
     /// <summary>
-    /// Serializes the .NET message object into a string.
+    /// Serializes the .NET message object into a string and specifies the content type of the serialized data.
     /// </summary>
     /// <param name="message">The .NET object that will be serialized.</param>
+    /// <returns>A <see cref="MessageSerializerResults"/> containing the serialized string and its content type.</returns>
     MessageSerializerResults Serialize(object message);
 
     /// <summary>

--- a/src/AWS.Messaging/Serialization/IMessageSerializer.cs
+++ b/src/AWS.Messaging/Serialization/IMessageSerializer.cs
@@ -12,7 +12,7 @@ public interface IMessageSerializer
     /// Serializes the .NET message object into a string.
     /// </summary>
     /// <param name="message">The .NET object that will be serialized.</param>
-    string Serialize(object message);
+    MessageSerializerResults Serialize(object message);
 
     /// <summary>
     /// Deserializes the raw string message into the .NET type.
@@ -30,9 +30,4 @@ public interface IMessageSerializer
     {
         return (T)Deserialize(message, typeof(T));
     }
-
-    /// <summary>
-    /// The data content type
-    /// </summary>
-    string DataContentType { get; }
 }

--- a/src/AWS.Messaging/Serialization/IMessageSerializer.cs
+++ b/src/AWS.Messaging/Serialization/IMessageSerializer.cs
@@ -30,4 +30,9 @@ public interface IMessageSerializer
     {
         return (T)Deserialize(message, typeof(T));
     }
+
+    /// <summary>
+    /// The data content type
+    /// </summary>
+    string DataContentType { get; }
 }

--- a/src/AWS.Messaging/Serialization/MessageSerializer.cs
+++ b/src/AWS.Messaging/Serialization/MessageSerializer.cs
@@ -113,4 +113,9 @@ internal class MessageSerializer : IMessageSerializer
             throw new FailedToSerializeApplicationMessageException("Failed to serialize application message into a string", ex);
         }
     }
+
+    /// <summary>
+    /// The data content type
+    /// </summary>
+    public string DataContentType => "application/json";
 }

--- a/src/AWS.Messaging/Serialization/MessageSerializer.cs
+++ b/src/AWS.Messaging/Serialization/MessageSerializer.cs
@@ -73,7 +73,7 @@ internal class MessageSerializer : IMessageSerializer
         Justification = "Consumers relying on trimming would have been required to call the AddAWSMessageBus overload that takes in JsonSerializerContext that will be used here to avoid the call that requires unreferenced code.")]
     [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ReflectionAnalysis", "IL3050",
         Justification = "Consumers relying on trimming would have been required to call the AddAWSMessageBus overload that takes in JsonSerializerContext that will be used here to avoid the call that requires unreferenced code.")]
-    public string Serialize(object message)
+    public MessageSerializerResults Serialize(object message)
     {
         try
         {
@@ -100,7 +100,7 @@ internal class MessageSerializer : IMessageSerializer
                 _logger.LogTrace("Serialized the message object to a raw string with a content length of {ContentLength}.", jsonString.Length);
             }
 
-            return jsonString;
+            return new MessageSerializerResults(jsonString, "application/json");
         }
         catch (JsonException) when (!_messageConfiguration.LogMessageContent)
         {
@@ -113,9 +113,4 @@ internal class MessageSerializer : IMessageSerializer
             throw new FailedToSerializeApplicationMessageException("Failed to serialize application message into a string", ex);
         }
     }
-
-    /// <summary>
-    /// The data content type
-    /// </summary>
-    public string DataContentType => "application/json";
 }

--- a/src/AWS.Messaging/Serialization/MessageSerializerResults.cs
+++ b/src/AWS.Messaging/Serialization/MessageSerializerResults.cs
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+namespace AWS.Messaging.Serialization;
+
+/// <summary>
+/// Represents the results of a message serialization operation, containing both the serialized data
+/// and its corresponding content type.
+/// </summary>
+public class MessageSerializerResults
+{
+    /// <summary>
+    /// Initializes a new instance of the MessageSerializerResults class.
+    /// </summary>
+    /// <param name="data">The serialized message data as a string.</param>
+    /// <param name="contentType">The MIME content type of the serialized data.</param>
+    public MessageSerializerResults(string data, string contentType)
+    {
+        Data = data;
+        ContentType = contentType;
+    }
+
+    /// <summary>
+    /// Gets or sets the MIME content type of the serialized data.
+    /// Common values include "application/json" or "application/xml".
+    /// </summary>
+    public string ContentType { get; }
+
+    /// <summary>
+    /// Gets or sets the serialized message data as a string.
+    /// This contains the actual serialized content of the message.
+    /// </summary>
+    public string Data { get; }
+}

--- a/test/AWS.Messaging.UnitTests/MessageHandlers/Handlers.cs
+++ b/test/AWS.Messaging.UnitTests/MessageHandlers/Handlers.cs
@@ -44,6 +44,16 @@ public class ChatMessageHandlerWithDependencies : IMessageHandler<ChatMessage>
     }
 }
 
+public class PlainTextHandler : IMessageHandler<string>
+{
+    public Task<MessageProcessStatus> HandleAsync(MessageEnvelope<string> messageEnvelope, CancellationToken token = default)
+    {
+        // Simple handler implementation for test purposes
+        return Task.FromResult(MessageProcessStatus.Success());
+    }
+}
+
+
 /// <summary>
 /// Implements handling for mutiple message types
 /// </summary>

--- a/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
@@ -35,6 +35,7 @@ public class EnvelopeSerializerTests
         {
             builder.AddSQSPublisher<AddressInfo>("sqsQueueUrl", "addressInfo");
             builder.AddMessageHandler<AddressInfoHandler, AddressInfo>("addressInfo");
+            builder.AddMessageHandler<PlainTextHandler, string>("plaintext");
             builder.AddMessageSource("/aws/messaging");
         });
 
@@ -736,6 +737,158 @@ public class EnvelopeSerializerTests
         Assert.Contains("Available mappings:", innerException.Message);
         Assert.Contains("addressInfo", innerException.Message);
     }
+
+    [Fact]
+    public async Task SerializeEnvelope_WithNonJsonContentType_PlainText()
+    {
+        // ARRANGE
+        var plainTextContent = "Hello, this is plain text content";
+        var envelope = new MessageEnvelope<string>
+        {
+            Id = "id-123",
+            Source = new Uri("/backend/service", UriKind.Relative),
+            Version = "1.0",
+            MessageTypeIdentifier = "plaintext",
+            TimeStamp = _testdate,
+            Message = plainTextContent,
+            DataContentType = "text/plain"
+        };
+
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+        var envelopeSerializer = serviceProvider.GetRequiredService<IEnvelopeSerializer>();
+
+        // ACT
+        var jsonBlob = await envelopeSerializer.SerializeAsync(envelope);
+
+        // ASSERT
+        var expectedBlob = "{\"id\":\"id-123\",\"source\":\"/backend/service\",\"specversion\":\"1.0\"," +
+                           "\"type\":\"plaintext\",\"time\":\"2000-12-05T10:30:55+00:00\"," +
+                           "\"datacontenttype\":\"text/plain\",\"data\":\"\\u0022Hello, this is plain text content\\u0022\"}";
+        Assert.Equal(expectedBlob, jsonBlob);
+    }
+
+    [Fact]
+    public async Task SerializeEnvelope_WithNonJsonContentType_Xml()
+    {
+        // ARRANGE
+        var xmlContent = "<root><message>Test XML Content</message></root>";
+        var envelope = new MessageEnvelope<string>
+        {
+            Id = "id-123",
+            Source = new Uri("/backend/service", UriKind.Relative),
+            Version = "1.0",
+            MessageTypeIdentifier = "xml",
+            TimeStamp = _testdate,
+            Message = xmlContent,
+            DataContentType = "application/xml"
+        };
+
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+        var envelopeSerializer = serviceProvider.GetRequiredService<IEnvelopeSerializer>();
+
+        // ACT
+        var jsonBlob = await envelopeSerializer.SerializeAsync(envelope);
+
+        // ASSERT
+        var expectedBlob = "{\"id\":\"id-123\",\"source\":\"/backend/service\",\"specversion\":\"1.0\",\"type\":\"xml\",\"time\":\"2000-12-05T10:30:55+00:00\",\"datacontenttype\":\"application/xml\",\"data\":\"\\u0022\\\\u003Croot\\\\u003E\\\\u003Cmessage\\\\u003ETest XML Content\\\\u003C/message\\\\u003E\\\\u003C/root\\\\u003E\\u0022\"}";
+        Assert.Equal(expectedBlob, jsonBlob);
+    }
+
+    [Fact]
+    //[InlineData("text/html", "<html><body>Hello World</body></html>")]
+    public async Task SerializeEnvelope_WithCSV()
+    {
+
+        var content = "column1,column2\nvalue1,value2";
+        // ARRANGE
+        var envelope = new MessageEnvelope<string>
+        {
+            Id = "id-123",
+            Source = new Uri("/backend/service", UriKind.Relative),
+            Version = "1.0",
+            MessageTypeIdentifier = "custom",
+            TimeStamp = _testdate,
+            Message = content,
+            DataContentType = "text/csv"
+        };
+
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+        var envelopeSerializer = serviceProvider.GetRequiredService<IEnvelopeSerializer>();
+
+        // ACT
+        var jsonBlob = await envelopeSerializer.SerializeAsync(envelope);
+
+        // ASSERT
+        var expectedBlob = $"{{\"id\":\"id-123\",\"source\":\"/backend/service\",\"specversion\":\"1.0\",\"type\":\"custom\",\"time\":\"2000-12-05T10:30:55+00:00\",\"datacontenttype\":\"text/csv\",\"data\":\"\\u0022column1,column2\\\\nvalue1,value2\\u0022\"}}";
+        Assert.Equal(expectedBlob, jsonBlob);
+    }
+
+    [Fact]
+    public async Task SerializeEnvelope_WithHTML()
+    {
+
+        var content = "<html><body>Hello World</body></html>";
+        // ARRANGE
+        var envelope = new MessageEnvelope<string>
+        {
+            Id = "id-123",
+            Source = new Uri("/backend/service", UriKind.Relative),
+            Version = "1.0",
+            MessageTypeIdentifier = "custom",
+            TimeStamp = _testdate,
+            Message = content,
+            DataContentType = "text/html"
+        };
+
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+        var envelopeSerializer = serviceProvider.GetRequiredService<IEnvelopeSerializer>();
+
+        // ACT
+        var jsonBlob = await envelopeSerializer.SerializeAsync(envelope);
+
+        // ASSERT
+        var expectedBlob = "{\"id\":\"id-123\",\"source\":\"/backend/service\",\"specversion\":\"1.0\",\"type\":\"custom\",\"time\":\"2000-12-05T10:30:55+00:00\",\"datacontenttype\":\"text/html\",\"data\":\"\\u0022\\\\u003Chtml\\\\u003E\\\\u003Cbody\\\\u003EHello World\\\\u003C/body\\\\u003E\\\\u003C/html\\\\u003E\\u0022\"}";
+        Assert.Equal(expectedBlob, jsonBlob);
+    }
+
+    [Fact]
+    public async Task ConvertToEnvelope_WithNonJsonContentType()
+    {
+        // ARRANGE
+        var serviceProvider = _serviceCollection.BuildServiceProvider();
+        var envelopeSerializer = serviceProvider.GetRequiredService<IEnvelopeSerializer>();
+        var plainTextContent = "Hello, this is plain text content";
+        var messageEnvelope = new MessageEnvelope<string>
+        {
+            Id = "id-123",
+            Source = new Uri("/aws/messaging", UriKind.Relative),
+            Version = "1.0",
+            MessageTypeIdentifier = "plaintext",
+            TimeStamp = _testdate,
+            Message = plainTextContent,
+            DataContentType = "text/plain"
+        };
+
+        var sqsMessage = new Message
+        {
+            Body = await envelopeSerializer.SerializeAsync(messageEnvelope),
+            ReceiptHandle = "receipt-handle"
+        };
+
+        // ACT
+        var result = await envelopeSerializer.ConvertToEnvelopeAsync(sqsMessage);
+
+        // ASSERT
+        var envelope = (MessageEnvelope<string>)result.Envelope;
+        Assert.NotNull(envelope);
+        Assert.Equal(_testdate, envelope.TimeStamp);
+        Assert.Equal("1.0", envelope.Version);
+        Assert.Equal("/aws/messaging", envelope.Source?.ToString());
+        Assert.Equal("plaintext", envelope.MessageTypeIdentifier);
+        Assert.Equal("text/plain", envelope.DataContentType);
+        Assert.Equal(plainTextContent, envelope.Message);
+    }
+
 
 }
 

--- a/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SerializationTests/EnvelopeSerializerTests.cs
@@ -119,7 +119,7 @@ public class EnvelopeSerializerTests
 
         // ASSERT
         // The \u0022 corresponds to quotation mark (")
-        var expectedBlob = "{\"id\":\"id-123\",\"source\":\"/backend/service\",\"specversion\":\"1.0\",\"type\":\"addressInfo\",\"time\":\"2000-12-05T10:30:55+00:00\",\"data\":\"{\\u0022Unit\\u0022:123,\\u0022Street\\u0022:\\u0022Prince St\\u0022,\\u0022ZipCode\\u0022:\\u002200001\\u0022}\"}";
+        var expectedBlob = "{\"id\":\"id-123\",\"source\":\"/backend/service\",\"specversion\":\"1.0\",\"type\":\"addressInfo\",\"time\":\"2000-12-05T10:30:55+00:00\",\"datacontenttype\":\"application/json\",\"data\":{\"Unit\":123,\"Street\":\"Prince St\",\"ZipCode\":\"00001\"}}";
         Assert.Equal(expectedBlob, jsonBlob);
     }
 
@@ -272,19 +272,19 @@ public class EnvelopeSerializerTests
         var serviceProvider = _serviceCollection.BuildServiceProvider();
         var envelopeSerializer = serviceProvider.GetRequiredService<IEnvelopeSerializer>();
 
-        var innerMessageEnvelope = new MessageEnvelope<string>
+        var innerMessageEnvelope = new MessageEnvelope<AddressInfo>
         {
             Id = "66659d05-e4ff-462f-81c4-09e560e66a5c",
             Source = new Uri("/aws/messaging", UriKind.Relative),
             Version = "1.0",
             MessageTypeIdentifier = "addressInfo",
             TimeStamp = _testdate,
-            Message = JsonSerializer.Serialize(new AddressInfo
+            Message = new AddressInfo
             {
                 Street = "Prince St",
                 Unit = 123,
                 ZipCode = "00001"
-            })
+            }
         };
 
         var outerMessageEnvelope = new Dictionary<string, object>
@@ -397,7 +397,7 @@ public class EnvelopeSerializerTests
         var serializedMessage = await envelopeSerializer.SerializeAsync(messageEnvelope);
 
         // ASSERT - Check expected base 64 encoded string
-        var expectedserializedMessage = "eyJpZCI6IjEyMyIsInNvdXJjZSI6Ii9hd3MvbWVzc2FnaW5nIiwic3BlY3ZlcnNpb24iOiIxLjAiLCJ0eXBlIjoiYWRkcmVzc0luZm8iLCJ0aW1lIjoiMjAwMC0xMi0wNVQxMDozMDo1NSswMDowMCIsImRhdGEiOiJ7XHUwMDIyVW5pdFx1MDAyMjoxMjMsXHUwMDIyU3RyZWV0XHUwMDIyOlx1MDAyMlByaW5jZSBTdFx1MDAyMixcdTAwMjJaaXBDb2RlXHUwMDIyOlx1MDAyMjAwMDAxXHUwMDIyfSIsIklzLURlbGl2ZXJlZCI6ZmFsc2V9";
+        var expectedserializedMessage = "eyJpZCI6IjEyMyIsInNvdXJjZSI6Ii9hd3MvbWVzc2FnaW5nIiwic3BlY3ZlcnNpb24iOiIxLjAiLCJ0eXBlIjoiYWRkcmVzc0luZm8iLCJ0aW1lIjoiMjAwMC0xMi0wNVQxMDozMDo1NSswMDowMCIsImRhdGFjb250ZW50dHlwZSI6ImFwcGxpY2F0aW9uL2pzb24iLCJkYXRhIjp7IlVuaXQiOjEyMywiU3RyZWV0IjoiUHJpbmNlIFN0IiwiWmlwQ29kZSI6IjAwMDAxIn0sIklzLURlbGl2ZXJlZCI6ZmFsc2V9";
         Assert.Equal(expectedserializedMessage, serializedMessage);
 
         // ACT - Convert To Envelope from base 64 Encoded Message
@@ -452,6 +452,15 @@ public class EnvelopeSerializerTests
             }
         };
 
+        var serializedContent = JsonSerializer.Serialize(messageEnvelope.Message);
+
+        // Mock the serializer to return a specific string
+        messageSerializer
+            .Setup(x => x.Serialize(It.IsAny<object>()))
+            .Returns(serializedContent);
+        messageSerializer.Setup(x => x.DataContentType).Returns("application/json");
+
+
         await envelopeSerializer.SerializeAsync(messageEnvelope);
 
         if (dataMessageLogging)
@@ -459,7 +468,7 @@ public class EnvelopeSerializerTests
             logger.Verify(log => log.Log(
                     It.Is<LogLevel>(logLevel => logLevel == LogLevel.Trace),
                     It.Is<EventId>(eventId => eventId.Id == 0),
-                    It.Is<It.IsAnyType>((@object, @type) => @object.ToString() == "Serialized the MessageEnvelope object as the following raw string:\n{\"id\":\"123\",\"source\":\"/aws/messaging\",\"specversion\":\"1.0\",\"type\":\"addressInfo\",\"time\":\"2000-12-05T10:30:55+00:00\",\"data\":null}"),
+                    It.Is<It.IsAnyType>((@object, @type) => @object.ToString() == "Serialized the MessageEnvelope object as the following raw string:\n{\"id\":\"123\",\"source\":\"/aws/messaging\",\"specversion\":\"1.0\",\"type\":\"addressInfo\",\"time\":\"2000-12-05T10:30:55+00:00\",\"datacontenttype\":\"application/json\",\"data\":{\"Unit\":123,\"Street\":\"Prince St\",\"ZipCode\":\"00001\"}}"),
                     null,
                     It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
                 Times.Once);
@@ -612,22 +621,30 @@ public class EnvelopeSerializerTests
         var envelopeSerializer = serviceProvider.GetRequiredService<IEnvelopeSerializer>();
 
         // Create a JSON string with both standard envelope properties and custom metadata
-        var jsonString = @"{
-            ""id"": ""test-id-123"",
-            ""source"": ""/aws/messaging"",
-            ""specversion"": ""1.0"",
-            ""type"": ""addressInfo"",
-            ""time"": ""2000-12-05T10:30:55+00:00"",
-            ""data"": ""{\""Unit\"":123,\""Street\"":\""Prince St\"",\""ZipCode\"":\""00001\""}"",
-            ""customString"": ""test-value"",
-            ""customNumber"": 42,
-            ""customBoolean"": true,
-            ""customObject"": {""nestedKey"": ""nestedValue""}
-        }";
+        var testData = new
+        {
+            id = "test-id-123",
+            source = "/aws/messaging",
+            specversion = "1.0",
+            type = "addressInfo",
+            time = "2000-12-05T10:30:55+00:00",
+            data = new AddressInfo
+            {
+                Unit = 123,
+                Street = "Prince St",
+                ZipCode = "00001"
+            },
+            customString = "test-value",
+            customNumber = 42,
+            customBoolean = true,
+            customObject = new { nestedKey = "nestedValue" }
+        };
+
+        var json = JsonSerializer.Serialize(testData);
 
         var sqsMessage = new Message
         {
-            Body = jsonString
+            Body = json
         };
 
         // ACT

--- a/test/AWS.Messaging.UnitTests/SerializationTests/MessageSerializerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SerializationTests/MessageSerializerTests.cs
@@ -47,11 +47,12 @@ public class MessageSerializerTests
         };
 
         // ACT
-        var jsonString = serializer.Serialize(person).Data;
+        var result = serializer.Serialize(person);
 
         // ASSERT
         var expectedString = "{\"FirstName\":\"Bob\",\"LastName\":\"Stone\",\"Age\":30,\"Gender\":\"Male\",\"Address\":{\"Unit\":12,\"Street\":\"Prince St\",\"ZipCode\":\"00001\"}}";
-        Assert.Equal(expectedString, jsonString);
+        Assert.Equal(expectedString, result.Data);
+        Assert.Equal("application/json", result.ContentType);
     }
 
     [Theory]

--- a/test/AWS.Messaging.UnitTests/SerializationTests/MessageSerializerTests.cs
+++ b/test/AWS.Messaging.UnitTests/SerializationTests/MessageSerializerTests.cs
@@ -47,7 +47,7 @@ public class MessageSerializerTests
         };
 
         // ACT
-        var jsonString = serializer.Serialize(person);
+        var jsonString = serializer.Serialize(person).Data;
 
         // ASSERT
         var expectedString = "{\"FirstName\":\"Bob\",\"LastName\":\"Stone\",\"Age\":30,\"Gender\":\"Male\",\"Address\":{\"Unit\":12,\"Street\":\"Prince St\",\"ZipCode\":\"00001\"}}";
@@ -75,7 +75,7 @@ public class MessageSerializerTests
             }
         };
 
-        var jsonString = serializer.Serialize(person);
+        var jsonString = serializer.Serialize(person).Data;
 
         _logger.Verify(logger => logger.Log(
                 It.Is<LogLevel>(logLevel => logLevel == LogLevel.Trace),


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-dotnet-messaging/issues/168

*Description of changes:*
1. Updates the `MessageSerializer` to store the json value as the actual json object in the `data` field. 
2. Add `datacontenttype` field to message

**Before**
```
{
    "version": "0",
    "id": "359472c2-c66b-00df-5976-cef04c383a15",
    "detail-type": "Payload",
    "source": "/aws/messaging",
    "account": "147997163238",
    "time": "2025-03-14T18:40:58Z",
    "region": "us-east-1",
    "resources": [],
    "detail": {
        "id": "fdc50c90-f747-4794-ae91-d39894cc6442",
        "source": "/aws/messaging",
        "specversion": "1.0",
        "type": "Payload",
        "time": "2025-03-14T18:40:56.3356898+00:00",
        "data": "{\"Id\":\"8b939477-089c-49ce-ae90-49e9817bd593\",\"Name\":\"Test\",\"SomeValue\":42}"
    }
```

**After**

```
{
    "version": "0",
    "id": "ce7c8a25-da87-879d-100c-874adbaf9c51",
    "detail-type": "Payload",
    "source": "/aws/messaging",
    "account": "147997163238",
    "time": "2025-03-14T19:03:10Z",
    "region": "us-east-1",
    "resources": [],
    "detail": {
        "id": "0ef8cf5e-938a-4dc8-9b62-c6ccb3344bc7",
        "source": "/aws/messaging",
        "specversion": "1.0",
        "type": "Payload",
        "time": "2025-03-14T19:03:08.4022404+00:00",
        "datacontenttype": "application/json",
        "data": {
            "Id": "0172a7de-3757-4740-a771-4aca5f05d67c",
            "Name": "Test",
            "SomeValue": 42
        }
    }
}
```

## Testing
1. I followed the steps in https://github.com/awslabs/aws-dotnet-messaging/issues/168#issuecomment-2563862763 to validate the before and after


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
