### PR TITLE
Fix null reference exception

### DIFF
--- a/.autover/changes/261d1081-4809-42df-afde-5541c4c1e3f2.json
+++ b/.autover/changes/261d1081-4809-42df-afde-5541c4c1e3f2.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AWS.Messaging",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Add null check when retrieved messages is null"
+      ]
+    }
+  ]
+}

--- a/src/AWS.Messaging/SQS/SQSMessagePoller.cs
+++ b/src/AWS.Messaging/SQS/SQSMessagePoller.cs
@@ -137,7 +137,7 @@ internal class SQSMessagePoller : IMessagePoller, ISQSMessageCommunication
                     }
 
                     _logger.LogTrace("Retrieved {MessagesCount} messages from {QueueUrl} via request ID {RequestId}",
-                        receiveMessageResponse.Messages.Count, receiveMessageRequest.QueueUrl, receiveMessageResponse.ResponseMetadata.RequestId);
+                        receiveMessageResponse.Messages?.Count ?? 0, receiveMessageRequest.QueueUrl, receiveMessageResponse.ResponseMetadata.RequestId);
 
                     return receiveMessageResponse.Messages;
                 },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When we poll SQS and no messages are received, `messages` is `null` but we are still trying to access the count anyway. This adds a check to ensure its not null

![image](https://github.com/user-attachments/assets/d7923a59-b585-4f52-aa5e-d1920db3d17e)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
