### PR TITLE
Update sample apps to use Aspire

### DIFF
--- a/AWS.Messaging.sln
+++ b/AWS.Messaging.sln
@@ -39,6 +39,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AWS.Messaging.Benchmarks", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PollyIntegration", "sampleapps\PollyIntegration\PollyIntegration.csproj", "{86896246-B032-4D34-82BE-CD5ACB6E43F9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AppHost", "sampleapps\AppHost\AppHost.csproj", "{C028BF43-16C6-42FB-B422-5AD4F15B492C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -93,6 +95,10 @@ Global
 		{86896246-B032-4D34-82BE-CD5ACB6E43F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{86896246-B032-4D34-82BE-CD5ACB6E43F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{86896246-B032-4D34-82BE-CD5ACB6E43F9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C028BF43-16C6-42FB-B422-5AD4F15B492C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C028BF43-16C6-42FB-B422-5AD4F15B492C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C028BF43-16C6-42FB-B422-5AD4F15B492C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C028BF43-16C6-42FB-B422-5AD4F15B492C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -110,6 +116,7 @@ Global
 		{F7A1B9DE-86DE-4F70-A2CD-628E56FE5BAD} = {80DB2C77-6ADD-4A60-B27D-763BDF9659D3}
 		{143DC3E0-A1C6-4670-86F4-E7CD4C8F52CB} = {80DB2C77-6ADD-4A60-B27D-763BDF9659D3}
 		{86896246-B032-4D34-82BE-CD5ACB6E43F9} = {1AA8985B-897C-4BD5-9735-FD8B33FEBFFB}
+		{C028BF43-16C6-42FB-B422-5AD4F15B492C} = {1AA8985B-897C-4BD5-9735-FD8B33FEBFFB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7B2B759D-6455-4089-8173-3F1619567B36}

--- a/sampleapps/AppHost/AppHost.csproj
+++ b/sampleapps/AppHost/AppHost.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireHost>true</IsAspireHost>
+    <UserSecretsId>979600ca-75aa-4eca-aff7-492ae2af1d88</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.1.0" />
+    <PackageReference Include="Aspire.Hosting.AWS" Version="9.1.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LambdaMessaging\LambdaMessaging.csproj" />
+    <ProjectReference Include="..\PollyIntegration\PollyIntegration.csproj" />
+    <ProjectReference Include="..\PublisherAPI\PublisherAPI.csproj" />
+    <ProjectReference Include="..\SubscriberService\SubscriberService.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/sampleapps/AppHost/Program.cs
+++ b/sampleapps/AppHost/Program.cs
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon;
+
+#pragma warning disable CA2252 // This API requires opting into preview features
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+var awsConfig = builder.AddAWSSDKConfig()
+                        .WithProfile("default")
+                        .WithRegion(RegionEndpoint.USWest2);
+
+
+builder.AddAWSLambdaFunction<Projects.LambdaMessaging>(
+    "LambdaMessaging",
+    lambdaHandler: "LambdaMessaging::LambdaMessaging.Function_FunctionHandler_Generated::FunctionHandler")
+    .WithReference(awsConfig);
+
+var awsResources = builder.AddAWSCloudFormationTemplate("AspireSampleDevResources", "app-resources.template")
+                          .WithReference(awsConfig);
+
+
+builder.AddProject<Projects.PublisherAPI>("PublisherAPI")
+       .WithReference(awsResources);
+
+// Note: PollyIntegration and SubscriberService demonstrate different ways to process messages
+// and should not run simultaneously. Comment/uncomment the appropriate line below to switch between them.
+builder.AddProject<Projects.SubscriberService>("SubscriberService")
+      .WithReference(awsResources);
+
+// builder.AddProject<Projects.PollyIntegration>("PollyIntegration")
+//        .WithReference(awsResources);
+
+
+builder.Build().Run();

--- a/sampleapps/AppHost/Properties/launchSettings.json
+++ b/sampleapps/AppHost/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17124;http://localhost:15282",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21168",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22160"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15282",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19082",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20298"
+      }
+    }
+  }
+}

--- a/sampleapps/AppHost/README.md
+++ b/sampleapps/AppHost/README.md
@@ -1,0 +1,86 @@
+# AWS Message Processing Framework - Aspire AppHost
+
+This project uses .NET Aspire to orchestrate and run the sample applications that demonstrate various aspects of the AWS Message Processing Framework for .NET. It demonstrates utilizing [integrations-on-dotnet-aspire-for-aws](https://github.com/aws/integrations-on-dotnet-aspire-for-aws/tree/main) with the Message Processing Framework.
+
+## Overview
+
+The AppHost project coordinates the following sample applications:
+- PublisherAPI - REST API for publishing messages
+- SubscriberService - Message processing service
+- PollyIntegration - Resilience patterns demonstration
+- LambdaMessaging - AWS Lambda integration
+
+## Prerequisites
+
+- .NET 8.0 or later
+- AWS CLI configured with appropriate credentials
+- .NET Aspire workload installed
+
+## Project Structure
+```
+AppHost/
+├── Program.cs # Aspire application configuration
+├── app-resources.template # CloudFormation template for AWS resources
+├── AppHost.csproj # Project file with Aspire references
+└── appsettings.json # Application configuration
+```
+
+## AWS Resources
+
+The application uses the following AWS resources defined in `app-resources.template`:
+- Standard SQS Queue (MPF)
+- FIFO SQS Queue (MPF.fifo)
+- Standard SNS Topic (MPF)
+- FIFO SNS Topic (MPF.fifo)
+- EventBridge Event Bus (MPF-EventBus)
+
+## Configuration
+
+The application is configured to:
+- Use AWS SDK with default profile
+- Deploy to US West 2 region (configurable)
+- Create required AWS resources via CloudFormation
+- Configure Lambda functions with appropriate permissions
+
+## Running the Application
+
+1. Install .NET Aspire and prerequisites. See [here](https://learn.microsoft.com/en-us/dotnet/aspire/fundamentals/setup-tooling?tabs=windows&pivots=visual-studio)
+
+2. Run the App host project in Visual Studio.
+
+This will:
+
+* Deploy the CloudFormation stack with required AWS resources
+* Start all sample applications
+* Configure the necessary integrations between components
+
+## Project References
+
+The AppHost orchestrates the following projects:
+
+- LambdaMessaging
+    
+- PollyIntegration
+    
+- PublisherAPI
+    
+- SubscriberService
+    
+
+## Important Configuration Note
+
+The sample includes two different message processing implementations that should not run simultaneously:
+- SubscriberService: Demonstrates basic message processing
+- PollyIntegration: Demonstrates message processing with resilience patterns
+
+To switch between these implementations:
+1. Open `Program.cs`
+2. Comment out one implementation and uncomment the other:
+```csharp
+// Use this for basic message processing
+builder.AddProject<Projects.SubscriberService>("SubscriberService")
+      .WithReference(awsResources);
+
+// OR use this for resilience pattern demonstration
+// builder.AddProject<Projects.PollyIntegration>("PollyIntegration")
+//        .WithReference(awsResources);

--- a/sampleapps/AppHost/app-resources.template
+++ b/sampleapps/AppHost/app-resources.template
@@ -1,0 +1,70 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: AWS Message Processing Framework - SQS Queues, SNS Topic, and EventBridge
+
+Resources:
+
+  # Standard SQS Queue
+  MPFQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: MPF
+
+  # FIFO SQS Queue
+  MPFFIFOQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: MPF.fifo
+      FifoQueue: true
+      ContentBasedDeduplication: true
+
+  # Standard SNS Topic
+  MPFTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: MPF
+
+  # FIFO SNS Topic  
+  MPFFIFOTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: MPF.fifo
+      FifoTopic: true
+      ContentBasedDeduplication: true
+
+  # EventBridge Event Bus
+  MPFEventBus:
+    Type: AWS::Events::EventBus
+    Properties:
+      Name: MPF-EventBus
+
+Outputs:
+
+  MPFQueueUrl:
+    Description: MPF Queue URL
+    Value: !Ref MPFQueue
+    Export:
+      Name: MPF-QueueURL
+
+  MPFFIFOQueueUrl:
+    Description: MPF FIFO Queue URL
+    Value: !Ref MPFFIFOQueue
+    Export:
+      Name: MPF-FIFOQueueURL
+
+  MPFTopicArn:
+    Description: MPF SNS Topic ARN
+    Value: !Ref MPFTopic
+    Export:
+      Name: MPF-TopicArn
+
+  MPFFIFOTopicArn:
+    Description: MPF FIFO SNS Topic ARN
+    Value: !Ref MPFFIFOTopic
+    Export:
+      Name: MPF-FIFOTopicArn
+
+  MPFEventBusArn:
+    Description: MPF EventBridge Event Bus ARN
+    Value: !GetAtt MPFEventBus.Arn
+    Export:
+      Name: MPF-EventBusArn

--- a/sampleapps/AppHost/appsettings.Development.json
+++ b/sampleapps/AppHost/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/sampleapps/AppHost/appsettings.json
+++ b/sampleapps/AppHost/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Aspire.Hosting.Dcp": "Warning"
+    }
+  }
+}

--- a/sampleapps/LambdaMessaging/Properties/launchSettings.json
+++ b/sampleapps/LambdaMessaging/Properties/launchSettings.json
@@ -1,13 +1,10 @@
 {
   "profiles": {
-    "Default": {
-      "workingDirectory": ".\\bin\\$(Configuration)\\net8.0",
+    "Aspire_LambdaMessaging": {
       "commandName": "Executable",
-      "commandLineArgs": "exec --depsfile ./LambdaMessaging.deps.json  --runtimeconfig ./LambdaMessaging.runtimeconfig.json %USERPROFILE%/.dotnet/tools/.store/amazon.lambda.testtool/${VERSION}/amazon.lambda.testtool/${VERSION}/content/Amazon.Lambda.RuntimeSupport/net8.0/Amazon.Lambda.RuntimeSupport.dll LambdaMessaging::LambdaMessaging.Function_FunctionHandler_Generated::FunctionHandler",
       "executablePath": "dotnet",
-      "environmentVariables": {
-        "AWS_LAMBDA_RUNTIME_API": "localhost:5050/MyFunction"
-      }
+      "commandLineArgs": "exec --depsfile ./LambdaMessaging.deps.json --runtimeconfig ./LambdaMessaging.runtimeconfig.json %USERPROFILE%\\.dotnet\\tools\\.store\\amazon.lambda.testtool\\0.9.1\\amazon.lambda.testtool\\0.9.1\\content\\Amazon.Lambda.RuntimeSupport\\net8.0\\Amazon.Lambda.RuntimeSupport.dll LambdaMessaging::LambdaMessaging.Function_FunctionHandler_Generated::FunctionHandler",
+      "workingDirectory": ".\\bin\\$(Configuration)\\net8.0"
     }
   }
 }

--- a/sampleapps/LambdaMessaging/README.md
+++ b/sampleapps/LambdaMessaging/README.md
@@ -14,10 +14,9 @@ This sample shows how to:
 ## Prerequisites
 
 - .NET 8.0 or later
-
+- Follow the setup instructions in the AppHost README to ensure all AWS resources and .NET Aspire components are properly configured
 
 ## Project Structure
-
 ```
 LambdaMessaging/
 ├── Function.cs # Lambda function handler
@@ -30,50 +29,10 @@ LambdaMessaging/
 
 ## Getting Started
 
-In order to test the lambda function locally with the messaging processing framework, it requires installing the Lambda Test Tool https://github.com/aws/aws-lambda-dotnet/blob/master/Tools/LambdaTestTool-v2 first.
+The easiest way to run this sample is to follow the instructions in the AppHost README to get the .NET Aspire environment running. This will ensure all necessary AWS resources are created and configured properly.
 
-1. Build the project
-
-```
-dotnet build
-```
-
-2Install the AWS Lambda Test Tool:
-```bash
-dotnet tool install -g amazon.lambda.testtool
-```
-
-3. Start the Lambda Test Tool:
-
-```bash
-dotnet lambda-test-tool start --lambda-emulator-port 5050
-```
-
-4. Get the test tool version:
-
-```
-dotnet lambda-test-tool info
-```
-
-5. Run the `LambdaMessaging` project.
-
-There are 2 ways to run it
-1. Visual studio (easiest way).
-    1a. Update `Properties/launchSettings.json` and replace `${VERSIOMN} with the actual test tool version.
-2. Via command line
-
-```
-cd bin\Debug\net8.0
-$env:AWS_LAMBDA_RUNTIME_API = "localhost:5050/MyFunction"
-$env:VERSION = "0.9.1" // Use the version returned from dotnet lambda-test-tool info
-
-dotnet exec --depsfile ./LambdaMessaging.deps.json --runtimeconfig ./LambdaMessaging.runtimeconfig.json "$env:USERPROFILE\.dotnet\tools\.store\amazon.lambda.testtool\$env:VERSION\amazon.lambda.testtool\$env:VERSION\content\Amazon.Lambda.RuntimeSupport\net8.0\Amazon.Lambda.RuntimeSupport.dll" LambdaMessaging::LambdaMessaging.Function_FunctionHandler_Generated::FunctionHandler
-
-
-```
-
-6. You should now see the `MyFunction` appear in the test tools function list drop down in the top right corner. Select `MyFunction`.
-
-7. We have provided a `HandlerSampleRequest.json` file to be used to test this function. Copy and paste this json into the test tools input window and then hit the "invoke button".
-
-8. You should see in the console window that the `ChatMessageHandler` successfully processed the message. There should be a log statement saying `Message Description: Testing!!!`.
+1. Run the App Host Project
+2. Select the `LambdaMessaging` resource.
+3. This will take you to the Lambda Test Tool.
+3. Use the provided HandlerSampleRequest.json file to test the function. Copy the JSON content into the Lambda Test Tool's input window and click "Invoke".
+4. You should see in the console window that the ChatMessageHandler successfully processed the message. Look for the log statement saying `Message Description: Testing!!!`. This will be in the Aspire logs.

--- a/sampleapps/PollyIntegration/Program.cs
+++ b/sampleapps/PollyIntegration/Program.cs
@@ -1,4 +1,4 @@
-﻿using AWS.Messaging.Services.Backoff;
+using AWS.Messaging.Services.Backoff;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -12,6 +12,7 @@ using Polly.Retry;
 using PollyIntegration;
 using PollyIntegration.MessageHandlers;
 using PollyIntegration.Models;
+using System.Text.Json;
 
 await Host.CreateDefaultBuilder(args)
     .ConfigureLogging(logging =>
@@ -39,8 +40,19 @@ await Host.CreateDefaultBuilder(args)
                 // To load the configuration from appsettings.json instead of the code below, uncomment this and remove the following lines.
                 // builder.LoadConfigurationFromSettings(context.Configuration);
 
-                builder.AddSQSPoller("https://sqs.us-west-2.amazonaws.com/012345678910/MPF");
+                var mpfQueueUrl = context.Configuration["AWS:Resources:MPFQueueUrl"];
+
+                builder.AddSQSPoller(mpfQueueUrl);
                 builder.AddMessageHandler<ChatMessageHandler, ChatMessage>("chatMessage");
+
+
+                builder.ConfigureSerializationOptions(options =>
+                {
+                    options.SystemTextJsonOptions = new JsonSerializerOptions
+                    {
+                        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                    };
+                });
 
                 // Logging data messages is disabled by default to protect sensitive user data. If you want this enabled, uncomment the line below.
                 // builder.EnableMessageContentLogging();

--- a/sampleapps/PollyIntegration/README.md
+++ b/sampleapps/PollyIntegration/README.md
@@ -8,108 +8,13 @@ This sample demonstrates:
 - Integration of AWS Message Processing Framework with Polly for resilient messaging
 - Custom backoff handling for message processing
 - SQS message processing with typed handlers
-- Both code-based and configuration-based setup options
+- Configuration-based setup using .NET Aspire
 
 ## Prerequisites
 
 - .NET 8.0 or later
-- AWS Account with appropriate permissions
-- Basic understanding of Amazon SQS and AWS Message Processing Framework
+- Follow the setup instructions in the AppHost README to ensure all AWS resources and .NET Aspire components are properly configured
 
-## Setup
-
-### 1. Create an SQS Queue
-
-1. Open the AWS Management Console
-2. Navigate to Amazon SQS
-3. Click "Create Queue"
-4. Choose "Standard Queue"
-5. Enter a queue name (e.g., "MPF")
-6. Keep default settings for this demo
-7. Click "Create Queue"
-8. Copy the Queue URL - you'll need this later
-
-### 2. Configure Message Processing
-
-You can choose either configuration approach:
-
-#### Option A: Code-based Configuration
-
-In `Program.cs`, update the queue URL and keep these lines uncommented:
-```csharp
-builder.AddSQSPoller("https://sqs.us-west-2.amazonaws.com/012345678910/MPF"); // Replace with your Queue URL
-builder.AddMessageHandler<ChatMessageHandler, ChatMessage>("chatMessage");
-```
-And keep this line commented:
-```
-// builder.LoadConfigurationFromSettings(context.Configuration);
-```
-
-#### Option B: Configuration-based (appsettings.json)
-1. Comment out the code-based configuration in Program.cs:
-
-```
-// builder.AddSQSPoller("https://sqs.us-west-2.amazonaws.com/012345678910/MPF");
-// builder.AddMessageHandler<ChatMessageHandler, ChatMessage>("chatMessage");
-```
-2. Uncomment the configuration loading:
-
-```
-builder.LoadConfigurationFromSettings(context.Configuration);
-```
-3. Update appsettings.json:
-
-```
-{
-    "AWS.Messaging": {
-        "SQSPollers": [
-            {
-                "QueueUrl": "https://sqs.us-west-2.amazonaws.com/012345678910/MPF"  // Replace with your Queue URL
-            }
-        ],
-        "MessageHandlers": [
-            {
-                "HandlerType": "PollyIntegration.MessageHandlers.ChatMessageHandler",
-                "MessageType": "PollyIntegration.Models.ChatMessage",
-                "MessageTypeIdentifier": "chatMessage"
-            }
-        ]
-    }
-}
-
-```
-
-Choose Option A if you:
-
-- Want configuration close to the code
-
-- Need dynamic runtime configuration
-
-- Are prototyping or testing
-
-
-Choose Option B if you:
-
-- Need configuration changes without recompiling
-
-- Want environment-specific settings
-
-- Prefer separation of configuration from code
-
-- Need to manage multiple configurations
-
-
-### 3. Configure AWS Credentials
-
-Ensure you have AWS credentials configured either through:
-
-- AWS CLI 
-
-- Environment variables
-
-- AWS credentials file
-
-- IAM role (if running on AWS)
 
 ## Project Structure
 ```
@@ -123,18 +28,18 @@ PollyIntegration/
 └── appsettings.json           # Application configuration
 ```
 
-## Running  the Application
-1. Build the project
-```
-dotnet build
-```
-2. Run the application
-```
-dotnet run
-```
 ## Testing
 
-### Send a Test Message
+You can test the application using one of these two methods:
+
+### 1. Using PublisherAPI (Recommended)
+
+1. Ensure the Aspire AppHost is running
+2. Open the PublisherAPI Swagger UI
+3. Navigate to the ChatMessage endpoint
+4. Send a test message using the Swagger interface
+
+### 2. Manual Testing via AWS CLI
 
 You can send a test message to your SQS queue using the AWS Console or AWS CLI:
 

--- a/sampleapps/PublisherAPI/Program.cs
+++ b/sampleapps/PublisherAPI/Program.cs
@@ -17,13 +17,26 @@ builder.Services.AddAWSMessageBus(bus =>
     // To load the configuration from appsettings.json instead of the code below, uncomment this and remove the following lines.
     // bus.LoadConfigurationFromSettings(builder.Configuration);
 
-    bus.AddSQSPublisher<ChatMessage>("https://sqs.us-west-2.amazonaws.com/012345678910/MPF", "chatMessage");
-    bus.AddSNSPublisher<OrderInfo>("arn:aws:sns:us-west-2:012345678910:MPF", "orderInfo");
-    bus.AddEventBridgePublisher<FoodItem>("arn:aws:events:us-west-2:012345678910:event-bus/default", "foodItem");
+    // Standard SQS Queue
+    var mpfQueueUrl = builder.Configuration["AWS:Resources:MPFQueueUrl"];
+    bus.AddSQSPublisher<ChatMessage>(mpfQueueUrl, "chatMessage");
 
-    // FIFO endpoints
-    bus.AddSQSPublisher<TransactionInfo>("https://sqs.us-west-2.amazonaws.com/012345678910/MPF.fifo", "transactionInfo");
-    bus.AddSNSPublisher<BidInfo>("arn:aws:sns:us-west-2:012345678910:MPF.fifo", "bidInfo");
+    // FIFO SQS Queue  
+    var mpfFifoQueueUrl = builder.Configuration["AWS:Resources:MPFFIFOQueueUrl"];
+    bus.AddSQSPublisher<TransactionInfo>(mpfFifoQueueUrl, "transactionInfo");
+
+    // Standard SNS Topic
+    var mpfTopicArn = builder.Configuration["AWS:Resources:MPFTopicArn"];
+    bus.AddSNSPublisher<OrderInfo>(mpfTopicArn, "orderInfo");
+
+    // FIFO SNS Topic
+    var mpfFifoTopicArn = builder.Configuration["AWS:Resources:MPFFIFOTopicArn"];
+    bus.AddSNSPublisher<BidInfo>(mpfFifoTopicArn, "bidInfo");
+
+    // EventBridge Event Bus
+    var mpfEventBusArn = builder.Configuration["AWS:Resources:MPFEventBusArn"];
+    bus.AddEventBridgePublisher<FoodItem>(mpfEventBusArn, "foodItem");
+
 
     bus.ConfigureSerializationOptions(options =>
     {

--- a/sampleapps/PublisherAPI/README.md
+++ b/sampleapps/PublisherAPI/README.md
@@ -8,112 +8,14 @@ This sample demonstrates:
 - Publishing messages to SQS queues (standard and FIFO)
 - Publishing messages to SNS topics (standard and FIFO)
 - Publishing messages to EventBridge
-- Configuration-based and code-based setup options
+- Configuration-based setup using .NET Aspire
 - Handling service-specific message options
 
 ## Prerequisites
 
 - .NET 8.0 or later
-- AWS Account with appropriate permissions
-- Basic understanding of AWS messaging services (SQS, SNS, EventBridge)
+- Follow the setup instructions in the AppHost README to ensure all AWS resources and .NET Aspire components are properly configured
 
-## Setup
-
-### 1. Create AWS Resources
-
-#### SQS Queues
-1. Create a standard SQS queue named "MPF"
-2. Create a FIFO SQS queue named "MPF.fifo". When creating the queue be sure to enable `Content-based deduplication`.
-3. Note the queue URLs
-
-#### SNS Topics
-1. Create a standard SNS topic named "MPF"
-2. Create a FIFO SNS topic named "MPF.fifo". When creating the topic be sure to enable `Content-based deduplication`.
-3. Note the topic ARNs
-
-#### EventBridge
-1. Note your default event bus ARN or create a custom event bus
-
-### 2. Configure Message Publishing
-
-You can choose either configuration approach:
-
-#### Option A: Code-based Configuration
-
-In `Program.cs`, update the endpoints and keep these lines uncommented:
-```csharp
-bus.AddSQSPublisher<ChatMessage>("https://sqs.us-west-2.amazonaws.com/012345678910/MPF", "chatMessage");
-bus.AddSNSPublisher<OrderInfo>("arn:aws:sns:us-west-2:012345678910:MPF", "orderInfo");
-bus.AddEventBridgePublisher<FoodItem>("arn:aws:events:us-west-2:012345678910:event-bus/default", "foodItem");
-
-// FIFO endpoints
-bus.AddSQSPublisher<TransactionInfo>("https://sqs.us-west-2.amazonaws.com/012345678910/MPF.fifo", "transactionInfo");
-bus.AddSNSPublisher<BidInfo>("arn:aws:sns:us-west-2:012345678910:MPF.fifo", "bidInfo");
-```
-And keep this line commented:
-
-```
-// bus.LoadConfigurationFromSettings(builder.Configuration);
-```
-#### Option B: Configuration-based (appsettings.json)
-
-1. Comment out the code-based configuration in Program.cs
-
-2. Uncomment the configuration loading:
-```
-bus.LoadConfigurationFromSettings(builder.Configuration);
-```
-3. Update appsettings.json:
-
-```
-{
-    "AWS.Messaging": {
-        "SQSPublishers": [
-            {
-                "MessageType": "PublisherAPI.Models.ChatMessage",
-                "QueueUrl": "https://sqs.us-west-2.amazonaws.com/012345678910/MPF",
-                "MessageTypeIdentifier": "chatMessage"
-            },
-            {
-                "MessageType": "PublisherAPI.Models.TransactionInfo",
-                "QueueUrl": "https://sqs.us-west-2.amazonaws.com/012345678910/MPF.fifo",
-                "MessageTypeIdentifier": "transactionInfo"
-            }
-        ],
-        "SNSPublishers": [
-            {
-                "MessageType": "PublisherAPI.Models.OrderInfo",
-                "TopicUrl": "arn:aws:sns:us-west-2:012345678910:MPF",
-                "MessageTypeIdentifier": "orderInfo"
-            },
-            {
-                "MessageType": "PublisherAPI.Models.BidInfo",
-                "TopicUrl": "arn:aws:sns:us-west-2:012345678910:MPF.fifo",
-                "MessageTypeIdentifier": "bidInfo"
-            }
-        ],
-        "EventBridgePublishers": [
-            {
-                "MessageType": "PublisherAPI.Models.FoodItem",
-                "EventBusName": "arn:aws:events:us-west-2:012345678910:event-bus/default",
-                "MessageTypeIdentifier": "foodItem"
-            }
-        ]
-    }
-}
-
-```
-### 3. Configure AWS Credentials
-
-Ensure you have AWS credentials configured either through:
-
-- AWS CLI
-
-- Environment variables
-
-- AWS credentials file
-
-- IAM role (if running on AWS)
 
 ## Project Structure
 
@@ -132,29 +34,12 @@ PublisherAPI/
 
 ```
 
-## Running the Application
-
-1. Build the project:
-
-
-```bash
-dotnet build
-```
-
-2. Run the application:
-
-
-```bash
-dotnet run
-```
-
 
 ## Testing
-The API includes Swagger UI for testing. Access it at:
 
-```
-https://localhost:7204/swagger
-```
+The API includes Swagger UI for testing. When running the Aspire AppHost, access it at: https://localhost:7204/swagger (the port may be different in Aspire)
+
+
 ### Example API Requests
 
 #### Send Chat Message (Standard SQS):

--- a/sampleapps/README.md
+++ b/sampleapps/README.md
@@ -4,12 +4,19 @@ This directory contains sample applications demonstrating different aspects and 
 
 ## Sample Projects
 
+### AppHost
+A .NET Aspire project that orchestrates and runs all sample applications:
+- Configures and deploys required AWS resources
+- Manages application dependencies and connections
+- Provides unified logging and monitoring
+- Handles service discovery and configuration
+
 ### PublisherAPI
 A REST API demonstrating how to publish messages to various AWS messaging services:
 - Publishing to SQS (standard and FIFO queues)
 - Publishing to SNS (standard and FIFO topics)
 - Publishing to EventBridge
-- Configuration-based and code-based setup options
+- Configuration-based setup options
 
 ### SubscriberService
 A service application showing how to process messages from SQS queues:
@@ -32,3 +39,19 @@ Shows how to use the framework with AWS Lambda:
 - Batch message handling
 - Partial batch failures
 - Dependency injection with Lambda Annotations
+
+## Getting Started
+
+1. Follow the setup instructions in the AppHost README to configure your development environment and AWS resources.
+
+2. Important Note: SubscriberService and PollyIntegration demonstrate different message processing implementations and should not run simultaneously. Use the AppHost's Program.cs to switch between them by commenting/uncommenting the appropriate project reference.
+
+3. Use the PublisherAPI's Swagger interface to test message publishing to different AWS messaging services.
+
+## Prerequisites
+
+- .NET 8.0 or later
+- AWS account with appropriate permissions
+- .NET Aspire workload installed
+
+For detailed instructions and configuration options, refer to each project's individual README file.

--- a/sampleapps/SubscriberService/Program.cs
+++ b/sampleapps/SubscriberService/Program.cs
@@ -30,7 +30,9 @@ await Host.CreateDefaultBuilder(args)
             // To load the configuration from appsettings.json instead of the code below, uncomment this and remove the following lines.
             // builder.LoadConfigurationFromSettings(context.Configuration);
 
-            builder.AddSQSPoller("https://sqs.us-west-2.amazonaws.com/012345678910/MPF");
+            var mpfQueueUrl = context.Configuration["AWS:Resources:MPFQueueUrl"];
+
+            builder.AddSQSPoller(mpfQueueUrl);
             builder.AddMessageHandler<ChatMessageHandler, ChatMessage>("chatMessage");
 
             builder.ConfigureSerializationOptions(options =>

--- a/sampleapps/SubscriberService/README.md
+++ b/sampleapps/SubscriberService/README.md
@@ -7,92 +7,14 @@ This sample application demonstrates how to use the AWS Message Processing Frame
 This sample demonstrates:
 - Configuring and using SQS message pollers
 - Implementing typed message handlers
-- Configuration-based and code-based setup options
+- Configuration-based setup using .NET Aspire
 - Configurable backoff policies for message processing
 - Proper message handling patterns
 
 ## Prerequisites
 
 - .NET 8.0 or later
-- AWS Account with appropriate permissions
-- Basic understanding of Amazon SQS and message processing
-
-## Setup
-
-### 1. Create AWS Resources
-
-#### SQS Queue
-1. Open the AWS Management Console
-2. Navigate to Amazon SQS
-3. Click "Create Queue"
-4. Choose "Standard Queue"
-5. Enter a queue name (e.g., "MPF")
-6. Keep default settings for this demo
-7. Click "Create Queue"
-8. Copy the Queue URL - you'll need this later
-
-### 2. Configure Message Processing
-
-You can choose either configuration approach:
-
-#### Option A: Code-based Configuration
-
-In `Program.cs`, update the queue URL and keep these lines uncommented:
-```csharp
-builder.AddSQSPoller("https://sqs.us-west-2.amazonaws.com/012345678910/MPF");
-builder.AddMessageHandler<ChatMessageHandler, ChatMessage>("chatMessage");
-```
-And keep this line commented:
-
-```
-// builder.LoadConfigurationFromSettings(context.Configuration);
-```
-#### Option B: Configuration-based (appsettings.json)
-
-1. Comment out the code-based configuration in Program.cs
-2. Uncomment the configuration loading:
-```
-builder.LoadConfigurationFromSettings(context.Configuration);
-```
-3. Update appsettings.json:
-```
-{
-    "AWS.Messaging": {
-        "MessageHandlers": [
-            {
-                "HandlerType": "SubscriberService.MessageHandlers.ChatMessageHandler",
-                "MessageType": "SubscriberService.Models.ChatMessage",
-                "MessageTypeIdentifier": "chatMessage"
-            }
-        ],
-        "SQSPollers": [
-            {
-                "QueueUrl": "https://sqs.us-west-2.amazonaws.com/012345678910/MPF",
-                "Options": {
-                    "MaxNumberOfConcurrentMessages": 10,
-                    "VisibilityTimeout": 20,
-                    "WaitTimeSeconds": 20,
-                    "VisibilityTimeoutExtensionHeartbeatInterval": 1,
-                    "VisibilityTimeoutExtensionThreshold": 5
-                }
-            }
-        ],
-        "BackoffPolicy": "CappedExponential"
-    }
-}
-```
-
-### 3. Configure AWS Credentials
-
-Ensure you have AWS credentials configured either through:
-
-- AWS CLI
-
-- Environment variables
-
-- AWS credentials file
-
-- IAM role (if running on AWS)
+- Follow the setup instructions in the AppHost README to ensure all AWS resources and .NET Aspire components are properly configured
 
 
 ## Project Structure
@@ -106,22 +28,19 @@ SubscriberService/
 └── appsettings.json           # Application configuration
 ```
 
-## Running the Application
-
-1. Build the project:
-```
-dotnet build
-```
-2. Run the application:
-```
-dotnet run
-```
-
 ## Testing
 
-You can test the service by sending messages to the SQS queue using the AWS Console, AWS CLI, or the companion PublisherAPI project.
+You can test the service using one of these two methods:
 
-### Using AWS CLI:
+### 1. Using PublisherAPI (Recommended)
+
+1. Ensure the Aspire AppHost is running
+2. Open the PublisherAPI Swagger UI
+3. Navigate to the ChatMessage endpoint
+4. Send a test message using the Swagger interface
+
+
+### 2. Manual Testing via AWS CLI
 ```
 $messageBody = "{""""type"""":""""chatMessage"""",""""id"""":""""123"""",""""source"""":""""test"""",""""specversion"""":""""1.0"""",""""time"""":""""2024-01-01T00:00:00Z"""",""""data"""":""""{\\""""messageDescription\\"""":\\""""Test message\\""""}""""}"
 


### PR DESCRIPTION
*Issue #, if available:* DOTNET-8037

*Description of changes:*
1. Update sample apps to use .NET aspire
2. This change adds all sample apps as projects to Aspire. It allows the user to easily test everything easily.
3. It also automatically creates all the required cloudformation/SQS/SNS queues

The basic end to end flow that the user can do is 2 scenarios.

1. Lambda Messaging - Uses aspire + test tool to allow user to try out lambda messaging functionality
2. Publisher + Subscriber. The user can use the PublisherAPI project to publish `ChatMessage`s and then the associated `SubscriberService` will read those messages. The user can swap out the regular `SubscriberService` for the `PollyIntegration` service as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
