### PR TITLE
Add dependabot to update github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/dependabot-label.yml
+++ b/.github/workflows/dependabot-label.yml
@@ -5,16 +5,30 @@ on:
     types:
       - opened
 
+permissions: 
+  id-token: write
+
 jobs:
   label-dependabot-pr:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
-    permissions:
-      pull-requests: write
 
     steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 #v4
+        with:
+          role-to-assume: ${{ secrets.RELEASE_WORKFLOW_ACCESS_TOKEN_ROLE_ARN }}
+          aws-region: us-west-2
+
+      - name: Retrieve secret from AWS Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@fbd65ea98e018858715f591f03b251f02b2316cb #v2.0.8
+        with:
+          secret-ids: |
+            AWS_SECRET, ${{ secrets.RELEASE_WORKFLOW_ACCESS_TOKEN_NAME }}
+          parse-json-secrets: true
+
       - name: Add Release Not Needed Label
+        env:
+          GITHUB_TOKEN: ${{ env.AWS_SECRET_TOKEN }}
         run: |
           gh pr edit ${{ github.event.pull_request.number }} --add-label "Release Not Needed"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-label.yml
+++ b/.github/workflows/dependabot-label.yml
@@ -1,0 +1,20 @@
+name: Add Label to Dependabot PRs
+
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  label-dependabot-pr:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Add Release Not Needed Label
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} --add-label "Release Not Needed"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semgrep-analysis.yml
+++ b/.github/workflows/semgrep-analysis.yml
@@ -35,7 +35,7 @@ jobs:
             p/owasp-top-ten
 
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@45775bd8235c68ba998cffa5171334d58593da47 #v3.28.15
         with:
           sarif_file: semgrep.sarif
         if: always()


### PR DESCRIPTION
*Issue #, if available:* DOTNET-8039

*Description of changes:*
1. Add dependabot github action to automatically update github actions. I tested it out with my fork https://github.com/GarrettBeatty/aws-dotnet-messaging/pulls
2. Add github workflow to tag dependabot PRs as Release not needed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
