### PR TITLE
Remove stale entries from inflight message metadata. Fixes #191

### DIFF
--- a/.autover/changes/81b0f05a-0e00-4c87-8bff-1d709e1b6e20.json
+++ b/.autover/changes/81b0f05a-0e00-4c87-8bff-1d709e1b6e20.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Messaging",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Remove failed messages from inflight messages metatadata dictionary. Fixes #191"
+      ]
+    }
+  ]
+}

--- a/src/AWS.Messaging/Services/DefaultMessageManager.cs
+++ b/src/AWS.Messaging/Services/DefaultMessageManager.cs
@@ -145,6 +145,7 @@ public class DefaultMessageManager : IMessageManager
                     for (var unprocessedIndex = i + 1; unprocessedIndex < messageGroup.Count; unprocessedIndex++)
                     {
                         await _sqsMessageCommunication.ReportMessageFailureAsync(messageGroup[unprocessedIndex].Envelope, token);
+                        _inFlightMessageMetadata.Remove(messageGroup[unprocessedIndex].Envelope, out _);
                     }
                     _logger.LogError("Handler invocation failed for a message belonging to message group '{GroupdId}' having message ID '{MessageID}'. Skipping processing of {Remaining} messages from the same group.", groupId, message.Envelope.Id, remaining);
                     break;


### PR DESCRIPTION
## Description
Fixes an issue in where failed FIFO queue message groups cause visibility timeout extensions errors. When a message in a group failed processing, subsequent messages remained in `_inFlightMessageMetadata` with stale receipt handles. These stale entries accumulated alongside new entries when messages were repolled, causing perpetual failed attempts to extend visibility timeouts after the SQS 12 hour maximum extension window was reached.

### Ticket
 DOTNET-8035

## Problem
In long-running processes using FIFO queues:
- When a message in a group failed, subsequent messages were correctly skipped but remained in metadata
- System continued trying to extend visibility timeouts using _outdated receipt handles_
- When messages were repolled, new entries were added to metadata while stale entries remained
- The visibility timeout extension task processed all entries in metadata, including stale ones

Example scenario before fix:
1. Two messages received in group "A": 
   - Message1 (receipt: "abc123") 
   - Message2 (receipt: "def456")
2. Message1 fails processing
3. Message2 is skipped but stays in metadata with receipt "def456"
4. System keeps trying to extend "def456" visibility
5. Message2 gets repolled with new receipt "xyz789"
6. Metadata now contains both entries for Message2:
   - Stale entry with receipt "def456"
   - New entry with receipt "xyz789"
5. After 12 hours, extensions fail for stale entries

Example scenario after fix:
1. Two messages received in group "A":
   - Message1 (receipt: "abc123")
   - Message2 (receipt: "def456") 
2. Message1 fails processing
3. Message2 is now removed from metadata  <------------ the change in this PR
4. Message2 gets repolled with new receipt "xyz789"
5. Only the new receipt handle exists in metadata, so visibility extension works as expected
6. No stale entries remain to cause failed extension attempts

## Solution
- Added cleanup of skipped messages from `_inFlightMessageMetadata` when a message in the group fails

## Testing
- Added unit test to verify cleanup of skipped messages from metadata
- Tested manually in debugger that `_inFlightMessageMetadata` was being cleared up and when messages the stale ones were not there anymore.

Fixes #191 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
